### PR TITLE
Fix resolve cost estimates always showing zero

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -232,7 +232,7 @@ jobs:
           # OpenHands 1.3.0 doesn't populate metrics, so we fall back to parsing
           # LiteLLM's standard logging payload from the resolve step output.
           read -r COST INPUT_TOKENS OUTPUT_TOKENS SOURCE < <(python3 << 'PYEOF'
-          import json, os, re
+          import json, os
 
           def parse_litellm_logs(log_content):
               """Parse LiteLLM standard logging payloads from log output."""
@@ -241,39 +241,26 @@ jobs:
               total_cost = 0.0
               call_count = 0
 
-              lines = log_content.split("\n")
-              json_buffer = []
-              in_json = False
-              brace_count = 0
-
-              for line in lines:
-                  stripped = line.strip()
-                  if not in_json and stripped.startswith("{"):
-                      in_json = True
-                      json_buffer = [line]
-                      brace_count = line.count("{") - line.count("}")
-                  elif in_json:
-                      json_buffer.append(line)
-                      brace_count += line.count("{") - line.count("}")
-                      if brace_count <= 0:
-                          json_str = "\n".join(json_buffer)
-                          try:
-                              data = json.loads(json_str)
-                              if isinstance(data, dict) and "response_cost" in data and "prompt_tokens" in data:
-                                  total_input += data.get("prompt_tokens", 0) or 0
-                                  total_output += data.get("completion_tokens", 0) or 0
-                                  cost = data.get("response_cost", 0) or 0
-                                  if isinstance(cost, (int, float)):
-                                      total_cost += cost
-                                  call_count += 1
-                          except (json.JSONDecodeError, ValueError):
-                              pass
-                          in_json = False
-                          json_buffer = []
-                          brace_count = 0
-                      elif stripped.startswith("{") and brace_count > 0:
-                          json_buffer = [line]
-                          brace_count = line.count("{") - line.count("}")
+              decoder = json.JSONDecoder()
+              pos = 0
+              while pos < len(log_content):
+                  idx = log_content.find("{", pos)
+                  if idx == -1:
+                      break
+                  try:
+                      data, end_pos = decoder.raw_decode(log_content, idx)
+                      pos = end_pos
+                      if not (isinstance(data, dict) and "response_cost" in data):
+                          continue
+                      cost = data.get("response_cost", 0) or 0
+                      if isinstance(cost, (int, float)):
+                          total_cost += cost
+                      usage = (data.get("metadata") or {}).get("usage_object") or {}
+                      total_input += usage.get("prompt_tokens") or data.get("prompt_tokens") or 0
+                      total_output += usage.get("completion_tokens") or data.get("completion_tokens") or 0
+                      call_count += 1
+                  except (json.JSONDecodeError, ValueError):
+                      pos = idx + 1
 
               return {
                   "input_tokens": total_input,


### PR DESCRIPTION
Fixes #160.

## Root cause

Two bugs in `parse_litellm_logs` caused every LiteLLM payload to be silently ignored:

**Bug 1 — Brace-counting parser broken by embedded braces in strings**
The old parser counted `{`/`}` characters per line to find JSON object boundaries. This breaks when string values inside the payload contain `{` or `}` — which happens constantly since the payload includes conversation history with code snippets and file contents. Every payload failed with "Extra data" and was discarded silently.

**Bug 2 — Wrong field path for tokens**
The parser checked `"prompt_tokens" in data` at the top level. But in the real LiteLLM `StandardLoggingPayload` format (as of >=1.74), tokens live at `data["metadata"]["usage_object"]["prompt_tokens"]`. Even if a payload had survived Bug 1, this guard would reject it.

## Fix

- Replace brace counting with `json.JSONDecoder().raw_decode()`, which uses Python's actual JSON parser to find object boundaries robustly
- Read tokens from `metadata.usage_object` with fallback to top-level fields
- Applied to both `lib/cost.py` and the inline copy in `resolve.yml`

## Verification

Ran the fixed parser against the actual log from run #22160220277 (issue #29). Previously reported $0 / 0 tokens. Now correctly extracts:
- 45 LLM calls
- 1,603,428 input tokens / 17,381 output tokens
- $1.84 estimated cost

## Tests

- All 29 existing tests still pass
- Added `test_parse_litellm_logs_real_format` — tests the actual LiteLLM payload structure with tokens in `metadata.usage_object`
- Added `test_parse_litellm_logs_unbalanced_braces_in_strings` — directly tests the brace-counting failure case
