### PR TITLE
Fix two bugs in compiled test infrastructure

### DIFF
--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -289,10 +289,10 @@ def compile_resolve(shim, workflow, config_yaml, output_path):
     # Inject security guardrails
     steps.append(find_step(resolve_steps, "Inject security guardrails").copy())
 
-    # Resolve issue (remove E2E_TEST_TOKEN, update token)
+    # Resolve issue (strip internal canary var, update token)
     resolve_step = find_step(resolve_steps, "Resolve issue").copy()
     resolve_step["env"] = {k: v for k, v in resolve_step["env"].items()
-                           if k != "E2E_TEST_TOKEN"}
+                           if k != "SANDBOX_ENV_E2E_TEST_TOKEN"}
     resolve_step["env"]["GITHUB_TOKEN"] = "${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}"
     steps.append(resolve_step)
 

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -192,15 +192,16 @@ restore_shim() {
         return
     fi
 
-    gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" \
+    if gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" \
         --method PUT \
         -f message="E2E: restore original shim after pre-release test" \
         -f content="$ORIGINAL_SHIM_CONTENT" \
-        -f sha="$current_sha" >/dev/null 2>&1 || {
-            err "Failed to restore shim — manual fix needed!"
-            err "Original content saved in ORIGINAL_SHIM_CONTENT variable"
-        }
-    log "  Original shim restored."
+        -f sha="$current_sha" >/dev/null 2>&1; then
+        log "  Original shim restored."
+    else
+        err "Failed to restore shim — manual fix needed!"
+        err "Original content saved in ORIGINAL_SHIM_CONTENT variable"
+    fi
 
     # Remove agent-design.yml if we added it
     local design_sha


### PR DESCRIPTION
## Summary

Two bugs found while investigating run [22220672217](https://github.com/gnovak/remote-dev-bot/actions/runs/22220672217).

**Bug 1 — e2e.sh: misleading restore output**

`log "  Original shim restored."` was unconditional, running after the `||` error block regardless of whether the restore succeeded. A failed restore would print both `ERROR: Failed to restore shim` and `Original shim restored.` Fix: moved into the success branch of an `if/else`.

**Bug 2 — compile.py: filter key mismatch**

The filter meant to strip the internal canary env var from compiled output was `k != "E2E_TEST_TOKEN"`, but the actual env key is `SANDBOX_ENV_E2E_TEST_TOKEN`. The filter never matched, so `SANDBOX_ENV_E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}` was always included in compiled workflows. Harmless for end users (undefined secret → empty string), but the intent was to strip it. Fixed to match the real key name.

The primary failure in run 22220672217 (HTTP 404 on the shim install PUT) appears to be a transient GitHub API issue — the file exists, permissions are fine, and it doesn't repro on retry.

## Test plan
- [ ] Rerun compiled e2e test and verify shim install/restore works
- [ ] Verify compiled workflow no longer includes `SANDBOX_ENV_E2E_TEST_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
