### PR TITLE
Document dev cycle in CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ GitHub Actions only runs workflows from the default branch (main), so developing
 
 This keeps test issues out of the main repo and lets you iterate on workflow changes before they hit `main`.
 
+For detailed dev cycle instructions (especially for AI assistants like Claude Code), see `CLAUDE.md`.
+
 ## LLM Provider Quick Reference
 
 Dashboard, billing, and API key management links for each supported provider.


### PR DESCRIPTION
## Summary
- Replaces the brief "Dev Workflow" bullet points in CLAUDE.md with detailed dev cycle instructions
- Explains the two-repo setup, how the `dev` pointer branch works, config vs workflow code distinction
- Includes copy-paste commands for triggering and monitoring tests
- Adds a pointer from README to CLAUDE.md for detailed dev instructions

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)