### PR TITLE
Full test suite: continue past e2e failures, fast-fail on unit tests

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -11,7 +11,17 @@ on:
 
 # Sequential execution: all jobs use the same test repo, so they
 # cannot run in parallel (shared dev pointer, workflow files, issues).
-# Unit tests run first as a fast-fail gate.
+#
+# Failure strategy:
+#   - unit-tests: fast-fail gate. If this fails, all e2e jobs are skipped.
+#   - e2e-shim, e2e-compiled, e2e-security: continue-on-failure. Each block
+#     runs regardless of whether the previous e2e block passed, so a single
+#     full-suite run gives a comprehensive failure picture across all blocks.
+#     This avoids the painful debug loop of: run → fail at block 1 → fix →
+#     run again → fail at block 2 → fix → run again → ...
+#
+# Implementation: e2e jobs use `if: always() && needs.unit-tests.result == 'success'`
+# to skip on unit-test failure but continue past e2e failures.
 
 jobs:
   unit-tests:
@@ -62,7 +72,8 @@ jobs:
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --all-models
 
   e2e-compiled:
-    needs: e2e-shim
+    needs: [unit-tests, e2e-shim]
+    if: always() && needs.unit-tests.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -89,7 +100,8 @@ jobs:
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --compiled --all-models
 
   e2e-security:
-    needs: e2e-compiled
+    needs: [unit-tests, e2e-compiled]
+    if: always() && needs.unit-tests.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ The design agent has two layers of defense against recursive loops (where its re
 ### Full test suite (`.github/workflows/full-test-suite.yml`)
 - One-button "run everything" workflow: unit tests → e2e shim → e2e compiled → e2e security
 - Jobs run **sequentially** — all e2e tests share `remote-dev-bot-test` and cannot run in parallel (shared dev pointer, workflow files, and issues)
+- **Failure strategy**: unit tests are a fast-fail gate (e2e jobs skip if they fail); the three e2e blocks continue past each other's failures so one run gives a complete picture across all blocks. After a full run, use the individual workflow_dispatch workflows to rerun only the failing blocks.
 - Use before releases to validate everything in one go
 
 ### Shared state constraint


### PR DESCRIPTION
## Summary

- Unit tests remain a fast-fail gate — if they fail, all e2e jobs are skipped (no point burning LLM budget on broken fundamentals)
- The three e2e blocks (shim, compiled, security) now continue past each other's failures using `if: always() && needs.unit-tests.result == 'success'`
- A single full-suite run now gives a complete failure picture across all blocks; use individual workflow_dispatch workflows to rerun only the failing ones during debugging

## Motivation

Without this, the debug loop for a multi-block failure was: run → fail at shim → fix → run again → fail at compiled → fix → run again → fail at security → fix → run again → pass. Each iteration burns a full LLM-heavy e2e run just to reach the next failure point.

## Implementation

Added `needs: [unit-tests, <previous-e2e-job>]` and `if: always() && needs.unit-tests.result == 'success'` to `e2e-compiled` and `e2e-security`. Sequential order is preserved (each job still waits for the previous), but failure no longer propagates as a skip.

Updated the workflow comment and CONTRIBUTING.md to document the strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
