### PR TITLE
Add GitHub App support, update auth model

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -7,6 +7,11 @@
 #   - Repository secrets: at least one LLM API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)
 #   - Actions permissions: read/write + allow PR creation
 #
+# Optional (for bot identity / CI triggering):
+#   - RDB_APP_ID (repo variable) + RDB_APP_PRIVATE_KEY (repo secret): GitHub App for bot identity
+#   - RDB_PAT_TOKEN (repo secret): PAT for CI triggering (bot posts as PAT owner)
+#   - Without either, github.token is used (bot posts as github-actions[bot], no CI on bot PRs)
+#
 # Note: secrets must be passed explicitly (not via `secrets: inherit`) because
 # GitHub Actions does not pass inherited secrets across different repo owners.
 #
@@ -41,4 +46,5 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      RDB_PAT_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
+      RDB_APP_PRIVATE_KEY: ${{ secrets.RDB_APP_PRIVATE_KEY }}

--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
           TESTER_PAT: ${{ secrets.TESTER_PAT_TOKEN }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         if: ${{ inputs.all_models }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"
           if [[ -n "${{ inputs.provider }}" && "${{ inputs.provider }}" != "all" ]]; then

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -43,14 +43,14 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         run: pip install PyYAML
 
       - name: Run E2E tests (shim, all models)
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --all-models
 
   e2e-compiled:
@@ -62,14 +62,14 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         run: pip install PyYAML
 
       - name: Run E2E tests (compiled, all models)
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --compiled --all-models
 
   e2e-security:
@@ -81,10 +81,10 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
           TESTER_PAT: ${{ secrets.TESTER_PAT_TOKEN }}
         run: ./tests/e2e-security.sh --branch ${{ inputs.branch }}

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -17,7 +17,9 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
-      PAT_TOKEN:
+      RDB_PAT_TOKEN:
+        required: false
+      RDB_APP_PRIVATE_KEY:
         required: false
       E2E_TEST_SECRET:
         required: false
@@ -39,16 +41,24 @@ jobs:
       commit_trailer: ${{ steps.parse.outputs.commit_trailer }}
 
     steps:
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           path: .remote-dev-bot
           sparse-checkout: lib
 
@@ -79,7 +89,7 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST --field content=rocket
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Assign commenter to issue
         continue-on-error: true
@@ -88,7 +98,7 @@ jobs:
           gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
             --add-assignee "${{ github.event.comment.user.login }}"
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
   # --- Mode: resolve (action=pr) — run OpenHands, open a PR ---
   resolve:
@@ -98,6 +108,14 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+
       - name: Checkout target repository
         uses: actions/checkout@v4
 
@@ -158,7 +176,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           E2E_TEST_SECRET: ${{ secrets.E2E_TEST_SECRET }}
@@ -198,7 +216,7 @@ jobs:
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
         run: |
@@ -221,7 +239,7 @@ jobs:
       - name: Calculate and post cost
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODEL="${{ needs.parse.outputs.model }}"
@@ -353,6 +371,14 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+
       - name: Checkout target repository
         uses: actions/checkout@v4
 
@@ -360,7 +386,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           path: .remote-dev-bot
           sparse-checkout: lib
 
@@ -415,7 +441,7 @@ jobs:
           echo "$ISSUE_BODY" > /tmp/issue_body.txt
           echo "$COMMENTS" > /tmp/issue_comments.txt
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Call LLM for design analysis
         id: llm
@@ -583,12 +609,12 @@ jobs:
             --repo "${{ github.repository }}" \
             --body-file /tmp/comment_body.md
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Post cost comment
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODEL="${{ needs.parse.outputs.model }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,29 @@ This file documents the development and testing infrastructure. If you're a user
 
 ## Test Accounts
 
-| Account | Purpose | PAT stored as |
-|---------|---------|---------------|
-| `gnovak` | Repo owner. Used for normal development and testing. | `PAT_TOKEN` (on both repos) |
+| Account | Purpose | Credentials stored as |
+|---------|---------|----------------------|
+| `gnovak` | Repo owner. Used for normal development and testing. | `RDB_PAT_TOKEN` (on both repos), or GitHub App (`RDB_APP_ID` variable + `RDB_APP_PRIVATE_KEY` secret) |
 | `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `TESTER_PAT_TOKEN` (on remote-dev-bot) |
 
 ### remote-dev-bot-tester details
 - Classic PAT with `public_repo` scope, no expiration
 - Used by e2e security tests to verify that non-collaborators cannot trigger agent runs
 - The PAT only works on public repos — the gating test requires repos to be public
+
+## GitHub App and Reserved Identities
+
+### GitHub App: `remote-dev-bot`
+- Created at https://github.com/settings/apps/remote-dev-bot (owned by `gnovak`)
+- When used, the bot posts as `remote-dev-bot[bot]` — a clearly distinct identity from the repo owner
+- Installed on `gnovak/remote-dev-bot` and `gnovak/bridge-analysis`
+- Permissions: Contents, Issues, Pull Requests (all Read & write)
+- Webhooks: inactive (tokens are generated on-demand via `actions/create-github-app-token`)
+- Private key stored as `RDB_APP_PRIVATE_KEY` secret; App ID stored as `RDB_APP_ID` variable
+
+### Reserved GitHub username: `remote-dev-bot`
+- Reserved for potential future use as a dedicated bot account
+- Not currently active — the GitHub App approach is preferred over a dedicated user account
 
 ## Secrets Map
 
@@ -30,8 +44,15 @@ Secrets stored on `gnovak/remote-dev-bot`:
 | `ANTHROPIC_API_KEY` | Anthropic API key (for Claude models) |
 | `OPENAI_API_KEY` | OpenAI API key (for GPT models) |
 | `GEMINI_API_KEY` | Google AI API key (for Gemini models) |
-| `PAT_TOKEN` | Fine-grained PAT (gnovak). Scoped to all repos, with Contents/Issues/PRs/Workflows read-write. |
+| `RDB_PAT_TOKEN` | Fine-grained PAT (gnovak). Scoped to all repos, with Contents/Issues/PRs/Workflows read-write. |
+| `RDB_APP_PRIVATE_KEY` | (Optional) GitHub App private key, for bot identity on comments/PRs. |
 | `TESTER_PAT_TOKEN` | Classic PAT (remote-dev-bot-tester). `public_repo` scope only. For security e2e tests. |
+
+Variables stored on `gnovak/remote-dev-bot`:
+
+| Variable | What it is |
+|----------|-----------|
+| `RDB_APP_ID` | (Optional) GitHub App ID, used with `RDB_APP_PRIVATE_KEY` for bot identity. |
 
 Secrets stored on `gnovak/remote-dev-bot-test`:
 
@@ -40,7 +61,7 @@ Secrets stored on `gnovak/remote-dev-bot-test`:
 | `ANTHROPIC_API_KEY` | Same key as above (shared) |
 | `OPENAI_API_KEY` | Same key as above (shared) |
 | `GEMINI_API_KEY` | Same key as above (shared) |
-| `PAT_TOKEN` | Same PAT as above (shared) |
+| `RDB_PAT_TOKEN` | Same PAT as above (shared) |
 
 ## Dev Cycle
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ The system has two parts:
 
 See `runbook.md` for complete setup instructions. The runbook is designed so you (or an AI assistant) can follow it step-by-step to get this running in your own GitHub account.
 
-**Quick version:** You need a GitHub repo, API keys for your preferred LLM provider(s), and about 10 minutes.
+**Quick version:** You need a GitHub repo, API keys for your preferred LLM provider(s), and about 10 minutes. No PAT or special authentication is required — the bot works with GitHub's built-in token and posts as `github-actions[bot]`.
+
+**Advanced auth options:** If you want bot PRs to auto-trigger CI, or a custom bot identity (e.g., `your-app[bot]`), see the advanced auth section in the runbook. Options include a GitHub App (recommended) or a PAT.
 
 ## Development
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -239,7 +239,7 @@ def test_both_inline_model_aliases(compiled_dir):
 def test_both_use_github_token_fallback(compiled_dir):
     for fname in ["agent-resolve.yml", "agent-design.yml"]:
         content = _read_text(compiled_dir / fname)
-        assert "secrets.PAT_TOKEN || github.token" in content
+        assert "secrets.RDB_PAT_TOKEN || github.token" in content
 
 
 # --- Both: no cross-repo checkout ---
@@ -264,7 +264,7 @@ def test_both_have_required_markers(compiled_dir):
         assert "SECURITY_GATE" in content, f"{fname} missing SECURITY_GATE marker"
         assert "MAX_ITERATIONS" in content, f"{fname} missing MAX_ITERATIONS marker"
         assert "PR_STYLE" in content, f"{fname} missing PR_STYLE marker"
-        assert "PAT_TOKEN" in content, f"{fname} missing PAT_TOKEN documentation"
+        assert "RDB_PAT_TOKEN" in content, f"{fname} missing RDB_PAT_TOKEN documentation"
 
 
 # --- Step count tripwire ---
@@ -273,6 +273,7 @@ def test_both_have_required_markers(compiled_dir):
 
 
 EXPECTED_RESOLVE_STEPS = [
+    "Generate app token",
     "Checkout repository",
     "Set up Python",
     "Parse config and model alias",
@@ -289,6 +290,7 @@ EXPECTED_RESOLVE_STEPS = [
 ]
 
 EXPECTED_DESIGN_STEPS = [
+    "Generate app token",
     "Checkout repository",
     "Set up Python",
     "Parse config and model alias",


### PR DESCRIPTION
## Summary

- Add three-way token fallback: GitHub App token > `RDB_PAT_TOKEN` > `github.token`
- Rename `PAT_TOKEN` to `RDB_PAT_TOKEN` across all workflows, tests, and docs
- Add `actions/create-github-app-token@v1` step to all three jobs (parse, resolve, design) in resolve.yml
- Add `RDB_APP_PRIVATE_KEY` to workflow_call secrets and shim template
- Update compiled workflow generator (compile.py) with same auth changes
- Update how-it-works.md with new "Authentication and Bot Identity" section
- Update runbook.md Step 2.4 with GitHub App and PAT setup instructions
- Update README.md with brief auth options mention
- Update CONTRIBUTING.md with GitHub App and reserved username documentation
- Update e2e and full-test-suite workflows for renamed secret
- Update test_compile.py assertions for new step names and secret names

All 137 unit tests pass.

Closes #107

## Manual steps required after merge

1. Create the `remote-dev-bot` GitHub App (if not already done)
2. Rename the `PAT_TOKEN` secret to `RDB_PAT_TOKEN` on:
   - `gnovak/remote-dev-bot`
   - `gnovak/remote-dev-bot-test`
   - `gnovak/bridge-analysis`
3. Set `RDB_APP_ID` variable and `RDB_APP_PRIVATE_KEY` secret on repos where the app is installed
4. Update bridge-analysis compiled workflow to use new secret names

## Test plan

- [x] Unit tests pass (137/137)
- [ ] Verify workflow runs with `github.token` only (no PAT, no app) -- bot should post as `github-actions[bot]`
- [ ] Verify workflow runs with `RDB_PAT_TOKEN` -- bot should post as PAT owner
- [ ] Verify workflow runs with GitHub App credentials -- bot should post as `remote-dev-bot[bot]`
- [ ] Verify compiled workflows generate correctly with new auth steps
- [ ] Run e2e tests after renaming secrets

Generated with [Claude Code](https://claude.com/claude-code)
