### PR TITLE
Fix PR feedback loop: detect issue type correctly

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -155,7 +155,12 @@ jobs:
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
 
-          ISSUE_TYPE=${{ github.event.issue && 'issue' || 'pr' }}
+          # Detect if this is a PR comment. Regular PR comments come through
+          # issue_comment (PRs are issues), so github.event.issue exists but
+          # github.event.issue.pull_request is only set for PRs. Review comments
+          # come through pull_request_review_comment where github.event.issue
+          # doesn't exist at all.
+          ISSUE_TYPE=${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
 
           python -m openhands.resolver.resolve_issue \
             --selected-repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary
- Fix issue type detection for PR comments so the agent correctly runs in PR mode
- `github.event.issue` exists for both issues and PRs (since PRs are issues), so checking its presence doesn't distinguish them
- Now checks `github.event.issue.pull_request` (set only for PRs) and `github.event.pull_request` (set for review comments)

## Test plan
- [ ] Comment `/agent` on an existing PR in remote-dev-bot-test — should run with `--issue-type pr`
- [ ] Comment `/agent` on a regular issue — should run with `--issue-type issue`
