### PR TITLE
Add openhands.on_failure config: comment or draft PR on partial resolution

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -37,6 +37,7 @@ jobs:
       max_iterations: ${{ steps.parse.outputs.max_iterations }}
       oh_version: ${{ steps.parse.outputs.oh_version }}
       pr_type: ${{ steps.parse.outputs.pr_type }}
+      on_failure: ${{ steps.parse.outputs.on_failure }}
       context_files: ${{ steps.parse.outputs.context_files }}
       commit_trailer: ${{ steps.parse.outputs.commit_trailer }}
 
@@ -211,17 +212,75 @@ jobs:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           TARGET_BRANCH=${{ github.event.pull_request.base.ref || 'main' }}
+          ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          python -m openhands.resolver.send_pull_request \
-            --issue-number "$ISSUE_NUMBER" \
-            --pr-type ${{ needs.parse.outputs.pr_type }} \
-            --target-branch "$TARGET_BRANCH" \
-            2>&1 | tee /tmp/spr_output.log
+          # Check whether the agent considered itself successful
+          SUCCESS=$(python3 -c "
+          import json, os, sys
+          path = 'output/output.jsonl'
+          if os.path.exists(path):
+              data = json.loads(open(path).read())
+              print('true' if data.get('success') else 'false')
+          else:
+              print('unknown')
+          " 2>/dev/null || echo "unknown")
+
+          if [[ "$SUCCESS" == "false" ]]; then
+            # Extract the agent's self-evaluation from the output
+            EXPLANATION=$(python3 -c "
+          import json, os
+          path = 'output/output.jsonl'
+          if os.path.exists(path):
+              data = json.loads(open(path).read())
+              print(data.get('result_explanation', '') or '')
+          " 2>/dev/null || echo "")
+
+            # Post a comment with the agent's evaluation
+            {
+              echo "### ⚠️ Agent could not fully resolve this issue"
+              echo ""
+              if [[ -n "$EXPLANATION" ]]; then
+                echo "**Agent's evaluation:**"
+                echo ""
+                echo "$EXPLANATION"
+                echo ""
+              fi
+              echo "See the [workflow run logs]($RUN_URL) for full details."
+              if [[ "$ON_FAILURE" == "comment" ]]; then
+                echo ""
+                echo "---"
+                echo "_To receive a draft PR with partial changes when this happens, set \`openhands.on_failure: draft\` in your \`remote-dev-bot.yaml\`._"
+              fi
+            } > /tmp/failure_comment.md
+
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/failure_comment.md
+
+            # If configured, also create a draft PR with whatever the agent did
+            if [[ "$ON_FAILURE" == "draft" ]]; then
+              python -m openhands.resolver.send_pull_request \
+                --issue-number "$ISSUE_NUMBER" \
+                --pr-type draft \
+                --target-branch "$TARGET_BRANCH" \
+                --send-on-failure \
+                2>&1 | tee /tmp/spr_output.log
+            fi
+          else
+            # Normal success path
+            python -m openhands.resolver.send_pull_request \
+              --issue-number "$ISSUE_NUMBER" \
+              --pr-type ${{ needs.parse.outputs.pr_type }} \
+              --target-branch "$TARGET_BRANCH" \
+              2>&1 | tee /tmp/spr_output.log
+          fi
 
       - name: Amend commit with model info
         if: needs.parse.outputs.commit_trailer != ''

--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ openhands:
   max_iterations: 30
 ```
 
+### When the Agent Can't Fully Resolve an Issue
+
+Sometimes the agent judges that it couldn't completely fix the issue (it reports `success=False` in its evaluation). The `on_failure` setting controls what happens next:
+
+| Value | Behaviour |
+|-------|-----------|
+| `comment` (default) | Posts a comment with the agent's evaluation and a link to the run logs. No PR is created. |
+| `draft` | Posts the same comment **and** opens a draft PR with whatever changes the agent made. Draft PRs cannot be merged until explicitly converted to "ready for review". |
+
+```yaml
+openhands:
+  on_failure: draft   # create a draft PR with partial changes
+```
+
+Use `draft` if you want to review and complete partial work yourself. The default `comment` is safer — it surfaces what happened without creating a PR that might be accidentally merged.
+
 ## Troubleshooting
 
 ### Getting a second PR instead of a revision
@@ -159,7 +175,11 @@ The workflow couldn't capture token usage data from this run. Check the Actions 
 
 ### Agent triggered but no PR appeared
 
-The agent ran but didn't open a PR. The log will say "Issue was not successfully resolved. Skipping PR creation." This usually means the agent hit the iteration limit without finishing. Try a more capable model (`/agent-resolve-claude-large`) or add more detail to the issue description.
+The agent ran, posted a comment with its evaluation, but didn't open a PR. This means the agent judged that it couldn't fully resolve the issue — it hit the iteration limit, got confused, or determined its changes were incomplete.
+
+Try a more capable model (`/agent-resolve-claude-large`) or add more detail to the issue description. The agent's evaluation comment will say what it attempted and why it stopped.
+
+To receive a draft PR with whatever partial changes the agent made, set `openhands.on_failure: draft` in your `remote-dev-bot.yaml` (see [When the Agent Can't Fully Resolve an Issue](#when-the-agent-cant-fully-resolve-an-issue)).
 
 **Diagnosing failures with an interactive agent:** The fastest way to understand what went wrong is to ask an AI coding assistant to read the logs for you:
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -187,6 +187,11 @@ def resolve_config(base_path, override_path, command_string, local_path=None):
     max_iter = oh.get("max_iterations", 50)
     oh_version = oh.get("version", "0.39.0")
     pr_type = oh.get("pr_type", "ready")
+    on_failure = oh.get("on_failure", "comment")
+    if on_failure not in ("comment", "draft"):
+        raise ValueError(
+            f"openhands.on_failure must be 'comment' or 'draft', got: {on_failure!r}"
+        )
 
     # Mode settings
     action = mode_config.get("action", "pr")
@@ -199,6 +204,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None):
         "max_iterations": max_iter,
         "oh_version": oh_version,
         "pr_type": pr_type,
+        "on_failure": on_failure,
         "has_override": bool(override_config),
     }
 
@@ -243,6 +249,7 @@ def main():
             f.write(f"max_iterations={result['max_iterations']}\n")
             f.write(f"oh_version={result['oh_version']}\n")
             f.write(f"pr_type={result['pr_type']}\n")
+            f.write(f"on_failure={result['on_failure']}\n")
             if "context_files" in result:
                 f.write(f"context_files={json.dumps(result['context_files'])}\n")
             f.write(f"commit_trailer={result['commit_trailer']}\n")

--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -9,6 +9,11 @@
 # Users CAN create their own remote-dev-bot.local.yaml; it will be
 # applied as a third layer on top of their remote-dev-bot.yaml.
 
+openhands:
+  # Show draft PRs for partial resolutions when devving rdb itself —
+  # partial changes are worth reviewing during active development.
+  on_failure: draft
+
 modes:
   design:
     # Extend context_files to include rdb implementation files.

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -74,3 +74,7 @@ openhands:
   pr_type: ready
   # Target branch for PRs
   target_branch: main
+  # What to do when the agent can't fully resolve the issue (success=False):
+  #   comment — post a comment with the agent's evaluation, no PR (default)
+  #   draft   — post the same comment AND open a draft PR with partial changes
+  on_failure: comment


### PR DESCRIPTION
## Summary

Adds `openhands.on_failure` config option to control what happens when the agent judges it couldn't fully resolve an issue (`success=False`).

| Value | Behaviour |
|-------|-----------|
| `comment` (default) | Post a comment with the agent's evaluation + log link. No PR. |
| `draft` | Same comment, **plus** a draft PR with partial changes. Draft PRs require explicit conversion before merging. |

The failure comment extracts `result_explanation` directly from `output/output.jsonl` — the agent's own evaluation of what it did and why it stopped — so users don't have to hunt through large log files.

## Config

`remote-dev-bot.yaml` (default, safe for users):
```yaml
openhands:
  on_failure: comment
```

`remote-dev-bot.local.yaml` (self-dev, where partial PRs are useful):
```yaml
openhands:
  on_failure: draft
```

## Changes

- **`lib/config.py`**: parse `on_failure`, validate (`comment`/`draft` only), emit to GITHUB_OUTPUT
- **`resolve.yml`**: `on_failure` in parse outputs; "Create pull request" step branches on agent success + config setting
- **`remote-dev-bot.yaml`**: `on_failure: comment`
- **`remote-dev-bot.local.yaml`**: `on_failure: draft`
- **`tests/test_config.py`**: 4 new tests
- **`README.md`**: new "When the Agent Can't Fully Resolve an Issue" section; updated troubleshooting entry

## Supersedes

Closes / supersedes PR #179 (`--send-on-failure` blanket flag). This replaces it with config-driven conditional behaviour and user-visible failure comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
