### PR TITLE
Reduce e2e poll rate to stay within bot account GraphQL quota

### DIFF
--- a/tests/e2e-security.sh
+++ b/tests/e2e-security.sh
@@ -25,8 +25,8 @@ set -euo pipefail
 
 TEST_REPO="gnovak/remote-dev-bot-test"
 CANARY_VALUE="Uh_Oh_c7f3a9b2e1d8k4m6p0q5r2w8"
-POLL_INTERVAL=60
-TIMEOUT=900
+POLL_INTERVAL=120
+TIMEOUT=1800
 SANITY_TIMEOUT=180
 
 # --- Argument parsing ---

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -17,8 +17,8 @@
 set -euo pipefail
 
 TEST_REPO="gnovak/remote-dev-bot-test"
-POLL_INTERVAL=60
-TIMEOUT=900  # 15 minutes
+POLL_INTERVAL=120
+TIMEOUT=1800  # 30 minutes
 
 # --- Argument parsing ---
 
@@ -321,7 +321,7 @@ while [[ $elapsed -lt $TIMEOUT ]]; do
 
     # Get recent workflow runs once per poll cycle — check all workflow files
     run_json=$(gh run list --repo "$TEST_REPO" \
-        --limit 50 \
+        --limit 20 \
         --json databaseId,status,conclusion,displayTitle 2>/dev/null || echo "[]")
 
     for pos in "${!issue_nums[@]}"; do


### PR DESCRIPTION
## Summary

The bot account (`remote-dev-bot`, used via `RDB_TESTER_PAT_TOKEN`) was hitting GitHub's 5000 GraphQL points/hour limit when running the full test suite twice in quick succession.

**Root cause:** `gh run list --limit 50 --json` costs ~51 GraphQL points per call (1 connection + 50 nodes). At 60s polling × 3 e2e jobs × ~15 polls each, a full suite run consumed ~2800 points — meaning only ~1.7 runs/hour before hitting the quota.

**Changes:**
- Poll interval: 60s → 120s
- `--limit 50` → `--limit 20` in e2e.sh poll loop
- TIMEOUT: 900s → 1800s in both scripts (preserves ~15 poll attempts at the new interval; also aligns with the 30-minute job timeout in the workflows)

**Expected result:** ~900 points per full suite run, allowing 5+ runs/hour comfortably within quota.

Note: e2e-security.sh poll loops already used `--limit 10/20`; only interval and timeout needed updating there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
