### PR TITLE
Rename TESTER_PAT_TOKEN to RDB_TESTER_PAT_TOKEN

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run security E2E tests
         env:
           GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
-          TESTER_PAT: ${{ secrets.TESTER_PAT_TOKEN }}
+          TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"
           if [[ -n "${{ inputs.test }}" && "${{ inputs.test }}" != "all" ]]; then

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -86,5 +86,5 @@ jobs:
       - name: Run security E2E tests
         env:
           GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
-          TESTER_PAT: ${{ secrets.TESTER_PAT_TOKEN }}
+          TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
         run: ./tests/e2e-security.sh --branch ${{ inputs.branch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This file documents the development and testing infrastructure. If you're a user
 | Account | Purpose | Credentials stored as |
 |---------|---------|----------------------|
 | `gnovak` | Repo owner. Used for normal development and testing. | `RDB_PAT_TOKEN` (on both repos), or GitHub App (`RDB_APP_ID` variable + `RDB_APP_PRIVATE_KEY` secret) |
-| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `TESTER_PAT_TOKEN` (on remote-dev-bot) |
+| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `RDB_TESTER_PAT_TOKEN` (on remote-dev-bot) |
 
 ### remote-dev-bot-tester details
 - Classic PAT with `public_repo` scope, no expiration
@@ -49,7 +49,7 @@ Secrets stored on `gnovak/remote-dev-bot`:
 | `GEMINI_API_KEY` | Google AI API key (for Gemini models) |
 | `RDB_PAT_TOKEN` | Fine-grained PAT (gnovak). Scoped to all repos, with Contents/Issues/PRs/Workflows read-write. |
 | `RDB_APP_PRIVATE_KEY` | (Optional) GitHub App private key, for bot identity on comments/PRs. |
-| `TESTER_PAT_TOKEN` | Classic PAT (remote-dev-bot-tester). `public_repo` scope only. For security e2e tests. |
+| `RDB_TESTER_PAT_TOKEN` | Classic PAT (remote-dev-bot-tester). `public_repo` scope only. For security e2e tests. |
 
 Variables stored on `gnovak/remote-dev-bot`:
 
@@ -85,7 +85,7 @@ See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how t
 ### Security e2e tests (`tests/e2e-security.sh`)
 - Secret exfiltration: verify agent refuses to expose secrets
 - User gating: verify non-collaborator comments don't trigger runs
-- Requires repos to be public and uses `TESTER_PAT_TOKEN`
+- Requires repos to be public and uses `RDB_TESTER_PAT_TOKEN`
 
 ### Loop prevention (not e2e tested — intentionally)
 The design agent has two layers of defense against recursive loops (where its response starts with `/agent` and re-triggers itself): a prompt instruction telling the LLM not to do it, and a regex check that blocks the response if it does. We deliberately do NOT e2e test this, because the test itself would be dangerous — if the regex has a bug, the test creates the very loop it's trying to prevent, consuming LLM budget. The regex is well covered by unit tests (`tests/test_yaml.py::TestLoopPreventionRegex`). The shim's `startsWith(comment.body, '/agent-')` trigger requires `/` as the literal first character (leading whitespace defeats it), which provides an additional layer of safety.

--- a/tests/e2e-security.sh
+++ b/tests/e2e-security.sh
@@ -9,7 +9,7 @@
 #
 # Prerequisites:
 #   - E2E_TEST_SECRET set on the test repo (a harmless canary value)
-#   - TESTER_PAT_TOKEN secret on remote-dev-bot (PAT for remote-dev-bot-tester)
+#   - RDB_TESTER_PAT_TOKEN secret on remote-dev-bot (PAT for remote-dev-bot-tester)
 #   - Test repo must be public (for unauthorized user test)
 #
 # Usage:


### PR DESCRIPTION
Missed in f11a689 when `PAT_TOKEN` was renamed to `RDB_PAT_TOKEN`. Consistent naming for all rdb infrastructure secrets.

**Remember to rename the secret on `gnovak/remote-dev-bot`** from `TESTER_PAT_TOKEN` to `RDB_TESTER_PAT_TOKEN` before merging, or the security e2e tests will fail.
