### PR TITLE
Add repo file listing to design agent context

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -546,8 +546,16 @@ jobs:
                       prompt_prefix = mode_cfg["prompt_prefix"]
                       break
 
+          # Generate repository file listing (tracked files only)
+          import subprocess
+          result = subprocess.run(
+              ["git", "ls-files"],
+              capture_output=True, text=True
+          )
+          file_listing = result.stdout.strip()
+          repo_context = f"## Repository File Listing\n\n```\n{file_listing}\n```"
+
           # Read repo context files (missing files are skipped gracefully)
-          repo_context = ""
           context_files = json.loads(os.environ.get("CONTEXT_FILES", "[]") or "[]")
           for filepath in context_files:
               if os.path.exists(filepath):


### PR DESCRIPTION
## Summary

Adds a `git ls-files` directory listing to the design agent's context, prepended before the `context_files` content.

The agent now sees all tracked files in the repo even when it doesn't have their contents. Combined with the "acknowledge what you can't see" instruction (#188), the agent can say "I see `lib/compile.py` exists but don't have its contents" rather than either hallucinating or being blind to its existence.

Also a prerequisite for two-stage file selection: stage 1 needs a file listing to let the agent pick what to fetch.

## Test plan
- [ ] Trigger `/agent-design` and verify the system prompt includes the file listing (visible in Actions logs)
- [ ] Verify the agent references actual file paths from the repo rather than invented ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
