### PR TITLE
Log config merge: base, override, and merged result (issue #150)

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -132,6 +132,22 @@ def resolve_config(base_path, override_path, command_string):
     # Merge: target repo overrides remote-dev-bot defaults
     config = deep_merge(base_config, override_config)
 
+    # Log the merge so users can see what config is actually in effect
+    print("=== Config Merge ===")
+    print("Base (remote-dev-bot defaults):")
+    print(yaml.dump(base_config, default_flow_style=False, sort_keys=False).rstrip() if base_config else "  (none)")
+    print()
+    if override_config:
+        print("Override (target repo remote-dev-bot.yaml):")
+        print(yaml.dump(override_config, default_flow_style=False, sort_keys=False).rstrip())
+    else:
+        print("Override (target repo remote-dev-bot.yaml): (none)")
+    print()
+    print("Merged:")
+    print(yaml.dump(config, default_flow_style=False, sort_keys=False).rstrip())
+    print("===================")
+    print()
+
     # Parse command into mode + model alias
     modes = config.get("modes", {})
     known_modes = set(modes.keys())


### PR DESCRIPTION
Closes #150.

Adds YAML-formatted logging of the config merge to the "Parse config and command" step output, showing:

1. **Base config** — the remote-dev-bot defaults
2. **Override config** — the target repo's `remote-dev-bot.yaml` (or "(none)" if absent)  
3. **Merged result** — what's actually in effect

Example output in the workflow logs:
```
=== Config Merge ===
Base (remote-dev-bot defaults):
default_model: claude-small
modes:
  resolve: ...
  design: ...

Override (target repo remote-dev-bot.yaml):
default_model: claude-large
modes:
  design:
    context_files:
      - AGENTS.md

Merged:
default_model: claude-large
modes:
  resolve: ...   # preserved from base
  design:
    context_files:  # overridden at leaf level
      - AGENTS.md
===================
```

Note: the merge behavior itself was already deep-merge (leaf-level) from the beginning — no behavioral change here, just visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
