### PR TITLE
Pass full issue thread to OpenHands resolver

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -159,8 +159,7 @@ jobs:
             --selected-repo "${{ github.repository }}" \
             --issue-number "$ISSUE_NUMBER" \
             --issue-type "$ISSUE_TYPE" \
-            --max-iterations ${{ needs.parse.outputs.max_iterations }} \
-            --comment-id ${{ github.event.comment.id }}
+            --max-iterations ${{ needs.parse.outputs.max_iterations }}
 
       - name: Create pull request
         env:


### PR DESCRIPTION
## Summary
- Remove `--comment-id` from the OpenHands invocation in `resolve.yml`
- Without this flag, OpenHands includes **all** issue comments in the agent's context, not just the triggering command
- This means design discussions, clarifications, and back-and-forth that happen before `/agent-resolve` are now visible to the agent

## Background
When `--comment-id` is passed, OpenHands filters `Issue Thread Comments` to only the single comment matching that ID. So if you have a 10-comment design discussion and then trigger with `/agent-resolve`, the agent only saw `/agent-resolve` — all context was lost.

Without `--comment-id`, OpenHands calls `get_issue_comments()` with `comment_id=None`, which returns all comments on the issue.

## Trade-off
The agent no longer knows which specific comment triggered the run. In practice this doesn't matter — the triggering comment is the most recent one, and the agent benefits far more from seeing the full conversation.

## Test plan
- [x] `pytest tests/ -v` — all 59 tests pass
- [ ] E2E: create an issue with a design discussion, then trigger `/agent-resolve` and verify the agent references the discussion context

🤖 Generated with [Claude Code](https://claude.com/claude-code)