### PR TITLE
Clarify quota reset time: show local, UTC, and relative

### DIFF
--- a/tests/e2e-security.sh
+++ b/tests/e2e-security.sh
@@ -58,7 +58,14 @@ check_graphql_quota() {
     fi
     remaining=$(echo "$result" | cut -d' ' -f1)
     reset_ts=$(echo "$result" | cut -d' ' -f2)
-    reset_time=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${reset_ts}).strftime('%H:%M:%S'))" 2>/dev/null || echo "unknown")
+    reset_time=$(python3 -c "
+import datetime
+ts = ${reset_ts}
+local_t = datetime.datetime.fromtimestamp(ts)
+utc_t = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc).replace(tzinfo=None)
+mins = max(0, int((local_t - datetime.datetime.now()).total_seconds() / 60))
+print(f'{local_t.strftime(\"%H:%M:%S\")} local / {utc_t.strftime(\"%H:%M:%S\")} UTC (in {mins} min)')
+" 2>/dev/null || echo "unknown")
     if [[ "$remaining" -lt "$min_points" ]]; then
         echo "ERROR: GraphQL quota too low: ${remaining} points remaining (need ${min_points}+)." >&2
         echo "ERROR: Quota resets at ${reset_time}. Please retry after that." >&2


### PR DESCRIPTION
## Summary

The quota guard message previously showed a bare time like `22:31:20` with no timezone context — ambiguous between local time on the runner (UTC for GitHub Actions, machine local time when run locally).

**Before:**
```
ERROR: Quota resets at 22:31:20. Please retry after that.
```

**After:**
```
ERROR: Quota resets at 14:31:20 local / 22:31:20 UTC (in 45 min). Please retry after that.
```

The `in N min` form is unambiguous regardless of where the script is running.

Depends on #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
