### PR TITLE
Fix compiled workflow gaps: on_failure, target_branch, oh_version

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -228,7 +228,7 @@ jobs:
           GIT_USERNAME: ${{ github.repository_owner }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
-          TARGET_BRANCH=${{ github.event.pull_request.base.ref || 'main' }}
+          TARGET_BRANCH=${{ github.event.pull_request.base.ref || needs.parse.outputs.target_branch || 'main' }}
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -185,9 +185,11 @@ def resolve_config(base_path, override_path, command_string, local_path=None):
     # Read OpenHands settings
     oh = config.get("openhands", {})
     max_iter = oh.get("max_iterations", 50)
-    oh_version = oh.get("version", "0.39.0")
+    # NOTE: keep this default in sync with scripts/compile.py inline_config_parsing()
+    oh_version = oh.get("version", "1.3.0")
     pr_type = oh.get("pr_type", "ready")
     on_failure = oh.get("on_failure", "comment")
+    target_branch = oh.get("target_branch", "main")
     if on_failure not in ("comment", "draft"):
         raise ValueError(
             f"openhands.on_failure must be 'comment' or 'draft', got: {on_failure!r}"
@@ -205,6 +207,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None):
         "oh_version": oh_version,
         "pr_type": pr_type,
         "on_failure": on_failure,
+        "target_branch": target_branch,
         "has_override": bool(override_config),
     }
 
@@ -250,6 +253,7 @@ def main():
             f.write(f"oh_version={result['oh_version']}\n")
             f.write(f"pr_type={result['pr_type']}\n")
             f.write(f"on_failure={result['on_failure']}\n")
+            f.write(f"target_branch={result['target_branch']}\n")
             if "context_files" in result:
                 f.write(f"context_files={json.dumps(result['context_files'])}\n")
             f.write(f"commit_trailer={result['commit_trailer']}\n")

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -81,8 +81,11 @@ def inline_config_parsing(config_yaml, mode):
     models = config_yaml.get("models", {})
     oh = config_yaml.get("openhands", {})
     max_iterations = oh.get("max_iterations", 50)
+    # NOTE: keep this default in sync with lib/config.py resolve_config()
     oh_version = oh.get("version", "1.3.0")
     pr_type = oh.get("pr_type", "ready")
+    on_failure = oh.get("on_failure", "comment")
+    target_branch = oh.get("target_branch", "main")
 
     # Commit trailer template (resolve mode only)
     commit_trailer_template = config_yaml.get("commit_trailer", "")
@@ -116,6 +119,14 @@ OH_VERSION = "{oh_version}"
 
 # --- PR_STYLE: "draft" or "ready" ---
 PR_TYPE = "{pr_type}"
+
+# --- ON_FAILURE: what to do when the agent can't fully resolve the issue ---
+# "comment" — post a comment explaining the situation, no PR
+# "draft"   — post the same comment AND open a draft PR with partial changes
+ON_FAILURE = "{on_failure}"
+
+# --- TARGET_BRANCH: branch the agent opens PRs against ---
+TARGET_BRANCH = "{target_branch}"
 
 # --- COMMIT_TRAILER: appended to commit messages (resolve mode only) ---
 # Supported variables: {{model_alias}}, {{model_id}}, {{oh_version}}
@@ -154,6 +165,8 @@ if output_file:
         f.write(f"max_iterations={{MAX_ITERATIONS}}\\n")
         f.write(f"oh_version={{OH_VERSION}}\\n")
         f.write(f"pr_type={{PR_TYPE}}\\n")
+        f.write(f"on_failure={{ON_FAILURE}}\\n")
+        f.write(f"target_branch={{TARGET_BRANCH}}\\n")
         f.write(f"commit_trailer={{commit_trailer}}\\n")
 
 # Log for visibility

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -314,9 +314,10 @@ def test_resolve_config_openhands_defaults():
     try:
         result = resolve_config(path, "nonexistent.yaml", "resolve")
         assert result["max_iterations"] == 50
-        assert result["oh_version"] == "0.39.0"
+        assert result["oh_version"] == "1.3.0"
         assert result["pr_type"] == "ready"
         assert result["on_failure"] == "comment"
+        assert result["target_branch"] == "main"
     finally:
         os.unlink(path)
 
@@ -360,6 +361,23 @@ def test_resolve_config_on_failure_via_override(config_dir):
         yaml.dump({"openhands": {"on_failure": "draft"}}, f)
     result = resolve_config(base_path, override_path, "resolve")
     assert result["on_failure"] == "draft"
+
+
+def test_resolve_config_target_branch_default(config_dir):
+    """target_branch defaults to 'main'."""
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "resolve")
+    assert result["target_branch"] == "main"
+
+
+def test_resolve_config_target_branch_override(config_dir):
+    """target_branch can be overridden."""
+    tmp_path, base_path = config_dir
+    override_path = str(tmp_path / "override.yaml")
+    with open(override_path, "w") as f:
+        yaml.dump({"openhands": {"target_branch": "master"}}, f)
+    result = resolve_config(base_path, override_path, "resolve")
+    assert result["target_branch"] == "master"
 
 
 def test_resolve_config_malformed_yaml(tmp_path):


### PR DESCRIPTION
## Summary

- on_failure in compiled installs: compile.py was not including on_failure in the inline config parser, so compiled workflows silently ignored openhands.on_failure: draft. Now wired up.
- target_branch in config: the config key existed but was never read. Now wired up — issue-triggered runs use the configured target_branch; PR-triggered runs still use the PR base branch.
- oh_version default: config.py had stale fallback '0.39.0' while compile.py used '1.3.0'. Aligned both with sync comments.
- Note: dist/ is .gitignored. Run python scripts/compile.py before cutting v1.0.0 to get fresh artifacts from these fixes.

## Test plan

- [x] All 143 unit tests pass
- [ ] E2E smoke test before merge