### PR TITLE
Add workflow files to self-dev design context

### DIFF
--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -32,3 +32,6 @@ modes:
       - lib/compile.py
       - lib/feedback.py
       - scripts/compile.py
+      # rdb workflows (core of the system)
+      - .github/workflows/resolve.yml
+      - .github/workflows/agent.yml


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/resolve.yml` and `.github/workflows/agent.yml` to `context_files` in `remote-dev-bot.local.yaml`
- The workflows are the core of rdb — the design agent was previously missing them when analyzing rdb issues, leading to hallucination about code it couldn't see

## Test plan
- [ ] Verify `remote-dev-bot.local.yaml` now lists both workflow files under `modes.design.context_files`
- [ ] Trigger `/agent-design` on an rdb issue and confirm the agent references actual workflow behavior rather than guessing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
