### PR TITLE
Fix issue #137: Have design task note model identity at the bottom of the resulting comment

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -474,6 +474,7 @@ jobs:
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODE="${{ needs.parse.outputs.mode }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
+          MODEL="${{ needs.parse.outputs.model }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           # Check if the response was blocked due to /agent command detection
@@ -487,7 +488,7 @@ jobs:
               echo "See the [workflow run logs]($RUN_URL) for the full response content."
               echo ""
               echo "---"
-              echo "_Blocked by \`/agent-${MODE}-${ALIAS}\` safety check_"
+              echo "_Blocked by \`/agent-${MODE}-${ALIAS}\` (${MODEL}) safety check_"
             } > /tmp/comment_body.md
           else
             # Add footer with metadata
@@ -495,7 +496,7 @@ jobs:
               cat /tmp/llm_response.md
               echo ""
               echo "---"
-              echo "_Design analysis by \`/agent-${MODE}-${ALIAS}\`_"
+              echo "_Design analysis by \`/agent-${MODE}-${ALIAS}\` (${MODEL})_"
             } > /tmp/comment_body.md
           fi
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -167,6 +167,19 @@ def test_design_has_cost_step(compiled_dir):
     assert "Output tokens" in content
 
 
+def test_design_comment_footer_includes_model(compiled_dir):
+    """Design mode comment footer should show both alias and model identity."""
+    content = _read_text(compiled_dir / "agent-design.yml")
+    # Check that the footer includes both alias and model in the format:
+    # _Design analysis by `/agent-${MODE}-${ALIAS}` (${MODEL})_
+    assert "_Design analysis by " in content
+    assert "(${MODEL})_" in content or "(${{ steps.parse.outputs.model }})_" in content
+    # Also check the blocked case footer
+    assert "_Blocked by " in content
+    # Verify MODEL variable is assigned in the Post comment step
+    assert 'MODEL="${{ steps.parse.outputs.model }}"' in content
+
+
 # --- Both: model aliases ---
 
 


### PR DESCRIPTION
This pull request fixes #137.

The issue requested that the design task show not just the model alias used, but also the actual model that the alias resolves to. 

The changes successfully address this by:

1. **Adding the MODEL variable** to the design job's "Post comment" step in `.github/workflows/resolve.yml`, pulling from `needs.parse.outputs.model` which already contains the resolved model identity.

2. **Updating both footer messages** to include the resolved model in parentheses:
   - Normal case: `_Design analysis by \`/agent-${MODE}-${ALIAS}\` (${MODEL})_`
   - Blocked case: `_Blocked by \`/agent-${MODE}-${ALIAS}\` (${MODEL}) safety check_`

3. **Adding a test** to verify the compiled workflow includes the model identity in the footer, ensuring the change is properly propagated.

The implementation transforms the footer from showing only the alias (e.g., `/agent-design-claude-small`) to showing both the alias and the resolved model (e.g., `/agent-design-claude-small (anthropic/claude-sonnet-4-5)`). This directly fulfills the user's request to see "the model that it resolves to as well."

The changes are minimal, focused, and leverage existing infrastructure (the parse job already provides both alias and model outputs). All tests pass, including the new test that specifically validates this feature.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌