### PR TITLE
Fix e2e auth flow and add security test sanity check

### DIFF
--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: "main"
       test:
-        description: "Test to run (all, exfiltration, gating)"
+        description: "Test to run (all, sanity, exfiltration, gating)"
         required: false
         default: "all"
 
@@ -34,8 +34,8 @@ jobs:
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
+          UNAUTHORIZED_PAT: ${{ secrets.RDB_TESTER_UNAUTHORIZED_PAT_TOKEN }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"
           if [[ -n "${{ inputs.test }}" && "${{ inputs.test }}" != "all" ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
         run: |
           ARGS="--branch ${{ inputs.branch }}"
           if [[ -n "${{ inputs.provider }}" && "${{ inputs.provider }}" != "all" ]]; then

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run E2E tests (shim, all models)
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --all-models
 
   e2e-compiled:
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run E2E tests (compiled, all models)
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --compiled --all-models
 
   e2e-security:
@@ -109,6 +109,6 @@ jobs:
 
       - name: Run security E2E tests
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          TESTER_PAT: ${{ secrets.RDB_TESTER_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
+          UNAUTHORIZED_PAT: ${{ secrets.RDB_TESTER_UNAUTHORIZED_PAT_TOKEN }}
         run: ./tests/e2e-security.sh --branch ${{ inputs.branch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,13 @@ This file documents the development and testing infrastructure. If you're a user
 | Account | Purpose | Credentials stored as |
 |---------|---------|----------------------|
 | `gnovak` | Repo owner. Used for normal development and testing. | `RDB_PAT_TOKEN` (on both repos), or GitHub App (`RDB_APP_ID` variable + `RDB_APP_PRIVATE_KEY` secret) |
-| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `RDB_TESTER_PAT_TOKEN` (on remote-dev-bot) |
+| `remote-dev-bot` | Dedicated bot account. Collaborator on `remote-dev-bot-test`. Posts authorized test comments that trigger agent runs without attributing activity to `gnovak`. | `RDB_TESTER_PAT_TOKEN` (on remote-dev-bot) |
+| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` (on remote-dev-bot) |
+
+### remote-dev-bot (bot account) details
+- Classic PAT with `public_repo` scope (or fine-grained with Issues/PRs R/W on rdb-test), no expiration
+- Used by e2e tests to post comments that trigger agent runs — must be a collaborator on `remote-dev-bot-test` so the security gate allows it
+- Keeps test activity out of `gnovak`'s GitHub contribution stats
 
 ### remote-dev-bot-tester details
 - Classic PAT with `public_repo` scope, no expiration
@@ -34,9 +40,10 @@ This file documents the development and testing infrastructure. If you're a user
 - Webhooks: inactive (tokens are generated on-demand via `actions/create-github-app-token`)
 - Private key stored as `RDB_APP_PRIVATE_KEY` secret; App ID stored as `RDB_APP_ID` variable
 
-### Reserved GitHub username: `remote-dev-bot`
-- Reserved for potential future use as a dedicated bot account
-- Not currently active — the GitHub App approach is preferred over a dedicated user account
+### GitHub username: `remote-dev-bot`
+- Active as a dedicated bot account (collaborator on `remote-dev-bot-test`)
+- Used by e2e tests to post authorized trigger comments (see Test Accounts above)
+- The GitHub App (`remote-dev-bot[bot]`) is a separate identity used for agent responses and PRs
 
 ## Secrets Map
 
@@ -49,7 +56,8 @@ Secrets stored on `gnovak/remote-dev-bot`:
 | `GEMINI_API_KEY` | Google AI API key (for Gemini models) |
 | `RDB_PAT_TOKEN` | Fine-grained PAT (gnovak). Scoped to all repos, with Contents/Issues/PRs/Workflows read-write. |
 | `RDB_APP_PRIVATE_KEY` | (Optional) GitHub App private key, for bot identity on comments/PRs. |
-| `RDB_TESTER_PAT_TOKEN` | Classic PAT (remote-dev-bot-tester). `public_repo` scope only. For security e2e tests. |
+| `RDB_TESTER_PAT_TOKEN` | PAT for `remote-dev-bot` account (collaborator on rdb-test). Used by e2e tests to post authorized trigger comments. |
+| `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` | PAT for `remote-dev-bot-tester` (not a collaborator). Used by security e2e tests to verify unauthorized users are blocked. |
 
 Variables stored on `gnovak/remote-dev-bot`:
 


### PR DESCRIPTION
## Problem

e2e tests were posting comments via the GitHub App token, which appears as `remote-dev-bot[bot]`. Since that identity isn't a collaborator on `remote-dev-bot-test`, the security gate blocked every run — all security tests passed vacuously (nothing ran, so nothing could fail).

## Fix

**Token separation:** `GH_TOKEN` for test execution now uses `RDB_TESTER_PAT_TOKEN` — the PAT for the `remote-dev-bot` GitHub account, which is a collaborator on `remote-dev-bot-test`. The App token is retained for checkout only.

**Secret rename:** `TESTER_PAT` → `UNAUTHORIZED_PAT` in scripts and workflows, backed by new `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` secret (`remote-dev-bot-tester` adversarial account).

**Sanity check test:** New `test_trigger_sanity` (test 0) posts an authorized `/agent-design` comment and verifies a run starts within 3 minutes. If it fails, the other tests would give vacuous passes — now they fail explicitly instead.

**Fast-fail on issue creation:** A new `create_issue` helper fails immediately with a clear message if `gh issue create` returns no issue number, rather than timing out after 900s.

## Required secrets on `gnovak/remote-dev-bot`

- `RDB_TESTER_PAT_TOKEN` → PAT for `remote-dev-bot` GitHub account (collaborator on rdb-test)
- `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` → PAT for `remote-dev-bot-tester` (adversarial, not a collaborator)

## Required account setup

- `remote-dev-bot` GitHub account added as collaborator (write) on `remote-dev-bot-test`
