### PR TITLE
Add interactive-agent diagnosis tip to troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The agent ran but didn't open a PR. The log will say "Issue was not successfully
 Have a look at issue 50 — I triggered the agent but it didn't make a PR. Look through the Actions logs and tell me what went wrong.
 ```
 
-Or find the specific run ID in the GitHub Actions tab and ask directly:
+Or point at a specific run ID from the Actions tab:
 
 ```
 Have a look at Actions run 12345678 in this repo. What went wrong?


### PR DESCRIPTION
Missed from PR #176 (merged before these commits were added).

Adds a practical tip to the 'no PR' troubleshooting item: point an interactive agent at the issue or Actions run ID and ask it to read the logs and diagnose the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)