### PR TITLE
Make AGENTS.md pointers imperative, strengthen PR policy

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,1 +1,1 @@
-See AGENTS.md in the repository root for all project conventions, key files, dev cycle, and code style guidelines.
+**Read AGENTS.md in the repository root now before doing anything else.** It contains project conventions, key files, dev cycle, PR policy, and code style guidelines that govern all work in this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ gh run view RUN_ID --repo gnovak/remote-dev-bot-test --log | tail -40
 
 ## PR Policy
 
-- **All changes go through a PR.** No direct commits to main. This keeps GitHub's PR list as a complete, searchable record of every change.
+- **All changes go through a PR. Never commit or push directly to main.** Open a PR and let the user merge it. This keeps GitHub's PR list as a complete, searchable record of every change.
 - For small changes, a single-commit PR self-merged immediately is fine — the point is the artifact, not the review ceremony.
 
 ## Compiler: two-file output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
 
-Project conventions are in [AGENTS.md](AGENTS.md). Read that file for all project-specific instructions.
+**Read [AGENTS.md](AGENTS.md) now before responding.** It contains project conventions that govern all work in this repo.
 
 Global personal preferences are in `~/.config/agents/AGENTS.md`.


### PR DESCRIPTION
## Summary
- CLAUDE.md and .openhands/microagents/repo.md: change passive pointers to AGENTS.md into direct imperatives so agents read it immediately at session start, not lazily
- AGENTS.md PR policy: add explicit 'never push directly to main, let the user merge' to remove ambiguity in 'no direct commits to main'

## Motivation
In a recent session, the PR policy was violated (direct commit+push to main) despite the rule being written in AGENTS.md. Root causes:
1. The pointers to AGENTS.md read like optional references rather than mandatory upfront reads
2. The PR policy said 'no direct commits' but did not explicitly prohibit pushing to main or say who merges

Generated with [Claude Code](https://claude.com/claude-code)