### PR TITLE
Always create PR on partial agent success (--send-on-failure)

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -218,6 +218,7 @@ jobs:
             --issue-number "$ISSUE_NUMBER" \
             --pr-type ${{ needs.parse.outputs.pr_type }} \
             --target-branch "$TARGET_BRANCH" \
+            --send-on-failure \
             2>&1 | tee /tmp/spr_output.log
 
       - name: Amend commit with model info


### PR DESCRIPTION
## Problem

When OpenHands reports `success=False` (agent judged its implementation incomplete), `send_pull_request` silently skips PR creation by default:

```python
if not resolver_output.success and not send_on_failure:
    logger.info('Issue was not successfully resolved. Skipping PR creation.')
    return
```

This caused issue #150's agent run to produce **no PR and no visible output** — the "Create pull request" step succeeded in 7 seconds (by silently returning), and the "Amend commit" step immediately skipped since there was no PR URL.

A partial fix is far better than silence: the user can see what was attempted, review it, and complete or discard it.

## Fix

Pass `--send-on-failure` to `send_pull_request` so a PR is always created when the agent made changes, even if it reports incomplete success.

## Root cause analysis for issue #150

The design analysis incorrectly described `merge_configs()` (shallow merge) as the current implementation — `deep_merge` was already there from the beginning. The agent found nothing to fix for the merge itself, only added logging, then correctly judged that the awkward wrapper pattern was incomplete and set `success=False`. With this fix, that partial work would have surfaced as a reviewable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
