### PR TITLE
Move customization to README, add Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,6 @@ Prefix the model string with the provider name in `remote-dev-bot.yaml` (e.g., `
 
 **For coding-heavy tasks:** Models with "codex" in the name (e.g., `openai/gpt-5.1-codex-mini`) are specifically tuned for code generation and may perform better on implementation tasks.
 
-### Customizing Models
-
-To add or modify model aliases, edit `remote-dev-bot.yaml`:
-
-```yaml
-models:
-  my-custom-alias:
-    id: anthropic/claude-sonnet-4-5
-    description: "My custom model configuration"
-```
-
-You can also create a `remote-dev-bot.yaml` in your target repo to override the defaults. See `runbook.md` Phase 5 for details.
-
 ### Commit Trailers
 
 By default, each OpenHands commit includes a trailer identifying the model used:
@@ -127,6 +114,56 @@ See `runbook.md` for complete setup instructions. The runbook is designed so you
 **Quick version:** You need a GitHub repo, API keys for your preferred LLM provider(s), and about 10 minutes. No PAT or special authentication is required — the bot works with GitHub's built-in token and posts as `github-actions[bot]`.
 
 **Advanced auth options:** If you want bot PRs to auto-trigger CI, or a custom bot identity (e.g., `your-app[bot]`), see the advanced auth section in the runbook. Options include a GitHub App (recommended) or a PAT.
+
+## Customization
+
+### Add Repo Context for the Agent
+
+Create `.openhands/microagents/repo.md` in your target repo with anything the agent should know about your codebase: coding conventions, architecture overview, how to run tests, directories to avoid, etc. The agent reads this file before starting work.
+
+An AI assistant can write this for you — just ask it to read your codebase and generate a `repo.md` describing the architecture and conventions.
+
+### Model Aliases
+
+Add or modify model aliases in your repo's `remote-dev-bot.yaml` (create it in the repo root if it doesn't exist):
+
+```yaml
+models:
+  my-alias:
+    id: anthropic/claude-sonnet-4-5
+    description: "My custom model"
+```
+
+These settings layer on top of the base config in `remote-dev-bot.yaml` from the remote-dev-bot repo. Your repo's settings take precedence. See [how-it-works.md](how-it-works.md) for config layering details.
+
+### Iteration Limits
+
+The agent runs for up to 50 iterations by default. Lower this for simpler repos (less cost, faster results) or raise it for complex tasks:
+
+```yaml
+openhands:
+  max_iterations: 30
+```
+
+## Troubleshooting
+
+### Getting a second PR instead of a revision
+
+You probably commented on the original issue instead of the PR. Commenting on the issue always creates a new PR; commenting on the PR adds commits to the existing one. Check which page you're on before triggering.
+
+(The two-PR behavior is also intentional when you want to compare different model implementations — trigger from the issue twice with different model aliases.)
+
+### Cost showing $0.00
+
+The workflow couldn't capture token usage data from this run. Check the Actions log for the run — look at the "Calculate and post cost" or "Post cost comment" step to see what was found.
+
+### Agent triggered but no PR appeared
+
+The agent ran but didn't open a PR. The log will say "Issue was not successfully resolved. Skipping PR creation." This usually means the agent hit the iteration limit without finishing. Try a more capable model (`/agent-resolve-claude-large`) or add more detail to the issue description.
+
+### Other issues
+
+See the Troubleshooting section in `runbook.md` for installation-related problems (workflow not triggering, secrets not reaching the workflow, etc.).
 
 ## Development
 

--- a/runbook.md
+++ b/runbook.md
@@ -12,7 +12,7 @@ This runbook will guide you through setting up Remote Dev Bot on your GitHub rep
 2. **Phase 2: GitHub Repository Settings** — Configure repository permissions, create API keys for your chosen LLM provider(s), and store them as GitHub secrets
 3. **Phase 3: Install the Workflow** — Add a small workflow file to your repository that connects to the Remote Dev Bot system
 4. **Phase 4: Test It** — Create a test issue and trigger the bot to verify everything works
-5. **Phase 5: Customize (Optional)** — Add repository context, adjust model settings, and tune iteration limits
+5. **Phase 5: Customize (Optional)** — See README.md for adding repo context, adjusting models, and tuning iteration limits
 6. **Phase 6: Report Install Feedback (Optional)** — If you encountered problems, report them to help improve the runbook
 
 **Time estimate:** 15-30 minutes for initial setup, depending on whether you already have the GitHub CLI installed and authenticated.
@@ -587,23 +587,7 @@ gh pr list --repo {owner}/{repo}
 
 ## Phase 5: Customize (Optional)
 
-### Step 5.1: Add Repository Context for the Agent
-
-Create `.openhands/microagents/repo.md` in your target repo with any context the agent should know (coding conventions, architecture, test commands, etc.).
-
-### Step 5.2: Adjust Model Aliases
-
-**Compiled install:** Search for `MODEL_CONFIG` in your workflow files to change the default model or add/modify aliases.
-
-**Shim install:** Create a `remote-dev-bot.yaml` file in your repo root to override the default model or add custom aliases. See `how-it-works.md` for config layering details.
-
-### Step 5.3: Adjust Iteration Limits
-
-**Compiled install:** Search for `MAX_ITERATIONS` in your workflow files. Default is 50.
-
-**Shim install:** Create or edit `remote-dev-bot.yaml` in your repo root and set `openhands.max_iterations`.
-
-If using cheaper models that tend to loop, consider lowering to 30.
+See the Customization section in `README.md` for details on adding repo context for the agent, adjusting model aliases, and changing iteration limits. These can be done any time after install — not just during initial setup.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Customization section** added to README: repo context (repo.md), model aliases, iteration limits. This is ongoing-use content, not install content — it belongs in the general reference, not the runbook.
- **Troubleshooting section** added to README: second PR instead of revision, $0.00 cost, agent triggered but no PR. Closes #138.
- **Customizing Models** removed from Commands section in README (config ≠ command syntax; now lives in Customization).
- **Runbook Phase 5** collapsed to a one-line pointer to README.

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)