### PR TITLE
Use github.workflow_ref to self-referentially checkout config

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -55,11 +55,22 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
+      - name: Set config ref from workflow branch
+        run: |
+          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
+          WF="${{ github.workflow_ref }}"
+          BRANCH="${WF##*@}"
+          BRANCH="${BRANCH#refs/heads/}"
+          BRANCH="${BRANCH#refs/tags/}"
+          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
+
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ env.RDB_CONFIG_REF }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml
@@ -460,11 +471,22 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v4
 
+      - name: Set config ref from workflow branch
+        run: |
+          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
+          WF="${{ github.workflow_ref }}"
+          BRANCH="${WF##*@}"
+          BRANCH="${BRANCH#refs/heads/}"
+          BRANCH="${BRANCH#refs/tags/}"
+          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
+
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ env.RDB_CONFIG_REF }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,18 +51,9 @@ This project has an unusual dev cycle because GitHub Actions only runs workflows
 - The test repo's shim calls `resolve.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
 - Only one feature can be tested at a time (since there's only one `e2e-test` pointer).
 
-**Important: config/lib vs workflow code (the "main checkout" constraint):**
-- The shim (`agent.yml`) determines which branch of `resolve.yml` to use (`@e2e-test` or `@main`)
-- But `resolve.yml` checks out `remote-dev-bot.yaml` and `lib/` in a separate step that always pulls from `main` — GitHub Actions doesn't expose which ref a reusable workflow was called with, so there's no way to say "use the same branch as myself"
-- This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch won't take effect in E2E tests unless they're already on `main`
-- Workaround for config values: with config layering, you can put a `remote-dev-bot.yaml` in the target repo (remote-dev-bot-test) to override specific values during testing
-
-**PR constraint — separate config parsing from workflow changes:**
-- `lib/config.py` is checked out from `main` at runtime, but unit tests (pytest) run against the branch version
-- If you change both config parsing logic AND workflow behavior in one PR, E2E tests will use the old (main) config.py with the new workflow — they won't match
-- **Rule: config parsing changes (`lib/config.py`) go in their own PR, merged first.** Then workflow changes that depend on them go in a follow-up PR.
-- This is usually natural: config changes tend to be additive ("add a new field"), and the code that reads the new field comes separately
-- Unit tests catch config parsing bugs on the branch; E2E tests validate the full workflow after config changes reach main
+**Config/lib checkout is self-referential:**
+- `resolve.yml` reads `github.workflow_ref` to detect which branch it was called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same branch
+- This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch take effect automatically when `e2e-test` points at your branch — no separate PR needed
 
 **Full dev cycle:**
 1. Create a feature branch from `dev`: `git checkout -b my-feature dev`


### PR DESCRIPTION
## Summary

- `resolve.yml` now reads `github.workflow_ref` to detect which branch it was called from
- Uses that ref (instead of hardcoded `main`) when checking out `remote-dev-bot.yaml` and `lib/` from this repo
- Applied to both the `parse` job and the `design` job (each does its own config checkout)

**Before:** config checkout always pulled from `main`, so `lib/config.py` or `remote-dev-bot.yaml` changes on a feature branch had no effect in E2E tests until merged.

**After:** workflow code and config come from the same branch automatically — the self-referential checkout "just works".

This eliminates the "config changes must go in their own PR" constraint. Updated AGENTS.md accordingly.

## How it works

`github.workflow_ref` is populated in `workflow_call` contexts with the full path+ref of the called workflow, e.g.:
```
gnovak/remote-dev-bot/.github/workflows/resolve.yml@refs/heads/dev
```

A new `Set config ref from workflow branch` step extracts `dev` from that string and writes it to `$GITHUB_ENV`, which the next step uses as the `ref:` in the sparse checkout.

## Test plan

- [x] All 160 unit tests pass
- [ ] E2E: verify that `lib/config.py` changes on a test branch take effect when `e2e-test` points at that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)