### PR TITLE
Add OpenAI and Gemini API key setup instructions

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -81,11 +81,13 @@ gh api repos/{owner}/{repo}/actions/permissions/workflow
 6. **Billing:** You must add a payment method at https://platform.openai.com/settings/organization/billing/overview before the key will work. New accounts get a $100/month usage limit by default; you can adjust this in the limits page.
 
 **For Google (Gemini models):**
-1. Go to https://aistudio.google.com/app/apikey
+1. Go to https://aistudio.google.com/app/apikey (this is Google AI Studio — much simpler than the Google Cloud Console, but uses the same underlying API)
 2. Sign in with your Google account and accept the Terms of Service if prompted
-3. Click "Create API Key", then select or create a Google Cloud project
+3. Click "Create API Key", name it (e.g., "remote-dev-bot"), then select or create a Google Cloud project
 4. **Copy the key immediately** (it starts with `AIza`)
-5. **Billing:** The free tier works for testing (5-15 requests/minute depending on model). For production use, enable billing on your Google Cloud project. Paid tier (Tier 1) unlocks 150-300 RPM.
+5. **Billing:** The free tier works for testing and light use (5-15 RPM depending on model). On the free tier, a compromised key can't cost you money — it's just rate-limited. For production use, enable billing on the underlying Google Cloud project. Paid tier (Tier 1) unlocks 150-300 RPM.
+6. **Note:** Google AI Studio is separate from a Google One AI Premium subscription ($20/mo). The subscription gives access to the Gemini chatbot; it does not provide API credits or affect API billing.
+7. **Useful links:** [API keys](https://aistudio.google.com/app/apikey) · [Usage & rate limits](https://aistudio.google.com/app/usage) · [Projects](https://aistudio.google.com/app/projects)
 
 **Tip:** Name each key after the project (e.g., "remote-dev-bot") to track costs and revoke later if needed. Store keys in a password manager.
 


### PR DESCRIPTION
## Summary
- Expands runbook Step 1.2 with detailed instructions for all three LLM providers
- Includes URLs, step-by-step walkthroughs, and billing/spending notes
- Replaces the previous follow their respective console instructions placeholder

## When you wake up
1. Create API keys for OpenAI and/or Gemini (requires your accounts)
2. Run gh secret set OPENAI_API_KEY and gh secret set GEMINI_API_KEY on both repos
3. Review and merge this PR