### PR TITLE
Fix issue #123: Remove small model aliases, rename medium → small

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This project has an unusual dev cycle because GitHub Actions only runs workflows
 1. Create a feature branch from `main`: `git checkout -b my-feature main`
 2. Make changes, commit freely (work log mode)
 3. Point dev at your branch: `git branch -f dev my-feature && git push --force-with-lease origin dev`
-4. In `remote-dev-bot-test`: create an issue, comment `/agent-resolve-claude-medium`
+4. In `remote-dev-bot-test`: create an issue, comment `/agent-resolve-claude-small`
 5. Monitor: `gh run list --repo gnovak/remote-dev-bot-test --workflow=agent.yml --limit 3`
 6. If it fails: check logs, fix, commit, push dev again, re-trigger
 7. If it works: clean up git history (rebase), open a PR (dev → main), merge
@@ -69,7 +69,7 @@ gh issue create --repo gnovak/remote-dev-bot-test \
   --title "Test: description" --body "What to do"
 # Trigger agent
 gh issue comment ISSUE_NUM --repo gnovak/remote-dev-bot-test \
-  --body "/agent-resolve-claude-medium"
+  --body "/agent-resolve-claude-small"
 # Monitor
 gh run list --repo gnovak/remote-dev-bot-test --workflow=agent.yml --limit 3
 # Check logs on failure

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Or use `/agent-design` to get AI design analysis posted as a comment (no code ch
 | `/agent-resolve` | Resolve the issue and open a PR (default model) |
 | `/agent-resolve-claude-large` | Resolve with a specific model |
 | `/agent-design` | Post design analysis as a comment (no code changes) |
-| `/agent-design-claude-small` | Design analysis with a specific model |
+| `/agent-design-claude-large` | Design analysis with a specific model |
 
 Modes and model aliases are configured in `remote-dev-bot.yaml`.
 
 ### Understanding Model Names
 
-Model aliases (like `claude-medium`) map to **LiteLLM model identifiers** in `remote-dev-bot.yaml`. LiteLLM is the library OpenHands uses to talk to different LLM providers through a unified interface.
+Model aliases (like `claude-small`) map to **LiteLLM model identifiers** in `remote-dev-bot.yaml`. LiteLLM is the library OpenHands uses to talk to different LLM providers through a unified interface.
 
 **Model ID format:** `provider/model-name`
 
@@ -49,11 +49,9 @@ Prefix the model string with the provider name in `remote-dev-bot.yaml` (e.g., `
 
 ### Choosing a Model
 
-**For most tasks:** Use the default (`/agent-resolve`). Claude Sonnet offers a good balance of capability and cost.
+**For most tasks:** Use the default (`/agent-resolve`). Claude Sonnet (`claude-small`) offers a good balance of capability and cost.
 
 **For complex multi-file features:** Use `/agent-resolve-claude-large` (Opus) or `/agent-resolve-openai-large` (GPT Codex). These models handle larger contexts and more intricate reasoning.
-
-**For simple, well-defined tasks:** Use `/agent-resolve-claude-small` (Haiku) or `/agent-resolve-gemini-small`. Faster and cheaper, but may struggle with ambiguous requirements.
 
 **For coding-heavy tasks:** Models with "codex" in the name (e.g., `openai/gpt-5.1-codex-mini`) are specifically tuned for code generation and may perform better on implementation tasks.
 
@@ -96,7 +94,7 @@ GitHub Actions only runs workflows from the default branch (main), so developing
 
 **Dev cycle:**
 1. In `remote-dev-bot`: reset `dev` to `main`, then make changes on `dev`
-2. In `remote-dev-bot-test`: create an issue and comment `/agent-resolve-claude-medium` to trigger the agent
+2. In `remote-dev-bot-test`: create an issue and comment `/agent-resolve-claude-small` to trigger the agent
 3. The shim in the test repo calls `resolve.yml@dev`, so it picks up your changes
 4. If it works, clean up the git history on `dev` (squash, rebase, reword) and merge to `main`
 5. If not, make more commits on `dev` and trigger the agent again

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -51,7 +51,7 @@ This is the "engine" — the shared infrastructure that all target repos use.
 | File | Purpose |
 |------|---------|
 | `.github/workflows/resolve.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
-| `remote-dev-bot.yaml` | Base configuration. Defines model aliases (claude-small, claude-large, etc.) and OpenHands settings (version, max iterations, PR type). |
+| `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
 | `lib/config.py` | Config parsing logic. Loads base config, merges with target repo overrides, resolves aliases. Used by resolve.yml at runtime. |
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
 | `runbook.md` | Step-by-step setup instructions for humans or AI assistants. |
@@ -116,18 +116,18 @@ Configuration is layered: target repo settings override remote-dev-bot defaults.
 
 ```yaml
 # remote-dev-bot/remote-dev-bot.yaml (base)
-default_model: claude-medium
+default_model: claude-small
 openhands:
   max_iterations: 50
   pr_type: ready
 
 # target-repo/remote-dev-bot.yaml (override)
-default_model: claude-small
+default_model: claude-large
 openhands:
   max_iterations: 30
 ```
 
-Result: `default_model: claude-small`, `max_iterations: 30`, `pr_type: ready` (inherited from base).
+Result: `default_model: claude-large`, `max_iterations: 30`, `pr_type: ready` (inherited from base).
 
 This lets you:
 - Use different default models per repo

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -5,16 +5,16 @@
 #   /agent-design              — design discussion, post comment
 #   /agent-design-claude-large  — design discussion with specific model
 
-default_model: claude-medium
+default_model: claude-small
 
 # Modes define what the agent does. Each mode has an action and optional defaults.
 modes:
   resolve:
     action: pr               # Run OpenHands, open a draft PR
-    default_model: claude-medium
+    default_model: claude-small
   design:
     action: comment           # Post analysis as an issue comment (no code changes)
-    default_model: claude-medium
+    default_model: claude-small
     context_files:
       - README.md
       - AGENTS.md
@@ -29,10 +29,6 @@ modes:
 
 models:
   claude-small:
-    id: anthropic/claude-haiku-4-5
-    description: "Fast and cheap — good for straightforward tasks"
-
-  claude-medium:
     id: anthropic/claude-sonnet-4-5
     description: "Balanced cost/capability — good default for most tasks"
 
@@ -41,24 +37,16 @@ models:
     description: "Most capable — for complex multi-file features"
 
   openai-small:
-    id: openai/gpt-5-nano
-    description: "OpenAI GPT-5 Nano — cheapest"
-
-  openai-medium:
     id: openai/gpt-5.1-codex-mini
-    description: "OpenAI GPT-5.1 Codex Mini"
+    description: "OpenAI GPT-5.1 Codex Mini — good default"
 
   openai-large:
     id: openai/gpt-5.2-codex
     description: "OpenAI GPT-5.2 Codex — best coding model"
 
   gemini-small:
-    id: gemini/gemini-2.5-flash-lite
-    description: "Google Gemini 2.5 Flash-Lite — cheapest"
-
-  gemini-medium:
     id: gemini/gemini-2.5-flash
-    description: "Google Gemini 2.5 Flash"
+    description: "Google Gemini 2.5 Flash — good default"
 
   gemini-large:
     id: gemini/gemini-2.5-pro

--- a/runbook.md
+++ b/runbook.md
@@ -475,17 +475,17 @@ gh issue create --repo {owner}/{repo} \
 
 ### Step 4.2: Trigger the Agent
 
-Comment on the issue to trigger the agent. For your first test, use `claude-medium` (Sonnet) — it handles the task lifecycle more reliably than `claude-small` (Haiku).
+Comment on the issue to trigger the agent. For your first test, use `claude-small` (Sonnet) — it's the default and handles most tasks well.
 
 **Via web interface:**
 1. Go to `https://github.com/{owner}/{repo}/issues/{issue-number}` (or click on the issue you just created)
 2. Scroll to the comment box at the bottom
-3. Type `/agent-resolve-claude-medium`
+3. Type `/agent-resolve-claude-small`
 4. Click "Comment"
 
 **Via command line:**
 ```bash
-gh issue comment {issue-number} --repo {owner}/{repo} --body "/agent-resolve-claude-medium"
+gh issue comment {issue-number} --repo {owner}/{repo} --body "/agent-resolve-claude-small"
 ```
 
 ### Step 4.3: Monitor the Run
@@ -537,7 +537,7 @@ gh pr list --repo {owner}/{repo}
 | `error: the following arguments are required: --selected-repo` | OpenHands 1.x API change | Update workflow — `--repo` was renamed to `--selected-repo` |
 | `ValueError: Username is required` | Missing env vars | Workflow needs `GITHUB_USERNAME` and `GIT_USERNAME` |
 | `Missing Anthropic API Key` or `x-api-key header is required` | API key not reaching the workflow | **Shim install:** Ensure secrets are passed explicitly (not via `secrets: inherit`) — see `.github/workflows/agent.yml`. **Both installs:** Re-check the secret value via web (`https://github.com/{owner}/{repo}/settings/secrets/actions`) |
-| `Agent reached maximum iteration` | Agent loops instead of finishing | Try `/agent-resolve-claude-medium` instead of `/agent-resolve` |
+| `Agent reached maximum iteration` | Agent loops instead of finishing | Try `/agent-resolve-claude-large` for complex tasks |
 | `429 Too Many Requests` | GitHub API rate limit | Wait a few minutes and try again |
 | `KeyError: 'LLM_API_KEY'` in PR creation step | Missing env vars in PR step | Update workflow to pass `LLM_API_KEY` and `LLM_MODEL` to both steps |
 | Workflow file issue (instant failure, 0s) | Reusable workflow not accessible | **Shim install:** Ensure `gnovak/remote-dev-bot` (or your fork) is public, or set Actions access to `user` level if using a private fork |
@@ -597,7 +597,7 @@ If the agent fails with `x-api-key header is required` or similar authentication
 
 ### Agent runs but hits max iterations
 - The agent completed the work but couldn't gracefully stop
-- Try a more capable model: `/agent-claude-medium` or `/agent-claude-large`
+- Try a more capable model: `/agent-resolve-claude-large`
 - Or lower `max_iterations` in `remote-dev-bot.yaml`
 
 ### Agent runs but skips PR creation

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -76,7 +76,7 @@ def inline_config_parsing(config_yaml, mode):
     modes_config = config_yaml.get("modes", {})
     mode_config = modes_config.get(mode, {})
     default_model = mode_config.get("default_model",
-                                     config_yaml.get("default_model", "claude-medium"))
+                                     config_yaml.get("default_model", "claude-small"))
 
     models = config_yaml.get("models", {})
     oh = config_yaml.get("openhands", {})

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -174,12 +174,13 @@ def test_both_inline_model_aliases(compiled_dir):
     for fname in ["agent-resolve.yml", "agent-design.yml"]:
         content = _read_text(compiled_dir / fname)
         assert "claude-small" in content
-        assert "claude-medium" in content
         assert "claude-large" in content
         assert "openai-small" in content
-        assert "gemini-medium" in content
+        assert "openai-large" in content
+        assert "gemini-small" in content
+        assert "gemini-large" in content
         assert "anthropic/claude-sonnet-4-5" in content
-        assert "openai/gpt-5-nano" in content
+        assert "openai/gpt-5.1-codex-mini" in content
         assert "gemini/gemini-2.5-flash" in content
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,7 +91,7 @@ def test_parse_command_design_with_model():
 
 def test_parse_command_multi_segment_model():
     """Model aliases with hyphens should be preserved."""
-    assert parse_command("resolve-openai-small", KNOWN_MODES) == ("resolve", "openai-small")
+    assert parse_command("resolve-openai-large", KNOWN_MODES) == ("resolve", "openai-large")
 
 
 def test_parse_command_bare_agent_errors():
@@ -120,20 +120,20 @@ def config_dir(tmp_path):
     base = tmp_path / "base"
     base.mkdir()
     config = {
-        "default_model": "claude-medium",
+        "default_model": "claude-small",
         "models": {
-            "claude-small": {"id": "anthropic/claude-haiku-4-5"},
-            "claude-medium": {"id": "anthropic/claude-sonnet-4-5"},
-            "openai-small": {"id": "openai/gpt-5-nano"},
+            "claude-small": {"id": "anthropic/claude-sonnet-4-5"},
+            "claude-large": {"id": "anthropic/claude-opus-4-5"},
+            "openai-small": {"id": "openai/gpt-5.1-codex-mini"},
         },
         "modes": {
             "resolve": {
                 "action": "pr",
-                "default_model": "claude-medium",
+                "default_model": "claude-small",
             },
             "design": {
                 "action": "comment",
-                "default_model": "claude-medium",
+                "default_model": "claude-small",
                 "prompt_prefix": "You are analyzing this issue.",
             },
         },
@@ -152,16 +152,16 @@ def test_resolve_config_resolve_default_model(config_dir):
     result = resolve_config(base_path, "nonexistent.yaml", "resolve")
     assert result["mode"] == "resolve"
     assert result["action"] == "pr"
-    assert result["alias"] == "claude-medium"
+    assert result["alias"] == "claude-small"
     assert result["model"] == "anthropic/claude-sonnet-4-5"
 
 
 def test_resolve_config_resolve_explicit_model(config_dir):
     tmp_path, base_path = config_dir
-    result = resolve_config(base_path, "nonexistent.yaml", "resolve-claude-small")
+    result = resolve_config(base_path, "nonexistent.yaml", "resolve-claude-large")
     assert result["mode"] == "resolve"
-    assert result["alias"] == "claude-small"
-    assert result["model"] == "anthropic/claude-haiku-4-5"
+    assert result["alias"] == "claude-large"
+    assert result["model"] == "anthropic/claude-opus-4-5"
 
 
 def test_resolve_config_design_mode(config_dir):
@@ -169,17 +169,17 @@ def test_resolve_config_design_mode(config_dir):
     result = resolve_config(base_path, "nonexistent.yaml", "design")
     assert result["mode"] == "design"
     assert result["action"] == "comment"
-    assert result["alias"] == "claude-medium"
+    assert result["alias"] == "claude-small"
     assert "prompt_prefix" in result
     assert "analyzing" in result["prompt_prefix"]
 
 
 def test_resolve_config_design_with_model(config_dir):
     tmp_path, base_path = config_dir
-    result = resolve_config(base_path, "nonexistent.yaml", "design-claude-small")
+    result = resolve_config(base_path, "nonexistent.yaml", "design-claude-large")
     assert result["mode"] == "design"
-    assert result["alias"] == "claude-small"
-    assert result["model"] == "anthropic/claude-haiku-4-5"
+    assert result["alias"] == "claude-large"
+    assert result["model"] == "anthropic/claude-opus-4-5"
 
 
 def test_resolve_config_unknown_model(config_dir):
@@ -215,7 +215,7 @@ def test_resolve_config_override_wins(config_dir):
 
     result = resolve_config(base_path, override_path, "resolve")
     assert result["alias"] == "openai-small"
-    assert result["model"] == "openai/gpt-5-nano"
+    assert result["model"] == "openai/gpt-5.1-codex-mini"
     assert result["max_iterations"] == 10
     # Version should come from base (not overridden)
     assert result["oh_version"] == "1.3.0"

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -196,11 +196,11 @@ def test_format_cost_comment_basic():
         output_tokens=2000,
         total_cost=0.06,
         mode="resolve",
-        alias="claude-medium",
+        alias="claude-small",
     )
 
     assert "### 💰 Cost Summary" in comment
-    assert "claude-medium" in comment
+    assert "claude-small" in comment
     assert "anthropic/claude-sonnet-4-5" in comment
     assert "resolve" in comment
     assert "10,000" in comment
@@ -228,15 +228,15 @@ def test_format_cost_comment_no_cost():
 def test_format_cost_comment_calculates_cost():
     """Test that format_cost_comment calculates cost if not provided."""
     comment = format_cost_comment(
-        model="anthropic/claude-haiku-4-5",
+        model="anthropic/claude-sonnet-4-5",
         input_tokens=100000,
         output_tokens=20000,
         mode="resolve",
         alias="claude-small",
     )
 
-    # Should calculate: (100000/1M * 0.25) + (20000/1M * 1.25) = 0.025 + 0.025 = 0.05
-    assert "$0.0500" in comment
+    # Should calculate: (100000/1M * 3.00) + (20000/1M * 15.00) = 0.30 + 0.30 = 0.60
+    assert "$0.6000" in comment
 
 
 def test_format_cost_comment_large_numbers():


### PR DESCRIPTION
This pull request fixes #123.

The issue has been successfully resolved. The changes made directly address all three requirements from the proposal:

1. **Removed all `*-small` model aliases that pointed to weak models**: In `remote-dev-bot.yaml`, the original small models (claude-haiku-4-5, gpt-5-nano, gemini-2.5-flash-lite) have been completely removed from the configuration.

2. **Renamed `*-medium` → `*-small`**: The former medium-tier models are now the new small tier:
   - `claude-small` now maps to `anthropic/claude-sonnet-4-5` (was claude-medium)
   - `openai-small` now maps to `openai/gpt-5.1-codex-mini` (was openai-medium)
   - `gemini-small` now maps to `gemini/gemini-2.5-flash` (was gemini-medium)

3. **`*-large` stays as-is**: The large models remain unchanged (Opus, GPT-5.2 Codex, Gemini Pro).

4. **Updated `default_model`**: Changed from `claude-medium` to `claude-small` throughout the configuration.

The changes also include:
- Updated all documentation (README.md, AGENTS.md, runbook.md, how-it-works.md) to reflect the new two-tier model system
- Updated all tests to use the new model aliases and verify the correct model IDs
- Updated the compile script's default fallback from `claude-medium` to `claude-small`

The tests pass (as indicated by the final message showing exit code 0), confirming that the configuration changes are consistent and the test assertions have been properly updated to match the new model structure.

This gives users the intended simple two-tier system: **small** (cost-effective, capable models like Sonnet) and **large** (most capable models like Opus), eliminating the footgun of users selecting inadequate cheap models.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌