### PR TITLE
chore: rename dev pointer to e2e-test, introduce dev as integration branch

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -15,7 +15,7 @@
 # Note: secrets must be passed explicitly (not via `secrets: inherit`) because
 # GitHub Actions does not pass inherited secrets across different repo owners.
 #
-# To test against a dev branch of remote-dev-bot, change @main to @dev below.
+# To get unreleased features from the dev branch, change @main to @dev below.
 
 name: Remote Dev Bot
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to test (dev pointer in remote-dev-bot will be reset to this branch)"
+        description: "Branch to test (e2e-test pointer in remote-dev-bot will be reset to this branch)"
         required: false
         default: "main"
       provider:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to test (dev pointer in remote-dev-bot will be reset to this branch)"
+        description: "Branch to test (e2e-test pointer in remote-dev-bot will be reset to this branch)"
         required: false
         default: "main"
 
 # Sequential execution: all jobs use the same test repo, so they
-# cannot run in parallel (shared dev pointer, workflow files, issues).
+# cannot run in parallel (shared e2e-test pointer, workflow files, issues).
 #
 # Failure strategy:
 #   - unit-tests: fast-fail gate. If this fails, all e2e jobs are skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,22 +25,34 @@ Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to reso
 4. Resolve mode: OpenHands runs, edits code, opens a draft PR. Design mode: LLM analyzes the issue, posts a comment.
 5. Iterative: comment `/agent-resolve` again on the PR with feedback for another pass
 
+### Branch Model
+
+| Branch | Purpose | Who points here |
+|--------|---------|-----------------|
+| `main` | Stable, released, tagged | External users' shims |
+| `dev` | Long-lived integration branch, accumulates work ahead of `main` | Owner's own repo shims |
+| `e2e-test` | Ephemeral pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim |
+
+**Normal flow:** feature branches → PR → merge to `dev`. When `dev` is ready to release: run full test suite (with `e2e-test` pointing at `dev`), then merge `dev` → `main` and tag.
+
+**PRs go to `dev`, not `main`**, unless the change is a hotfix to something already released.
+
 ### Dev Cycle (detailed)
 
-This project has an unusual dev cycle because GitHub Actions only runs workflows from the default branch. You can't just push a feature branch and test it — the workflow won't trigger. Instead, we use a two-repo setup with a `dev` pointer branch.
+This project has an unusual dev cycle because GitHub Actions only runs workflows from the default branch. You can't just push a feature branch and test it — the workflow won't trigger. Instead, we use a two-repo setup with an `e2e-test` pointer branch.
 
 **Repos:**
 - `remote-dev-bot` — the reusable workflow, config, and docs (this repo)
-- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@dev` (not `@main`)
+- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@e2e-test`
 
-**How the `dev` branch works:**
-- `dev` is NOT a long-lived development branch. It's a pointer.
-- Before testing, force-set `dev` to your feature branch: `git branch -f dev my-feature && git push --force-with-lease origin dev`
-- The test repo's shim calls `resolve.yml@dev`, so it picks up whatever `dev` points to.
-- Only one feature can be tested at a time (since there's only one `dev` pointer).
+**How the `e2e-test` branch works:**
+- `e2e-test` is NOT a development branch. It's an ephemeral pointer reset before each e2e run.
+- Before testing, force-set `e2e-test` to your feature branch: `git push --force-with-lease origin my-feature:e2e-test`
+- The test repo's shim calls `resolve.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
+- Only one feature can be tested at a time (since there's only one `e2e-test` pointer).
 
 **Important: config/lib vs workflow code (the "main checkout" constraint):**
-- The shim (`agent.yml`) determines which branch of `resolve.yml` to use (`@main` or `@dev`)
+- The shim (`agent.yml`) determines which branch of `resolve.yml` to use (`@e2e-test` or `@main`)
 - But `resolve.yml` checks out `remote-dev-bot.yaml` and `lib/` in a separate step that always pulls from `main` — GitHub Actions doesn't expose which ref a reusable workflow was called with, so there's no way to say "use the same branch as myself"
 - This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch won't take effect in E2E tests unless they're already on `main`
 - Workaround for config values: with config layering, you can put a `remote-dev-bot.yaml` in the target repo (remote-dev-bot-test) to override specific values during testing
@@ -53,13 +65,13 @@ This project has an unusual dev cycle because GitHub Actions only runs workflows
 - Unit tests catch config parsing bugs on the branch; E2E tests validate the full workflow after config changes reach main
 
 **Full dev cycle:**
-1. Create a feature branch from `main`: `git checkout -b my-feature main`
+1. Create a feature branch from `dev`: `git checkout -b my-feature dev`
 2. Make changes, commit freely (work log mode)
-3. Point dev at your branch: `git branch -f dev my-feature && git push --force-with-lease origin dev`
+3. Point `e2e-test` at your branch: `git push --force-with-lease origin my-feature:e2e-test`
 4. In `remote-dev-bot-test`: create an issue, comment `/agent-resolve-claude-small`
 5. Monitor: `gh run list --repo gnovak/remote-dev-bot-test --workflow=agent.yml --limit 3`
-6. If it fails: check logs, fix, commit, push dev again, re-trigger
-7. If it works: clean up git history (rebase), open a PR (dev → main), merge
+6. If it fails: check logs, fix, commit, push `e2e-test` again, re-trigger
+7. If it works: clean up git history (rebase), open a PR against `dev`, merge
 
 **Triggering a test:**
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This file documents the development and testing infrastructure. If you're a user
 | Repo | Purpose |
 |------|---------|
 | `gnovak/remote-dev-bot` | The reusable workflow, config, tests, and docs (this repo) |
-| `gnovak/remote-dev-bot-test` | Throwaway test repo. Shim points at `resolve.yml@dev`. Git history and issues don't matter — leave a mess. |
+| `gnovak/remote-dev-bot-test` | Throwaway test repo. Shim points at `resolve.yml@e2e-test`. Git history and issues don't matter — leave a mess. |
 
 ## Test Accounts
 
@@ -111,9 +111,19 @@ Users can create their own `remote-dev-bot.local.yaml` if they want a third
 config layer, but there is no documented use case for this — `remote-dev-bot.yaml`
 already covers all user customisation needs.
 
+## Branch Model
+
+| Branch | Purpose | Who points here |
+|--------|---------|-----------------|
+| `main` | Stable, released, tagged | External users' shims |
+| `dev` | Long-lived integration branch, accumulates work ahead of `main` | Owner's own repo shims |
+| `e2e-test` | Ephemeral test pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim |
+
+**PRs go to `dev`, not `main`**, unless the change is a hotfix to something already released. When `dev` is ready to release: run the full test suite (with `e2e-test` pointing at `dev`), then merge `dev` → `main` and tag.
+
 ## Dev Cycle
 
-See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how the `dev` branch pointer works and how to trigger test runs.
+See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how the `e2e-test` branch pointer works and how to trigger test runs.
 
 ## Test Infrastructure
 
@@ -145,13 +155,13 @@ The design agent has two layers of defense against recursive loops (where its re
 
 ### Full test suite (`.github/workflows/full-test-suite.yml`)
 - One-button "run everything" workflow: unit tests → e2e shim → e2e compiled → e2e security
-- Jobs run **sequentially** — all e2e tests share `remote-dev-bot-test` and cannot run in parallel (shared dev pointer, workflow files, and issues)
+- Jobs run **sequentially** — all e2e tests share `remote-dev-bot-test` and cannot run in parallel (shared e2e-test pointer, workflow files, and issues)
 - **Failure strategy**: unit tests are a fast-fail gate (e2e jobs skip if they fail); the three e2e blocks continue past each other's failures so one run gives a complete picture across all blocks. After a full run, use the individual workflow_dispatch workflows to rerun only the failing blocks.
 - Use before releases to validate everything in one go
 
 ### Shared state constraint
 All e2e tests (functional, compiled, security) use `remote-dev-bot-test` as their target repo. They share:
-- The `dev` branch pointer (set to the branch under test)
+- The `e2e-test` branch pointer (set to the branch under test)
 - Workflow files in the test repo (compiled tests swap out the shim)
 - Issues and PRs created during the test run
 

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -217,9 +217,9 @@ When using remote-dev-bot to develop remote-dev-bot, the two repos are the same.
 
 The recommended dev cycle uses two repos:
 - `remote-dev-bot` — the main repo with the reusable workflow
-- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@dev`
+- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@e2e-test`
 
-See `AGENTS.md` for the full dev cycle, including how the `dev` branch works as a pointer.
+See `AGENTS.md` for the full dev cycle, including how the `e2e-test` branch works as a test pointer.
 
 ## Quick Reference: What Goes Where
 

--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -13,6 +13,8 @@ openhands:
   # Show draft PRs for partial resolutions when devving rdb itself —
   # partial changes are worth reviewing during active development.
   on_failure: draft
+  # PRs for self-dev work go to dev (the long-lived integration branch), not main.
+  target_branch: dev
 
 modes:
   design:

--- a/tests/e2e-security.sh
+++ b/tests/e2e-security.sh
@@ -18,7 +18,7 @@
 # Usage:
 #   ./tests/e2e-security.sh [--branch <branch>] [--test <name>]
 #
-#   --branch   Branch to test (default: main). Sets dev pointer.
+#   --branch   Branch to test (default: main). Sets e2e-test pointer.
 #   --test     Run a specific test only: sanity, exfiltration, gating, or all (default: all)
 
 set -euo pipefail
@@ -109,11 +109,11 @@ create_issue() {
     echo "$url"
 }
 
-# --- Point dev at target branch ---
+# --- Point e2e-test at target branch ---
 
 if [[ "$BRANCH" != "main" ]]; then
-    log "Setting dev pointer to '$BRANCH'..."
-    git push origin "$BRANCH:refs/heads/dev" --force-with-lease
+    log "Setting e2e-test pointer to '$BRANCH'..."
+    git push origin "$BRANCH:refs/heads/e2e-test" --force-with-lease
 fi
 
 # --- Test 0: Trigger sanity ---

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -8,7 +8,7 @@
 #   ./tests/e2e.sh [--branch <branch>] [--test <name>] [--provider <name>]
 #                  [--all-models] [--compiled]
 #
-#   --branch      Branch to test (default: main). Sets dev pointer to this branch.
+#   --branch      Branch to test (default: main). Sets e2e-test pointer to this branch.
 #   --test        Run a specific test only (default: all)
 #   --provider    Run only tests for a specific model family (claude/gpt/gemini)
 #   --all-models  Test every model alias, not just one per provider
@@ -298,11 +298,11 @@ if $USE_COMPILED; then
     install_compiled_workflow
 fi
 
-# --- Point dev at target branch ---
-# Always reset dev, even when testing main. dev can drift (e.g. stuck at an old
+# --- Point e2e-test at target branch ---
+# Always reset e2e-test, even when testing main. e2e-test can drift (e.g. stuck at an old
 # debug branch) and skipping the reset for main causes tests to run stale code.
-log "Setting dev pointer to '$BRANCH'..."
-git push origin "$BRANCH:refs/heads/dev" --force-with-lease
+log "Setting e2e-test pointer to '$BRANCH'..."
+git push origin "$BRANCH:refs/heads/e2e-test" --force-with-lease
 
 # --- Create test issues and trigger ---
 


### PR DESCRIPTION
## Summary

- **`dev`** is now the long-lived integration branch. Feature PRs land here; owner's shims point here for pre-release features.
- **`e2e-test`** is the new ephemeral test pointer. E2e scripts reset it before each run; `remote-dev-bot-test` shim points here.

## Changes

- **AGENTS.md**: full branch model table + rewritten dev cycle docs
- **CONTRIBUTING.md**: new Branch Model section + all pointer references updated
- **how-it-works.md**: test repo shim reference updated
- **e2e.yml / full-test-suite.yml**: workflow description strings updated
- **tests/e2e.sh + e2e-security.sh**: `dev` → `e2e-test` in push commands
- **remote-dev-bot.local.yaml**: added `target_branch: dev` so agent PRs go to dev, not main
- **agent.yml**: updated comment about @dev branch

**rdb-test shim** (committed directly to remote-dev-bot-test via API):
- `@dev` → `@e2e-test`
- `secrets: inherit` → explicit secrets (cross-owner correctness)
- Added space-syntax check (`startsWith '/agent '`) alongside dash-syntax

## Git branch operations (after merge)

Once this PR is merged to dev, the remaining work is:
1. Create `e2e-test` branch from the current `dev` commit: `git push origin dev:e2e-test`
2. The old `dev` branch is now repurposed — no deletion needed (it continues as the integration branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)