### PR TITLE
Fix openai-large model ID and show URLs for timed-out runs

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -45,8 +45,8 @@ models:
     description: "OpenAI GPT-5.1 Codex Mini"
 
   openai-large:
-    id: openai/gpt-5.3-codex
-    description: "OpenAI GPT-5.3 Codex — best coding model"
+    id: openai/gpt-5.2-codex
+    description: "OpenAI GPT-5.2 Codex — best coding model"
 
   gemini-small:
     id: gemini/gemini-2.5-flash-lite

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -347,9 +347,9 @@ while [[ $elapsed -lt $TIMEOUT ]]; do
 
             # Match: run title contains our timestamp AND our test's title prefix
             if [[ "$display_title" == *"$match_str"* && "$display_title" == *"$title"* ]]; then
+                test_run_ids[$pos]="$run_id"
                 if [[ "$status" == "completed" ]]; then
                     test_results[$pos]="$conclusion"
-                    test_run_ids[$pos]="$run_id"
                     log "  $name: $conclusion (run $run_id)"
                 else
                     # Found our run but still in progress


### PR DESCRIPTION
## Summary
- Fix `openai-large` model: `gpt-5.3-codex` is not yet available via API (only in ChatGPT). Switch to `gpt-5.2-codex`.
- Fix e2e.sh: save the workflow run ID when a run is found (even if still in progress), so timed-out tests show a clickable URL in the results table instead of a blank.

Discovered in e2e run 22072912223 where openai-large failed (model not found) and gemini-large timed out with no log link.

## Test plan
- [x] `pytest tests/ -v` — all 70 tests pass
- [ ] Re-run e2e with `--all-models` to verify openai-large works with gpt-5.2-codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)