### PR TITLE
Fix git identity missing before amend step

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -188,6 +188,8 @@ jobs:
       - name: Amend commit with model info
         if: needs.parse.outputs.commit_trailer != ''
         run: |
+          git config user.email "openhands@all-hands.dev"
+          git config user.name "openhands"
           TRAILER="${{ needs.parse.outputs.commit_trailer }}"
           CURRENT_MSG=$(git log -1 --format=%B)
           git commit --amend -m "${CURRENT_MSG}


### PR DESCRIPTION
The 'Amend commit with model info' step was failing with exit code 128 because the GitHub Actions runner has no git user configured by default, causing `git commit --amend` to error with 'empty ident name not allowed'.

Sets git identity to match OpenHands' own commits (`openhands@all-hands.dev`) so the amended commit author is consistent.

Fixes the root cause of PR #157's `/agent resolve` producing no new commit.

Generated with [Claude Code](https://claude.com/claude-code)