### PR TITLE
Document why loop prevention is not e2e tested

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,9 @@ See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how t
 - User gating: verify non-collaborator comments don't trigger runs
 - Requires repos to be public and uses `TESTER_PAT_TOKEN`
 
+### Loop prevention (not e2e tested — intentionally)
+The design agent has two layers of defense against recursive loops (where its response starts with `/agent` and re-triggers itself): a prompt instruction telling the LLM not to do it, and a regex check that blocks the response if it does. We deliberately do NOT e2e test this, because the test itself would be dangerous — if the regex has a bug, the test creates the very loop it's trying to prevent, consuming LLM budget. The regex is well covered by unit tests (`tests/test_yaml.py::TestLoopPreventionRegex`). The shim's `startsWith(comment.body, '/agent-')` trigger requires `/` as the literal first character (leading whitespace defeats it), which provides an additional layer of safety.
+
 ### Compiled workflow tests
 - Unit tests (`tests/test_compile.py`): validate both compiled files (resolve and design) — structure, triggers, permissions, model aliases, security microagent
 - E2E: `./tests/e2e.sh --compiled` swaps compiled workflows into the test repo, runs the full suite, then restores the shim. Use this before releases.


### PR DESCRIPTION
## Summary
- Adds a paragraph to CONTRIBUTING.md explaining why the design agent loop prevention is deliberately not covered by e2e tests
- The test itself would be dangerous: if the regex has a bug, the test creates the very loop it is trying to prevent, consuming LLM budget
- Unit tests cover the regex; the shim trigger provides additional safety

This was part of PR #108 but the commit landed after merge. Cherry-picked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)