### PR TITLE
Fix issue #95: Agent loops?

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -321,6 +321,13 @@ jobs:
 
           result = response.choices[0].message.content
 
+          # Loop prevention: strip any leading /agent commands to prevent
+          # the bot from triggering itself when posting the comment
+          import re
+          if re.match(r'^/agent-', result.lstrip()):
+              result = re.sub(r'^(\s*/agent-[^\n]*\n?)+', '', result)
+              print("WARNING: Stripped /agent command(s) from LLM response to prevent loop")
+
           # Write to file (avoid shell escaping)
           with open("/tmp/llm_response.md", "w") as f:
               f.write(result)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -136,6 +136,13 @@ def test_design_has_llm_and_comment_steps(compiled_dir):
     assert "Gather issue context" in content
 
 
+def test_design_has_loop_prevention(compiled_dir):
+    """Design mode should strip /agent commands from LLM responses to prevent loops."""
+    content = _read_text(compiled_dir / "agent-design.yml")
+    assert "Loop prevention" in content
+    assert "Stripped /agent command" in content
+
+
 # --- Both: model aliases ---
 
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -123,3 +123,14 @@ def test_agent_yml_has_author_association_gate():
         # Ensure it's a restrictive check, not just a comment
         assert 'fromJson(' in content
         assert 'github.event.comment.author_association' in content
+
+
+def test_design_job_has_loop_prevention(resolve_yml):
+    """Verify the design job strips /agent commands from LLM responses.
+
+    This prevents the bot from triggering itself when posting comments,
+    which could create an infinite loop.
+    """
+    assert "/agent-" in resolve_yml  # The pattern we're checking for
+    assert "Loop prevention" in resolve_yml
+    assert "Stripped /agent command" in resolve_yml


### PR DESCRIPTION
This pull request fixes #95.

The issue raised a concern about preventing the design job from creating an infinite loop by posting comments that start with `/agent` commands, which could trigger the bot to respond to itself.

The changes made directly address this concern:

1. **Loop prevention logic added to resolve.yml**: In the design job's Python code that processes LLM responses, a regex check was added that:
   - Detects if the LLM response starts with `/agent-` commands (after stripping whitespace)
   - Strips any leading `/agent-*` commands from the response before posting it as a comment
   - Logs a warning when this stripping occurs

2. **Tests added to verify the fix**:
   - `test_design_has_loop_prevention` in `test_compile.py` verifies the compiled workflow contains the loop prevention code
   - `test_design_job_has_loop_prevention` in `test_yaml.py` verifies the source YAML contains the loop prevention markers

The implementation is straightforward and effective: before the bot posts its response as a comment, it sanitizes the content to remove any `/agent-` commands that could trigger another workflow run. This prevents the self-triggering loop scenario described in the issue, regardless of whether the comment is posted as a user (which would bypass the author_association gate mentioned in the issue).

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌