### PR TITLE
Fix cost extraction to match OpenHands output format

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -209,27 +209,32 @@ jobs:
           ALIAS="${{ needs.parse.outputs.alias }}"
           MODE="${{ needs.parse.outputs.mode }}"
 
-          # Check if output/output.jsonl exists
-          if [ ! -f output/output.jsonl ]; then
-            echo "No output/output.jsonl found, skipping cost calculation"
-            exit 0
-          fi
-
           # Parse metrics from output/output.jsonl
-          # OpenHands writes metrics at the end of the run
-          METRICS=$(tail -20 output/output.jsonl | grep -E '"metrics"' | tail -1 || echo "")
+          # OpenHands writes a single JSON object with a metrics field.
+          # Note: as of OpenHands 1.3.0, metrics are present but unpopulated (all zeros).
+          # This code is ready for when they start populating the fields.
+          read -r COST INPUT_TOKENS OUTPUT_TOKENS < <(python3 << 'PYEOF'
+          import json, os
 
-          if [ -n "$METRICS" ]; then
-            # Extract accumulated cost and tokens from metrics
-            COST=$(echo "$METRICS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('metrics',{}).get('accumulated_cost',0))" 2>/dev/null || echo "0")
-            INPUT_TOKENS=$(echo "$METRICS" | python3 -c "import sys,json; d=json.load(sys.stdin); m=d.get('metrics',{}); print(m.get('accumulated_input_tokens', m.get('prompt_tokens',0)))" 2>/dev/null || echo "0")
-            OUTPUT_TOKENS=$(echo "$METRICS" | python3 -c "import sys,json; d=json.load(sys.stdin); m=d.get('metrics',{}); print(m.get('accumulated_output_tokens', m.get('completion_tokens',0)))" 2>/dev/null || echo "0")
-          else
-            # Fallback: try to sum up from individual events
-            INPUT_TOKENS=$(grep -o '"prompt_tokens":[0-9]*' output/output.jsonl | cut -d: -f2 | awk '{s+=$1}END{print s+0}')
-            OUTPUT_TOKENS=$(grep -o '"completion_tokens":[0-9]*' output/output.jsonl | cut -d: -f2 | awk '{s+=$1}END{print s+0}')
-            COST="0"
-          fi
+          path = "output/output.jsonl"
+          if not os.path.exists(path):
+              print("0 0 0")
+              raise SystemExit
+
+          with open(path) as f:
+              data = json.loads(f.read().strip())
+
+          m = data.get("metrics", {})
+          cost = m.get("accumulated_cost", 0) or 0
+
+          # Tokens live under metrics.accumulated_token_usage
+          atu = m.get("accumulated_token_usage", {})
+          input_tokens = atu.get("prompt_tokens", 0) or 0
+          output_tokens = atu.get("completion_tokens", 0) or 0
+
+          print(f"{cost} {input_tokens} {output_tokens}")
+          PYEOF
+          )
 
           TOTAL_TOKENS=$((INPUT_TOKENS + OUTPUT_TOKENS))
 
@@ -245,7 +250,7 @@ jobs:
             echo "| Input tokens | ${INPUT_TOKENS} |"
             echo "| Output tokens | ${OUTPUT_TOKENS} |"
             echo "| Total tokens | ${TOTAL_TOKENS} |"
-            if [ "$COST" != "0" ] && [ -n "$COST" ]; then
+            if [ -n "$COST" ] && [ "$COST" != "0" ] && [ "$COST" != "0.0" ]; then
               printf "| **Estimated cost** | **\$%.2f** |\n" "$COST"
             else
               echo "| Estimated cost | _(not available)_ |"


### PR DESCRIPTION
## Summary

- Replace fragile `tail | grep | python3` extraction with proper Python JSON parsing
- Fix field paths: tokens live at `metrics.accumulated_token_usage.prompt_tokens`, not `metrics.accumulated_input_tokens`
- Handle `0.0` (float) in addition to `0` (string) for the "not available" display
- As of OpenHands 1.3.0, metrics are present but unpopulated — this fix ensures we'll pick up the data when they start reporting

## Context

Investigation of #134 revealed three issues:
1. OpenHands 1.3.0 doesn't populate token metrics in resolve mode (upstream issue)
2. Our extraction paths were wrong (would miss data even if populated)
3. File is a single JSON object, not JSONL — grep-based parsing was fragile

This PR fixes issues 2 and 3.

Closes #134

## Test plan

- [x] `pytest tests/test_compile.py -v` — all 21 pass
- [x] `python scripts/compile.py` compiles without error
- [x] Compiled resolve workflow contains updated extraction code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
