### PR TITLE
Add testing framework: unit tests, YAML validation, E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,52 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: false
+        default: "main"
+      provider:
+        description: "Provider to test (all, claude, openai, gemini)"
+        required: false
+        default: "all"
+      all_models:
+        description: "Test every model alias (expensive!)"
+        type: boolean
+        required: false
+        default: false
+      test:
+        description: "Specific test name (blank for all)"
+        required: false
+        default: ""
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Install PyYAML
+        if: ${{ inputs.all_models }}
+        run: pip install PyYAML
+
+      - name: Run E2E tests
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          ARGS="--branch ${{ inputs.branch }}"
+          if [[ -n "${{ inputs.provider }}" && "${{ inputs.provider }}" != "all" ]]; then
+            ARGS="$ARGS --provider ${{ inputs.provider }}"
+          fi
+          if [[ "${{ inputs.all_models }}" == "true" ]]; then
+            ARGS="$ARGS --all-models"
+          fi
+          if [[ -n "${{ inputs.test }}" ]]; then
+            ARGS="$ARGS --test ${{ inputs.test }}"
+          fi
+          ./tests/e2e.sh $ARGS

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -29,8 +29,7 @@ jobs:
           repository: gnovak/remote-dev-bot
           token: ${{ secrets.PAT_TOKEN || github.token }}
           path: .remote-dev-bot
-          sparse-checkout: remote-dev-bot.yaml
-          sparse-checkout-cone-mode: false
+          sparse-checkout: lib
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,70 +46,7 @@ jobs:
           # Extract alias: "/agent-claude-large do X" -> "claude-large", "/agent" -> ""
           ALIAS=$(echo "$COMMENT" | grep -oP '^/agent-?\K[a-z0-9-]*' || echo "")
 
-          python3 << PYEOF
-          import yaml, sys, os
-
-          def deep_merge(base, override):
-              """Merge override into base, recursively for dicts."""
-              result = base.copy()
-              for key, value in override.items():
-                  if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-                      result[key] = deep_merge(result[key], value)
-                  else:
-                      result[key] = value
-              return result
-
-          # Read base config from remote-dev-bot
-          base_config = {}
-          base_path = '.remote-dev-bot/remote-dev-bot.yaml'
-          if os.path.exists(base_path):
-              with open(base_path) as f:
-                  base_config = yaml.safe_load(f) or {}
-
-          # Read override config from target repo (if it exists)
-          override_config = {}
-          override_path = 'remote-dev-bot.yaml'
-          if os.path.exists(override_path):
-              with open(override_path) as f:
-                  override_config = yaml.safe_load(f) or {}
-
-          # Merge: target repo overrides remote-dev-bot defaults
-          config = deep_merge(base_config, override_config)
-
-          # Resolve model alias
-          alias = '$ALIAS'
-          if not alias:
-              alias = config.get('default_model', 'claude-small')
-
-          models = config.get('models', {})
-          if alias not in models:
-              print(f'ERROR: Unknown model alias: {alias}', file=sys.stderr)
-              print(f'Available aliases: {list(models.keys())}', file=sys.stderr)
-              sys.exit(1)
-
-          model_id = models[alias]['id']
-
-          # Read OpenHands settings
-          oh = config.get('openhands', {})
-          max_iter = oh.get('max_iterations', 50)
-          oh_version = oh.get('version', '0.39.0')
-          pr_type = oh.get('pr_type', 'ready')
-
-          # Write outputs
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'model={model_id}\n')
-              f.write(f'alias={alias}\n')
-              f.write(f'max_iterations={max_iter}\n')
-              f.write(f'oh_version={oh_version}\n')
-              f.write(f'pr_type={pr_type}\n')
-
-          # Log for visibility
-          has_override = bool(override_config)
-          print(f'Config: base=remote-dev-bot, override={"target repo" if has_override else "none"}')
-          print(f'Model alias: {alias}')
-          print(f'Model ID: {model_id}')
-          print(f'PR type: {pr_type}')
-          PYEOF
+          python3 .remote-dev-bot/lib/config.py "$ALIAS"
 
       - name: Determine API key
         id: apikey

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pytest PyYAML
+
+      - name: Run tests
+        run: pytest tests/ -v
+        env:
+          PYTHONPATH: .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,0 +1,127 @@
+"""Config parsing for remote-dev-bot.
+
+Loads base config from remote-dev-bot repo, merges with optional
+per-repo override config, resolves model aliases, and writes
+GitHub Actions outputs.
+
+Called by resolve.yml at runtime (checked out from main via sparse-checkout)
+and imported directly by unit tests. See CLAUDE.md "PR constraints" for why
+config parsing changes must be in their own PR, separate from workflow changes.
+"""
+
+import os
+import sys
+
+import yaml
+
+
+def deep_merge(base, override):
+    """Merge override into base, recursively for dicts."""
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+KNOWN_PROVIDERS = ("anthropic/", "openai/", "gemini/")
+
+
+def detect_api_provider(model_id):
+    """Return the provider name for a model ID.
+
+    >>> detect_api_provider("anthropic/claude-sonnet-4-5")
+    'anthropic'
+    >>> detect_api_provider("openai/gpt-5-nano")
+    'openai'
+    >>> detect_api_provider("gemini/gemini-2.5-flash")
+    'gemini'
+    """
+    for prefix in KNOWN_PROVIDERS:
+        if model_id.startswith(prefix):
+            return prefix.rstrip("/")
+    raise ValueError(f"Unknown provider for model: {model_id}")
+
+
+def resolve_config(base_path, override_path, alias):
+    """Load configs, merge, resolve alias, return outputs dict.
+
+    Returns a dict with keys: model, alias, max_iterations, oh_version, pr_type.
+    """
+    # Read base config
+    base_config = {}
+    if os.path.exists(base_path):
+        with open(base_path) as f:
+            base_config = yaml.safe_load(f) or {}
+
+    # Read override config from target repo (if it exists)
+    override_config = {}
+    if os.path.exists(override_path):
+        with open(override_path) as f:
+            override_config = yaml.safe_load(f) or {}
+
+    # Merge: target repo overrides remote-dev-bot defaults
+    config = deep_merge(base_config, override_config)
+
+    # Resolve model alias
+    if not alias:
+        alias = config.get("default_model", "claude-small")
+
+    models = config.get("models", {})
+    if alias not in models:
+        raise KeyError(
+            f"Unknown model alias: {alias}. Available: {list(models.keys())}"
+        )
+
+    model_id = models[alias]["id"]
+
+    # Read OpenHands settings
+    oh = config.get("openhands", {})
+    max_iter = oh.get("max_iterations", 50)
+    oh_version = oh.get("version", "0.39.0")
+    pr_type = oh.get("pr_type", "ready")
+
+    return {
+        "model": model_id,
+        "alias": alias,
+        "max_iterations": max_iter,
+        "oh_version": oh_version,
+        "pr_type": pr_type,
+        "has_override": bool(override_config),
+    }
+
+
+def main():
+    alias = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    base_path = ".remote-dev-bot/remote-dev-bot.yaml"
+    override_path = "remote-dev-bot.yaml"
+
+    try:
+        result = resolve_config(base_path, override_path, alias)
+    except (KeyError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Write outputs
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"model={result['model']}\n")
+            f.write(f"alias={result['alias']}\n")
+            f.write(f"max_iterations={result['max_iterations']}\n")
+            f.write(f"oh_version={result['oh_version']}\n")
+            f.write(f"pr_type={result['pr_type']}\n")
+
+    # Log for visibility
+    override_label = "target repo" if result["has_override"] else "none"
+    print(f"Config: base=remote-dev-bot, override={override_label}")
+    print(f"Model alias: {result['alias']}")
+    print(f"Model ID: {result['model']}")
+    print(f"PR type: {result['pr_type']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# E2E tests for remote-dev-bot.
+#
+# Creates test issues in remote-dev-bot-test, triggers the agent,
+# waits for workflow completion, and verifies results.
+#
+# Usage:
+#   ./tests/e2e.sh [--branch <branch>] [--test <name>] [--provider <name>]
+#                  [--all-models]
+#
+#   --branch      Branch to test (default: main). Sets dev pointer to this branch.
+#   --test        Run a specific test only (default: all)
+#   --provider    Run only tests for a specific provider (claude/openai/gemini)
+#   --all-models  Test every model alias, not just one per provider
+
+set -euo pipefail
+
+TEST_REPO="gnovak/remote-dev-bot-test"
+POLL_INTERVAL=60
+TIMEOUT=900  # 15 minutes
+
+# --- Argument parsing ---
+
+BRANCH="main"
+FILTER_TEST=""
+FILTER_PROVIDER=""
+ALL_MODELS=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --branch) BRANCH="$2"; shift 2 ;;
+        --test) FILTER_TEST="$2"; shift 2 ;;
+        --provider) FILTER_PROVIDER="$2"; shift 2 ;;
+        --all-models) ALL_MODELS=true; shift ;;
+        -h|--help)
+            head -14 "$0" | tail -10
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# --- Test case definitions ---
+# Parallel arrays — index i corresponds to the same test across all arrays.
+
+all_names=()
+all_titles=()
+all_bodies=()
+all_cmds=()
+all_providers=()
+
+add_test() {
+    all_names+=("$1"); all_titles+=("$2"); all_bodies+=("$3")
+    all_cmds+=("$4"); all_providers+=("$5")
+}
+
+if $ALL_MODELS; then
+    # Generate a test for every model alias in the config file.
+    # Requires PyYAML (pip install PyYAML).
+    config_file="remote-dev-bot.yaml"
+    if [[ ! -f "$config_file" ]]; then
+        echo "ERROR: $config_file not found. Run from repo root." >&2
+        exit 1
+    fi
+
+    # Read all model aliases and their provider prefixes from the config
+    while IFS='|' read -r alias provider; do
+        # Sanitize alias for use in filenames: claude-small -> claude_small
+        safe_alias="${alias//-/_}"
+        add_test "$alias" "Test ($alias): add hello_${safe_alias}.py" \
+            "Create a file hello_${safe_alias}.py with a function hello() that returns 'Hello from ${alias}!'" \
+            "/agent-$alias" "$provider"
+    done < <(python3 -c "
+import yaml, sys
+with open('$config_file') as f:
+    config = yaml.safe_load(f)
+for alias, info in config.get('models', {}).items():
+    model_id = info.get('id', '')
+    provider = model_id.split('/')[0] if '/' in model_id else 'unknown'
+    print(f'{alias}|{provider}')
+")
+
+    # Also add the default-model test (uses /agent with no alias)
+    add_test "default-model" "Test (default): add hello_default.py" \
+        "Create a file hello_default.py with a function hello() that returns 'Hello from default!'" \
+        "/agent" "all"
+else
+    # Smoke tests: one small model per provider + default alias
+    add_test "default-model" "Test: add hello.py" \
+        "Create a file hello.py with a function hello() that returns 'Hello, world!'" \
+        "/agent" "all"
+
+    add_test "claude" "Test: add greet.py" \
+        "Create a file greet.py with a function greet(name) that returns f'Hello, {name}!'" \
+        "/agent-claude-small" "claude"
+
+    add_test "openai" "Test: add wave.py" \
+        "Create a file wave.py with a function wave() that returns 'Wave!'" \
+        "/agent-openai-small" "openai"
+
+    add_test "gemini" "Test: add hi.py" \
+        "Create a file hi.py with a function hi() that returns 'Hi!'" \
+        "/agent-gemini-small" "gemini"
+fi
+
+# --- Helpers ---
+
+log() { echo "==> $*"; }
+err() { echo "ERROR: $*" >&2; }
+
+cleanup_issues=()
+cleanup_branches=()
+
+cleanup() {
+    log "Cleaning up..."
+    for issue_num in "${cleanup_issues[@]+"${cleanup_issues[@]}"}"; do
+        gh issue close "$issue_num" --repo "$TEST_REPO" --comment "E2E test cleanup" 2>/dev/null || true
+    done
+    for branch in "${cleanup_branches[@]+"${cleanup_branches[@]}"}"; do
+        gh api "repos/$TEST_REPO/git/refs/heads/$branch" -X DELETE 2>/dev/null || true
+    done
+    log "Cleanup complete."
+}
+
+trap cleanup EXIT
+
+# --- Filter tests ---
+
+active_indices=()
+for i in "${!all_names[@]}"; do
+    name="${all_names[$i]}"
+    provider="${all_providers[$i]}"
+
+    if [[ -n "$FILTER_TEST" && "$name" != "$FILTER_TEST" ]]; then
+        continue
+    fi
+    if [[ -n "$FILTER_PROVIDER" && "$FILTER_PROVIDER" != "all" && "$provider" != "all" && "$provider" != "$FILTER_PROVIDER" ]]; then
+        continue
+    fi
+    active_indices+=("$i")
+done
+
+if [[ ${#active_indices[@]} -eq 0 ]]; then
+    err "No tests match filters (--test '$FILTER_TEST', --provider '$FILTER_PROVIDER')"
+    exit 1
+fi
+
+mode="smoke"
+$ALL_MODELS && mode="all-models"
+log "Running ${#active_indices[@]} test(s) against branch '$BRANCH' ($mode)"
+
+# --- Point dev at target branch ---
+
+if [[ "$BRANCH" != "main" ]]; then
+    log "Setting dev pointer to '$BRANCH'..."
+    git push origin "$BRANCH:refs/heads/dev" --force-with-lease
+fi
+
+# --- Create test issues and trigger ---
+
+# Per-test state (parallel arrays, one entry per active test)
+issue_nums=()       # issue number for each active test
+test_results=()     # "success", "failure", or "" (pending)
+test_run_ids=()     # workflow run ID once found
+
+timestamp=$(date +%s)
+
+for idx in "${active_indices[@]}"; do
+    name="${all_names[$idx]}"
+    title="${all_titles[$idx]}"
+    body="${all_bodies[$idx]}"
+    cmd="${all_cmds[$idx]}"
+
+    tag_title="$title (e2e-$timestamp)"
+    log "Creating issue: $tag_title"
+
+    issue_url=$(gh issue create --repo "$TEST_REPO" \
+        --title "$tag_title" \
+        --body "$body")
+    issue_num="${issue_url##*/}"
+    issue_nums+=("$issue_num")
+    test_results+=("")
+    test_run_ids+=("")
+    cleanup_issues+=("$issue_num")
+
+    log "  Issue #$issue_num created. Triggering: $cmd"
+    gh issue comment "$issue_num" --repo "$TEST_REPO" --body "$cmd"
+done
+
+# Give GitHub a moment to start the workflows
+log "Waiting 15s for workflows to start..."
+sleep 15
+
+# --- Poll for workflow completion ---
+#
+# Match runs to issues using the run's displayTitle, which includes the
+# issue title. Our issue titles contain a unique timestamp (e2e-NNNN)
+# so we can match precisely.
+
+log "Polling for workflow completion (timeout: ${TIMEOUT}s)..."
+
+elapsed=0
+while [[ $elapsed -lt $TIMEOUT ]]; do
+    all_done=true
+
+    # Get recent workflow runs once per poll cycle
+    run_json=$(gh run list --repo "$TEST_REPO" \
+        --workflow=agent.yml \
+        --limit 50 \
+        --json databaseId,status,conclusion,displayTitle 2>/dev/null || echo "[]")
+
+    for pos in "${!issue_nums[@]}"; do
+        # Skip already-resolved tests
+        if [[ -n "${test_results[$pos]}" ]]; then
+            continue
+        fi
+
+        issue_num="${issue_nums[$pos]}"
+        name="${all_names[${active_indices[$pos]}]}"
+        title="${all_titles[${active_indices[$pos]}]}"
+        # Match on the unique timestamp tag in the issue title
+        match_str="e2e-$timestamp"
+
+        while IFS= read -r row; do
+            [[ -z "$row" ]] && continue
+            display_title=$(echo "$row" | jq -r '.displayTitle')
+            status=$(echo "$row" | jq -r '.status')
+            conclusion=$(echo "$row" | jq -r '.conclusion')
+            run_id=$(echo "$row" | jq -r '.databaseId')
+
+            # Match: run title contains our timestamp AND our test's title prefix
+            if [[ "$display_title" == *"$match_str"* && "$display_title" == *"$title"* ]]; then
+                if [[ "$status" == "completed" ]]; then
+                    test_results[$pos]="$conclusion"
+                    test_run_ids[$pos]="$run_id"
+                    log "  $name: $conclusion (run $run_id)"
+                else
+                    # Found our run but still in progress
+                    log "  $name: $status (run $run_id)"
+                fi
+                break
+            fi
+        done <<< "$(echo "$run_json" | jq -c '.[]')"
+
+        if [[ -z "${test_results[$pos]}" ]]; then
+            all_done=false
+        fi
+    done
+
+    if $all_done; then
+        break
+    fi
+
+    log "  Waiting... (${elapsed}s elapsed)"
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+done
+
+# --- Verify results ---
+
+log ""
+log "========================================="
+log "  E2E Test Results"
+log "========================================="
+
+pass=0
+fail=0
+timeout_count=0
+
+for pos in "${!issue_nums[@]}"; do
+    idx="${active_indices[$pos]}"
+    name="${all_names[$idx]}"
+    issue_num="${issue_nums[$pos]}"
+    conclusion="${test_results[$pos]:-timeout}"
+    run_id="${test_run_ids[$pos]}"
+
+    if [[ "$conclusion" == "success" ]]; then
+        # Check if a PR was created (OpenHands branch pattern: openhands-fix-issue-N)
+        pr_count=$(gh pr list --repo "$TEST_REPO" \
+            --search "head:openhands-fix-issue-$issue_num" \
+            --json number --jq 'length' 2>/dev/null || echo "0")
+
+        if [[ "$pr_count" -gt 0 ]]; then
+            status="PASS"
+            ((pass++)) || true
+            cleanup_branches+=("openhands-fix-issue-$issue_num")
+        else
+            # Workflow succeeded but no PR — agent ran but didn't produce a PR.
+            # This is still a "pass" for the workflow itself (config parsing,
+            # agent invocation all worked). The agent just didn't solve the issue.
+            status="PASS (no PR)"
+            ((pass++)) || true
+        fi
+    elif [[ "$conclusion" == "timeout" ]]; then
+        status="TIMEOUT"
+        ((timeout_count++)) || true
+    else
+        status="FAIL ($conclusion)"
+        ((fail++)) || true
+        if [[ -n "$run_id" ]]; then
+            log "  Logs: gh run view $run_id --repo $TEST_REPO --log | tail -40"
+        fi
+    fi
+
+    printf "  %-25s %-25s issue #%s\n" "$name" "$status" "$issue_num"
+done
+
+log "========================================="
+log "  Pass: $pass  Fail: $fail  Timeout: $timeout_count"
+log "========================================="
+
+# Exit with failure if any test didn't pass
+if [[ $fail -gt 0 || $timeout_count -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,169 @@
+"""Tests for lib/config.py — config parsing and model resolution."""
+
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from lib.config import deep_merge, detect_api_provider, resolve_config
+
+
+# --- deep_merge ---
+
+
+def test_deep_merge_basic():
+    base = {"a": 1, "b": 2}
+    override = {"b": 3, "c": 4}
+    assert deep_merge(base, override) == {"a": 1, "b": 3, "c": 4}
+
+
+def test_deep_merge_nested():
+    base = {"a": {"x": 1, "y": 2}, "b": 3}
+    override = {"a": {"y": 99, "z": 100}}
+    result = deep_merge(base, override)
+    assert result == {"a": {"x": 1, "y": 99, "z": 100}, "b": 3}
+
+
+def test_deep_merge_new_keys():
+    base = {"a": 1}
+    override = {"b": {"nested": True}}
+    assert deep_merge(base, override) == {"a": 1, "b": {"nested": True}}
+
+
+def test_deep_merge_empty_override():
+    base = {"a": 1, "b": {"c": 2}}
+    assert deep_merge(base, {}) == base
+
+
+def test_deep_merge_empty_base():
+    override = {"a": 1}
+    assert deep_merge({}, override) == {"a": 1}
+
+
+def test_deep_merge_does_not_mutate_base():
+    base = {"a": {"x": 1}}
+    override = {"a": {"x": 2}}
+    deep_merge(base, override)
+    assert base == {"a": {"x": 1}}
+
+
+# --- detect_api_provider ---
+
+
+def test_detect_api_provider_anthropic():
+    assert detect_api_provider("anthropic/claude-sonnet-4-5") == "anthropic"
+
+
+def test_detect_api_provider_openai():
+    assert detect_api_provider("openai/gpt-5-nano") == "openai"
+
+
+def test_detect_api_provider_gemini():
+    assert detect_api_provider("gemini/gemini-2.5-flash") == "gemini"
+
+
+def test_detect_api_provider_unknown():
+    with pytest.raises(ValueError, match="Unknown provider"):
+        detect_api_provider("mistral/mixtral-8x7b")
+
+
+# --- resolve_config ---
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    """Create a temp dir with base config files."""
+    base = tmp_path / "base"
+    base.mkdir()
+    config = {
+        "default_model": "claude-medium",
+        "models": {
+            "claude-small": {"id": "anthropic/claude-haiku-4-5"},
+            "claude-medium": {"id": "anthropic/claude-sonnet-4-5"},
+            "openai-small": {"id": "openai/gpt-5-nano"},
+        },
+        "openhands": {
+            "version": "1.3.0",
+            "max_iterations": 50,
+            "pr_type": "ready",
+        },
+    }
+    (base / "remote-dev-bot.yaml").write_text(yaml.dump(config))
+    return tmp_path, str(base / "remote-dev-bot.yaml")
+
+
+def test_resolve_config_default_alias(config_dir):
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "")
+    assert result["alias"] == "claude-medium"
+    assert result["model"] == "anthropic/claude-sonnet-4-5"
+
+
+def test_resolve_config_explicit_alias(config_dir):
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "claude-small")
+    assert result["alias"] == "claude-small"
+    assert result["model"] == "anthropic/claude-haiku-4-5"
+
+
+def test_resolve_config_unknown_alias(config_dir):
+    tmp_path, base_path = config_dir
+    with pytest.raises(KeyError, match="Unknown model alias"):
+        resolve_config(base_path, "nonexistent.yaml", "does-not-exist")
+
+
+def test_resolve_config_override_wins(config_dir):
+    tmp_path, base_path = config_dir
+    override_path = str(tmp_path / "override.yaml")
+    override = {
+        "default_model": "openai-small",
+        "openhands": {"max_iterations": 10},
+    }
+    with open(override_path, "w") as f:
+        yaml.dump(override, f)
+
+    result = resolve_config(base_path, override_path, "")
+    assert result["alias"] == "openai-small"
+    assert result["model"] == "openai/gpt-5-nano"
+    assert result["max_iterations"] == 10
+    # Version should come from base (not overridden)
+    assert result["oh_version"] == "1.3.0"
+    assert result["has_override"] is True
+
+
+def test_resolve_config_openhands_defaults():
+    """When base config has no openhands section, defaults kick in."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(
+            {"default_model": "m", "models": {"m": {"id": "anthropic/test"}}}, f
+        )
+        path = f.name
+    try:
+        result = resolve_config(path, "nonexistent.yaml", "")
+        assert result["max_iterations"] == 50
+        assert result["oh_version"] == "0.39.0"
+        assert result["pr_type"] == "ready"
+    finally:
+        os.unlink(path)
+
+
+def test_resolve_config_missing_base():
+    """Missing base config file should still work (empty base)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump({"models": {"x": {"id": "anthropic/test"}}}, f)
+        path = f.name
+    try:
+        # Use the override as the only config source, base doesn't exist
+        result = resolve_config("nonexistent_base.yaml", path, "x")
+        assert result["model"] == "anthropic/test"
+    finally:
+        os.unlink(path)
+
+
+def test_resolve_config_malformed_yaml(tmp_path):
+    """Malformed YAML should raise an error."""
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text(": this is not valid yaml\n  - broken:\nindent")
+    with pytest.raises(yaml.YAMLError):
+        resolve_config(str(bad_yaml), "nonexistent.yaml", "")

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,80 @@
+"""Tests for YAML file validity and structural requirements."""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.config import KNOWN_PROVIDERS
+
+# Repo root relative to this test file
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_yaml(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# --- YAML files parse without errors ---
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "remote-dev-bot.yaml",
+        ".github/workflows/resolve.yml",
+        ".github/workflows/agent.yml",
+        "examples/agent.yml",
+    ],
+)
+def test_yaml_parses(path):
+    full = REPO_ROOT / path
+    if not full.exists():
+        pytest.skip(f"{path} not found")
+    load_yaml(full)
+
+
+# --- remote-dev-bot.yaml structural validation ---
+
+
+@pytest.fixture
+def bot_config():
+    return load_yaml(REPO_ROOT / "remote-dev-bot.yaml")
+
+
+def test_config_has_required_keys(bot_config):
+    assert "default_model" in bot_config
+    assert "models" in bot_config
+    assert "openhands" in bot_config
+
+
+def test_default_model_exists_in_models(bot_config):
+    default = bot_config["default_model"]
+    assert default in bot_config["models"], (
+        f"default_model '{default}' not in models"
+    )
+
+
+def test_every_model_has_id(bot_config):
+    for alias, info in bot_config["models"].items():
+        assert "id" in info, f"Model alias '{alias}' missing 'id' field"
+
+
+def test_every_model_id_has_known_provider(bot_config):
+    for alias, info in bot_config["models"].items():
+        model_id = info["id"]
+        assert any(model_id.startswith(p) for p in KNOWN_PROVIDERS), (
+            f"Model '{alias}' has id '{model_id}' with unknown provider. "
+            f"Expected one of: {KNOWN_PROVIDERS}"
+        )
+
+
+def test_openhands_has_version(bot_config):
+    assert "version" in bot_config["openhands"]
+
+
+def test_openhands_has_max_iterations(bot_config):
+    assert "max_iterations" in bot_config["openhands"]
+    assert isinstance(bot_config["openhands"]["max_iterations"], int)


### PR DESCRIPTION
## Summary
- Extract inline Python config parsing from resolve.yml into `lib/config.py` — resolve.yml calls it via sparse-checkout from main
- Add 27 pytest unit tests: config merging, alias resolution, provider detection, YAML validation
- Add E2E test script (`tests/e2e.sh`) and workflow_dispatch (`e2e.yml`) for full agent runs against remote-dev-bot-test
- Add CI workflow (`test.yml`) — runs unit tests on PRs to main
- Document PR constraint in CLAUDE.md: config parsing changes must merge before workflow changes that depend on them (because resolve.yml checks out lib/ from main)

### E2E test modes
- **Default (smoke):** one small model per provider — cheap, catches workflow/config bugs
- **`--all-models`:** tests every model alias from `remote-dev-bot.yaml` — catches model-specific issues (e.g. parameter incompatibilities)
- **`--provider`:** filters by provider, composes with both modes
- Available via GitHub Actions UI (workflow_dispatch) with checkbox for "all models"

## Test plan
- [x] `pytest tests/ -v` — 27/27 pass locally
- [x] CI (test.yml) runs and passes on this PR
- [x] E2E script runs correctly (creates issues, matches runs by displayTitle, polls, reports results, cleans up)
- [ ] E2E workflow fails as expected (bootstrap: lib/config.py not on main yet) — will work after merge
