### PR TITLE
Bump OpenHands to 1.4.0

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -196,8 +196,8 @@ jobs:
           GIT_USERNAME: ${{ github.repository_owner }}
           SANDBOX_ENV_E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
           # Enable LiteLLM standard logging payload for cost tracking.
-          # OpenHands 1.3.0 doesn't populate token metrics, so we parse
-          # LiteLLM's output as a workaround. Remove once OpenHands fixes this.
+          # OpenHands doesn't populate token metrics (tracked upstream), so we
+          # parse LiteLLM's output as a workaround. Remove once OpenHands fixes this.
           LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD: "1"
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
@@ -337,7 +337,7 @@ jobs:
           MODE="${{ needs.parse.outputs.mode }}"
 
           # Parse metrics from output/output.jsonl and/or LiteLLM logs.
-          # OpenHands 1.3.0 doesn't populate metrics, so we fall back to parsing
+          # OpenHands doesn't populate metrics (tracked upstream), so we fall back to parsing
           # LiteLLM's standard logging payload from the resolve step output.
           read -r COST INPUT_TOKENS OUTPUT_TOKENS SOURCE < <(python3 << 'PYEOF'
           import json, os

--- a/lib/config.py
+++ b/lib/config.py
@@ -186,7 +186,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None):
     oh = config.get("openhands", {})
     max_iter = oh.get("max_iterations", 50)
     # NOTE: keep this default in sync with scripts/compile.py inline_config_parsing()
-    oh_version = oh.get("version", "1.3.0")
+    oh_version = oh.get("version", "1.4.0")
     pr_type = oh.get("pr_type", "ready")
     on_failure = oh.get("on_failure", "comment")
     target_branch = oh.get("target_branch", "main")

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -72,7 +72,7 @@ models:
 # OpenHands settings
 openhands:
   # Pin to a specific version to avoid regressions (check for updates periodically)
-  version: "1.3.0"
+  version: "1.4.0"
   # Max agent iterations per run (controls cost ceiling)
   max_iterations: 50
   # PR type: "draft" or "ready"

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -82,7 +82,7 @@ def inline_config_parsing(config_yaml, mode):
     oh = config_yaml.get("openhands", {})
     max_iterations = oh.get("max_iterations", 50)
     # NOTE: keep this default in sync with lib/config.py resolve_config()
-    oh_version = oh.get("version", "1.3.0")
+    oh_version = oh.get("version", "1.4.0")
     pr_type = oh.get("pr_type", "ready")
     on_failure = oh.get("on_failure", "comment")
     target_branch = oh.get("target_branch", "main")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,7 +161,7 @@ def config_dir(tmp_path):
             },
         },
         "openhands": {
-            "version": "1.3.0",
+            "version": "1.4.0",
             "max_iterations": 50,
             "pr_type": "ready",
         },
@@ -241,7 +241,7 @@ def test_resolve_config_override_wins(config_dir):
     assert result["model"] == "openai/gpt-5.1-codex-mini"
     assert result["max_iterations"] == 10
     # Version should come from base (not overridden)
-    assert result["oh_version"] == "1.3.0"
+    assert result["oh_version"] == "1.4.0"
     assert result["has_override"] is True
 
 
@@ -316,7 +316,7 @@ def test_resolve_config_openhands_defaults():
     try:
         result = resolve_config(path, "nonexistent.yaml", "resolve")
         assert result["max_iterations"] == 50
-        assert result["oh_version"] == "1.3.0"
+        assert result["oh_version"] == "1.4.0"
         assert result["pr_type"] == "ready"
         assert result["on_failure"] == "comment"
         assert result["target_branch"] == "main"
@@ -565,7 +565,7 @@ def test_resolve_config_local_preserves_base_and_override(config_dir):
 
     result = resolve_config(base_path, "nonexistent.yaml", "resolve", local_path=local_path)
     assert result["max_iterations"] == 5
-    assert result["oh_version"] == "1.3.0"   # preserved from base
+    assert result["oh_version"] == "1.4.0"   # preserved from base
     assert result["pr_type"] == "ready"       # preserved from base
 
 


### PR DESCRIPTION
Update OpenHands version to 1.4.0 everywhere.

- `remote-dev-bot.yaml`: default version
- `lib/config.py`: hardcoded fallback default
- `scripts/compile.py`: hardcoded fallback default
- `tests/test_config.py`: fixture and default assertions
- `.github/workflows/resolve.yml`: removed version-pinned comments about upstream token metrics issue (still tracked upstream, version number was just going to keep getting stale)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>