### PR TITLE
e2e.yml: list smoke test names in test input description

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ on:
         required: false
         default: false
       test:
-        description: "Specific test name (blank for all)"
+        description: "Specific test name, blank for all. Smoke tests: default-model, claude, gpt, gemini, design. All-models test names: model aliases in remote-dev-bot.yaml"
         required: false
         default: ""
       compiled:


### PR DESCRIPTION
Orphaned from #195 — merged before this commit landed.

Lists the five smoke test names inline in the workflow_dispatch description, and points to `remote-dev-bot.yaml` for all-models aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)