### PR TITLE
Add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   e2e-security:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,6 +37,7 @@ jobs:
   e2e-shim:
     needs: unit-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,6 +56,7 @@ jobs:
   e2e-compiled:
     needs: e2e-shim
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,6 +75,7 @@ jobs:
   e2e-security:
     needs: e2e-compiled
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -25,6 +25,7 @@ jobs:
   # --- Shared setup: parse config, determine mode and model ---
   parse:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       mode: ${{ steps.parse.outputs.mode }}
       action: ${{ steps.parse.outputs.action }}
@@ -79,6 +80,7 @@ jobs:
     needs: parse
     if: needs.parse.outputs.action == 'pr'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout target repository
@@ -190,6 +192,7 @@ jobs:
     needs: parse
     if: needs.parse.outputs.action == 'comment'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout target repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `timeout-minutes` to every job across all workflows to prevent runaway runs
- Without explicit timeouts, GitHub defaults to 360 minutes (6 hours) per job

### Timeouts chosen
| Job | Timeout | Rationale |
|-----|---------|-----------|
| parse | 5 min | Trivial config parsing |
| resolve | 60 min | Agent needs time for complex tasks, but shouldn't run forever |
| design | 10 min | Single LLM call |
| e2e jobs | 30 min | Polling timeout is 15 min, plus setup overhead |
| unit tests | 5 min | Fast, should complete in seconds |

### Motivation
A gemini-large run hit a quota error and sat spinning for 40+ minutes consuming GitHub runner minutes. The iteration limit controls LLM round-trips but doesn't cap wall-clock time when OpenHands is stuck retrying.

## Test plan
- [x] `pytest tests/ -v` — all 70 tests pass
- [ ] Verify timeouts don't interfere with normal runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)