### PR TITLE
Use GitHub App token in e2e workflows

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -18,15 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.RDB_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,11 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.RDB_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         if: ${{ inputs.all_models }}
@@ -44,7 +52,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"
           if [[ -n "${{ inputs.provider }}" && "${{ inputs.provider }}" != "all" ]]; then

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -39,18 +39,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.RDB_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         run: pip install PyYAML
 
       - name: Run E2E tests (shim, all models)
         env:
-          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --all-models
 
   e2e-compiled:
@@ -58,18 +66,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.RDB_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Install PyYAML
         run: pip install PyYAML
 
       - name: Run E2E tests (compiled, all models)
         env:
-          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --compiled --all-models
 
   e2e-security:
@@ -77,14 +93,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.RDB_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
         run: ./tests/e2e-security.sh --branch ${{ inputs.branch }}


### PR DESCRIPTION
Fixes the e2e failure caused by removing `RDB_PAT_TOKEN`.

## Problem
`e2e.yml`, `full-test-suite.yml`, and `e2e-security.yml` were using `RDB_PAT_TOKEN || github.token`. With `RDB_PAT_TOKEN` removed, they fell back to `github.token`, which is scoped only to `remote-dev-bot` and can't create issues in `remote-dev-bot-test`.

## Fix
Add an `actions/create-github-app-token@v1` step to each job with `owner: ${{ github.repository_owner }}`, giving the token access to all repos under the account (the app is already installed on all `gnovak` repos).

Token fallback chain: **App token → `RDB_PAT_TOKEN` → `github.token`**

The app token step is skipped if `RDB_APP_ID` is unset, so the PAT fallback still works for anyone who prefers that route.
