### PR TITLE
Add GraphQL quota guard to e2e scripts

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -43,6 +43,31 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# --- GraphQL quota guard ---
+# Fail fast if the bot account's hourly quota is too low to complete a run.
+# A single all-models e2e run costs ~450-500 GraphQL points (polling + API calls).
+
+check_graphql_quota() {
+    local min_points=500
+    local result remaining reset_ts reset_time
+    result=$(gh api rate_limit --jq '.resources.graphql | "\(.remaining) \(.reset)"' 2>/dev/null || true)
+    if [[ -z "$result" ]]; then
+        log "Warning: could not check GraphQL rate limit — proceeding anyway"
+        return
+    fi
+    remaining=$(echo "$result" | cut -d' ' -f1)
+    reset_ts=$(echo "$result" | cut -d' ' -f2)
+    reset_time=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${reset_ts}).strftime('%H:%M:%S'))" 2>/dev/null || echo "unknown")
+    if [[ "$remaining" -lt "$min_points" ]]; then
+        err "GraphQL quota too low: ${remaining} points remaining (need ${min_points}+)."
+        err "Quota resets at ${reset_time}. Please retry after that."
+        exit 1
+    fi
+    log "GraphQL quota: ${remaining} points remaining (resets ${reset_time})."
+}
+
+check_graphql_quota
+
 # --- Test case definitions ---
 # Parallel arrays — index i corresponds to the same test across all arrays.
 # test_type: "resolve" expects a PR, "design" expects a comment


### PR DESCRIPTION
## Summary

Adds a GraphQL quota check at startup to both e2e scripts. Instead of failing mid-run with a cryptic "rate limit already exceeded" error, the scripts now check upfront and exit immediately with the remaining points and the reset time if quota is too low.

**Before:** run starts, makes a few API calls, fails with `GraphQL: API rate limit already exceeded for user ID 262446887`

**After:**
```
==> GraphQL quota too low: 42 points remaining (need 500+).
ERROR: Quota resets at 14:21:00. Please retry after that.
```

Threshold is 500 points — enough for one all-models e2e run (~450 points with the --limit 20 / 2-min polling from #204). The full test suite (3 sequential jobs) needs ~1500 points total, but each job checks independently so a quota-exhausted middle job will fail fast rather than hanging at the poll loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
