### PR TITLE
Tell design agent to acknowledge missing context rather than guess

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -38,6 +38,11 @@ modes:
       Do NOT end your response with conversational invitations like
       "Want me to elaborate?" or "Let me know if you have questions."
       Your response is a design document, not a chat message.
+      IMPORTANT: You have been given a limited set of context files. If the
+      issue touches code or behavior you cannot verify from those files, say
+      so explicitly. Do NOT invent function names, describe behavior you
+      haven't seen, or assume how unshared code works. Acknowledging what
+      you cannot see is more useful than a confident answer based on guesses.
 
 models:
   claude-small:


### PR DESCRIPTION
## Summary

Adds an instruction to the design agent's `prompt_prefix` to acknowledge gaps in its context rather than hallucinating.

The motivating failure: the design agent analyzed issue #150 and described a `merge_configs()` shallow-merge function that doesn't exist — `deep_merge` was always there. The agent was reasoning blind because `lib/config.py` wasn't in `context_files`.

The new instruction:
> If the issue touches code or behavior you cannot verify from those files, say so explicitly. Do NOT invent function names, describe behavior you haven't seen, or assume how unshared code works. Acknowledging what you cannot see is more useful than a confident answer based on guesses.

This complements the context_files improvements in #183/#184/#187 (adding more files) — belt-and-suspenders for when context is still incomplete.

## Test plan
- [ ] Trigger `/agent-design` on an issue that touches code not in `context_files`; agent should flag the gap rather than confabulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
