### PR TITLE
Tell design agent not to end with conversational invitations

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -26,6 +26,9 @@ modes:
       clarifying questions. Respond in a GitHub comment.
       IMPORTANT: Never begin your response with a slash command like /agent
       or any text that could trigger another bot action.
+      Do NOT end your response with conversational invitations like
+      "Want me to elaborate?" or "Let me know if you have questions."
+      Your response is a design document, not a chat message.
 
 models:
   claude-small:


### PR DESCRIPTION
## Summary
- Adds prompt instruction telling the design agent not to end responses with chat-style invitations like "Want me to elaborate?" or "Let me know if you have questions"
- The design comment is a document posted on a GitHub issue, not a chat message

## Test plan
- [x] All 96 tests pass
- [ ] E2E: trigger /agent-design and verify response does not end with a question

Generated with [Claude Code](https://claude.com/claude-code)