### PR TITLE
Rename resolve.yml to remote-dev-bot.yml

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -15,7 +15,7 @@
 # Note: secrets must be passed explicitly (not via `secrets: inherit`) because
 # GitHub Actions does not pass inherited secrets across different repo owners.
 #
-# To get unreleased features from the dev branch, change @main to @dev below.
+# To get unreleased features from the dev branch, change @main to @dev in the uses: line below.
 
 name: Remote Dev Bot
 
@@ -41,7 +41,7 @@ jobs:
       (github.event.issue || github.event.pull_request) &&
       (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
-    uses: gnovak/remote-dev-bot/.github/workflows/resolve.yml@main
+    uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -3,9 +3,10 @@ name: Resolve Issue
 # Reusable workflow — called by thin shims in target repos.
 # See .github/workflows/agent.yml for the shim template.
 #
-# Supports two modes via /agent-<mode>[-<model>] or /agent <mode> [<model>]:
+# Supports three modes via /agent-<mode>[-<model>] or /agent <mode> [<model>]:
 #   /agent-resolve[-<model>] or /agent resolve [<model>]  — run OpenHands to resolve the issue, open a PR
 #   /agent-design[-<model>] or /agent design [<model>]    — post a design analysis comment (no code changes)
+#   /agent-review[-<model>] or /agent review [<model>]    — post a code review comment on a PR (no code changes)
 # Both dash and space separators are supported for mobile-friendly typing.
 
 on:
@@ -57,7 +58,7 @@ jobs:
 
       - name: Set config ref from workflow branch
         run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
           # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
           WF="${{ github.workflow_ref }}"
           BRANCH="${WF##*@}"
@@ -473,7 +474,7 @@ jobs:
 
       - name: Set config ref from workflow branch
         run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
           # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
           WF="${{ github.workflow_ref }}"
           BRANCH="${WF##*@}"

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -55,11 +55,22 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
+      - name: Set config ref from workflow branch
+        run: |
+          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
+          WF="${{ github.workflow_ref }}"
+          BRANCH="${WF##*@}"
+          BRANCH="${BRANCH#refs/heads/}"
+          BRANCH="${BRANCH#refs/tags/}"
+          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
+
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ env.RDB_CONFIG_REF }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml
@@ -460,11 +471,22 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v4
 
+      - name: Set config ref from workflow branch
+        run: |
+          # github.workflow_ref = "owner/repo/.github/workflows/resolve.yml@refs/heads/dev"
+          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
+          WF="${{ github.workflow_ref }}"
+          BRANCH="${WF##*@}"
+          BRANCH="${BRANCH#refs/heads/}"
+          BRANCH="${BRANCH#refs/tags/}"
+          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
+
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ env.RDB_CONFIG_REF }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,18 +51,9 @@ This project has an unusual dev cycle because GitHub Actions only runs workflows
 - The test repo's shim calls `resolve.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
 - Only one feature can be tested at a time (since there's only one `e2e-test` pointer).
 
-**Important: config/lib vs workflow code (the "main checkout" constraint):**
-- The shim (`agent.yml`) determines which branch of `resolve.yml` to use (`@e2e-test` or `@main`)
-- But `resolve.yml` checks out `remote-dev-bot.yaml` and `lib/` in a separate step that always pulls from `main` — GitHub Actions doesn't expose which ref a reusable workflow was called with, so there's no way to say "use the same branch as myself"
-- This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch won't take effect in E2E tests unless they're already on `main`
-- Workaround for config values: with config layering, you can put a `remote-dev-bot.yaml` in the target repo (remote-dev-bot-test) to override specific values during testing
-
-**PR constraint — separate config parsing from workflow changes:**
-- `lib/config.py` is checked out from `main` at runtime, but unit tests (pytest) run against the branch version
-- If you change both config parsing logic AND workflow behavior in one PR, E2E tests will use the old (main) config.py with the new workflow — they won't match
-- **Rule: config parsing changes (`lib/config.py`) go in their own PR, merged first.** Then workflow changes that depend on them go in a follow-up PR.
-- This is usually natural: config changes tend to be additive ("add a new field"), and the code that reads the new field comes separately
-- Unit tests catch config parsing bugs on the branch; E2E tests validate the full workflow after config changes reach main
+**Config/lib checkout is self-referential:**
+- `resolve.yml` reads `github.workflow_ref` to detect which branch it was called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same branch
+- This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch take effect automatically when `e2e-test` points at your branch — no separate PR needed
 
 **Full dev cycle:**
 1. Create a feature branch from `dev`: `git checkout -b my-feature dev`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,18 +9,18 @@ Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to reso
 ### Key Files
 - `remote-dev-bot.yaml` — model aliases and OpenHands settings
 - `runbook.md` — setup instructions (designed to be followed by humans or AI assistants)
-- `.github/workflows/resolve.yml` — the reusable workflow (all the real logic)
-- `.github/workflows/agent.yml` — thin shim that calls resolve.yml
+- `.github/workflows/remote-dev-bot.yml` — the reusable workflow (all the real logic)
+- `.github/workflows/agent.yml` — thin shim that calls remote-dev-bot.yml
 - `.github/workflows/test.yml` — CI: runs pytest on PRs to main
 - `.github/workflows/e2e.yml` — manual trigger for E2E tests
-- `lib/config.py` — config parsing logic (used by resolve.yml and unit tests)
+- `lib/config.py` — config parsing logic (used by remote-dev-bot.yml and unit tests)
 - `scripts/compile.py` — compiles two self-contained workflows (`dist/agent-resolve.yml`, `dist/agent-design.yml`)
 - `tests/` — pytest unit tests and E2E test script
 - `.openhands/microagents/repo.md` — (in target repos) context for the agent
 
 ### How It Works
 1. User comments `/agent-resolve[-<model>]` or `/agent-design[-<model>]` on a GitHub issue
-2. Target repo's shim workflow calls `resolve.yml` from this repo
+2. Target repo's shim workflow calls `remote-dev-bot.yml` from this repo
 3. Reusable workflow parses the mode and model, dispatches to the right job
 4. Resolve mode: OpenHands runs, edits code, opens a draft PR. Design mode: LLM analyzes the issue, posts a comment.
 5. Iterative: comment `/agent-resolve` again on the PR with feedback for another pass
@@ -43,16 +43,16 @@ This project has an unusual dev cycle because GitHub Actions only runs workflows
 
 **Repos:**
 - `remote-dev-bot` — the reusable workflow, config, and docs (this repo)
-- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@e2e-test`
+- `remote-dev-bot-test` — a test repo whose shim points at `remote-dev-bot.yml@e2e-test`
 
 **How the `e2e-test` branch works:**
 - `e2e-test` is NOT a development branch. It's an ephemeral pointer reset before each e2e run.
 - Before testing, force-set `e2e-test` to your feature branch: `git push --force-with-lease origin my-feature:e2e-test`
-- The test repo's shim calls `resolve.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
+- The test repo's shim calls `remote-dev-bot.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
 - Only one feature can be tested at a time (since there's only one `e2e-test` pointer).
 
 **Config/lib checkout is self-referential:**
-- `resolve.yml` reads `github.workflow_ref` to detect which branch it was called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same branch
+- `remote-dev-bot.yml` reads `github.workflow_ref` to detect which branch it was called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same branch
 - This means changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch take effect automatically when `e2e-test` points at your branch — no separate PR needed
 
 **Full dev cycle:**
@@ -85,9 +85,9 @@ gh run view RUN_ID --repo gnovak/remote-dev-bot-test --log | tail -40
 
 ## Compiler: two-file output
 
-`scripts/compile.py` produces two compiled workflows: `dist/agent-resolve.yml` and `dist/agent-design.yml`. It finds steps by **name** (not index), so reordering steps in resolve.yml is safe as long as step names don't change.
+`scripts/compile.py` produces two compiled workflows: `dist/agent-resolve.yml` and `dist/agent-design.yml`. It finds steps by **name** (not index), so reordering steps in remote-dev-bot.yml is safe as long as step names don't change.
 
-**Rule: if you add, remove, or rename a step in resolve.yml, update compile.py to match.** Run `pytest tests/test_compile.py -v` after changes — the step-count tripwire tests (`test_resolve_step_count`, `test_design_step_count`) will fail if the compiled output doesn't match the expected step list, forcing you to update both `compile.py` and the expected step lists in `test_compile.py`.
+**Rule: if you add, remove, or rename a step in remote-dev-bot.yml, update compile.py to match.** Run `pytest tests/test_compile.py -v` after changes — the step-count tripwire tests (`test_resolve_step_count`, `test_design_step_count`) will fail if the compiled output doesn't match the expected step list, forcing you to update both `compile.py` and the expected step lists in `test_compile.py`.
 
 ## Code Style
 - Follow existing patterns in the codebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ## v0.2.0 — Shim + reusable workflow (Feb 11, 2026)
 
-- Refactored into a thin shim (`agent.yml`) per target repo that calls a shared reusable workflow (`resolve.yml`).
+- Refactored into a thin shim (`agent.yml`) per target repo that calls a shared reusable workflow (`remote-dev-bot.yml`).
 - Cross-repo support tested with separate test repo.
 - Dev cycle infrastructure in place.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This file documents the development and testing infrastructure. If you're a user
 | Repo | Purpose |
 |------|---------|
 | `gnovak/remote-dev-bot` | The reusable workflow, config, tests, and docs (this repo) |
-| `gnovak/remote-dev-bot-test` | Throwaway test repo. Shim points at `resolve.yml@e2e-test`. Git history and issues don't matter — leave a mess. |
+| `gnovak/remote-dev-bot-test` | Throwaway test repo. Shim points at `remote-dev-bot.yml@e2e-test`. Git history and issues don't matter — leave a mess. |
 
 ## Test Accounts
 
@@ -205,4 +205,4 @@ E2E tests cost real money (they invoke LLM APIs), so the full test suite is not 
 
 - Two compiled workflow files: `agent-resolve.yml` (issue resolution) and `agent-design.yml` (design analysis). Both are self-contained with inlined config, model aliases, and security guardrails.
 - Users who installed via compiled workflows get updates by downloading the new release.
-- Users who installed via the shim get updates automatically (the shim calls `resolve.yml@main`).
+- Users who installed via the shim get updates automatically (the shim calls `remote-dev-bot.yml@main`).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Remote Dev Bot currently supports three LLM providers out of the box:
 
 The workflow automatically selects the correct API key based on the model prefix. For example, a model ID starting with `anthropic/` will use `ANTHROPIC_API_KEY`.
 
-**Adding a new provider:** LiteLLM supports many providers beyond these three. To add support for a new provider, you'll need to modify `.github/workflows/resolve.yml`:
+**Adding a new provider:** LiteLLM supports many providers beyond these three. To add support for a new provider, you'll need to modify `.github/workflows/remote-dev-bot.yml`:
 
 1. Add the new secret to the `workflow_call.secrets` section
 2. Add a case in the "Determine API key" step to match the provider prefix
@@ -102,7 +102,7 @@ commit_trailer: ""
 The system has two parts:
 
 - **Shim workflow** (`.github/workflows/agent.yml`) — a thin trigger that lives in each target repo. Fires on `/agent-` commands and calls the reusable workflow. Copy this file to set up the shim install.
-- **Reusable workflow** (`.github/workflows/resolve.yml`) — all the logic: parses commands, dispatches to resolve or design mode, runs the agent. Lives in this repo and is called by shims in target repos.
+- **Reusable workflow** (`.github/workflows/remote-dev-bot.yml`) — all the logic: parses commands, dispatches to resolve or design mode, runs the agent. Lives in this repo and is called by shims in target repos.
 - **OpenHands** — the AI agent framework that does the actual code exploration and editing
 - **`remote-dev-bot.yaml`** — model aliases and OpenHands settings (version, max iterations, PR type)
 - **`runbook.md`** — step-by-step setup instructions, designed to be followed by a human or by an AI assistant (like Claude Code)

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -12,7 +12,7 @@ Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two rep
 │                    (where you want AI to help develop)                      │
 │                                                                             │
 │   .github/workflows/agent.yml  ←── Shim: triggers on /agent- commands       │
-│                                    and calls resolve.yml from remote-dev-bot│
+│                                    and calls remote-dev-bot.yml from remote-dev-bot│
 │                                                                             │
 │   remote-dev-bot.yaml          ←── (Optional) Override config for this repo │
 │                                                                             │
@@ -29,7 +29,7 @@ Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two rep
 │                         REMOTE-DEV-BOT REPO                                 │
 │              (gnovak/remote-dev-bot or your org's fork)                     │
 │                                                                             │
-│   .github/workflows/resolve.yml  ←── Reusable workflow: all the logic       │
+│   .github/workflows/remote-dev-bot.yml  ←── Reusable workflow: all the logic       │
 │                                      (model parsing, OpenHands, PR creation)│
 │                                                                             │
 │   remote-dev-bot.yaml            ←── Base config: model aliases, settings   │
@@ -50,9 +50,9 @@ This is the "engine" — the shared infrastructure that all target repos use.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/resolve.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
+| `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
 | `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
-| `lib/config.py` | Config parsing logic. Loads base config, merges with target repo overrides, resolves aliases. Used by resolve.yml at runtime. |
+| `lib/config.py` | Config parsing logic. Loads base config, merges with target repo overrides, resolves aliases. Used by remote-dev-bot.yml at runtime. |
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
 | `runbook.md` | Step-by-step setup instructions for humans or AI assistants. |
 | `AGENTS.md` | Development guidance for AI assistants working on this repo. |
@@ -65,7 +65,7 @@ This is where you want the AI agent to help with development.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve` and `/agent-design` comments and calls `resolve.yml` from remote-dev-bot. This is the only workflow file you need. |
+| `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve` and `/agent-design` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
 | `remote-dev-bot.yaml` | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config. |
 | `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. |
 
@@ -82,8 +82,8 @@ This is where you want the AI agent to help with development.
 When someone comments `/agent-resolve-claude-large` on an issue:
 
 1. **Shim triggers** — The target repo's `agent.yml` fires on the comment
-2. **Calls reusable workflow** — The shim calls `resolve.yml@main` from remote-dev-bot
-3. **Config checkout** — resolve.yml checks out `lib/config.py` from remote-dev-bot
+2. **Calls reusable workflow** — The shim calls `remote-dev-bot.yml@main` from remote-dev-bot
+3. **Config checkout** — remote-dev-bot.yml checks out `lib/config.py` from remote-dev-bot
 4. **Config merge** — config.py loads base config from remote-dev-bot, merges with any override config in the target repo
 5. **Model resolution** — The alias `claude-large` is resolved to a model ID like `anthropic/claude-opus-4-5`
 6. **Feedback** — A rocket emoji is added to your comment and you're assigned to the issue, so you can see at a glance which issues have active work
@@ -99,11 +99,11 @@ User comments /agent-resolve-claude-large
 │ agent.yml triggers  │
 └─────────────────────┘
          │
-         │ uses: gnovak/remote-dev-bot/.github/workflows/resolve.yml@main
+         │ uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
          ▼
 ┌─────────────────────┐
 │ remote-dev-bot      │
-│ resolve.yml runs    │
+│ remote-dev-bot.yml runs    │
 │   • checkout config │
 │   • parse alias     │
 │   • run OpenHands   │
@@ -157,7 +157,7 @@ The workflow uses a three-way token fallback: GitHub App token > `RDB_PAT_TOKEN`
 GitHub Actions does not pass `secrets: inherit` across different repo owners. Since your target repo and `gnovak/remote-dev-bot` have different owners, the shim must list secrets explicitly:
 
 ```yaml
-    uses: gnovak/remote-dev-bot/.github/workflows/resolve.yml@main
+    uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -196,7 +196,7 @@ Organizations often want full control over the reusable workflow. To use a fork:
 1. Fork `gnovak/remote-dev-bot` to your org (e.g., `myorg/remote-dev-bot`)
 2. In your target repos' shims, change the `uses:` line:
    ```yaml
-   uses: myorg/remote-dev-bot/.github/workflows/resolve.yml@main
+   uses: myorg/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
    ```
 3. Set Actions access on your fork (Settings → Actions → General → Access → "Accessible from repositories owned by the user")
 4. If your fork and target repos are in the same org, you can use `secrets: inherit` instead of listing secrets explicitly
@@ -210,14 +210,14 @@ Now updates to your fork flow to your target repos, and you control the release 
 When using remote-dev-bot to develop remote-dev-bot, the two repos are the same. This creates a bootstrapping situation:
 
 - The shim (`agent.yml`) lives in remote-dev-bot
-- The reusable workflow (`resolve.yml`) also lives in remote-dev-bot
-- The shim calls `resolve.yml@main`, so changes on feature branches don't take effect
+- The reusable workflow (`remote-dev-bot.yml`) also lives in remote-dev-bot
+- The shim calls `remote-dev-bot.yml@main`, so changes on feature branches don't take effect
 
 **Solution: Use a separate test repo.**
 
 The recommended dev cycle uses two repos:
 - `remote-dev-bot` — the main repo with the reusable workflow
-- `remote-dev-bot-test` — a test repo whose shim points at `resolve.yml@e2e-test`
+- `remote-dev-bot-test` — a test repo whose shim points at `remote-dev-bot.yml@e2e-test`
 
 See `AGENTS.md` for the full dev cycle, including how the `e2e-test` branch works as a test pointer.
 
@@ -227,7 +227,7 @@ See `AGENTS.md` for the full dev cycle, including how the `e2e-test` branch work
 |--------------|--------------|------------|
 | Add a new model alias | `remote-dev-bot.yaml` | remote-dev-bot (or your fork) |
 | Change the default model for one repo | `remote-dev-bot.yaml` | target repo |
-| Modify how the agent runs | `.github/workflows/resolve.yml` | remote-dev-bot |
+| Modify how the agent runs | `.github/workflows/remote-dev-bot.yml` | remote-dev-bot |
 | Give the agent context about my codebase | `.openhands/microagents/repo.md` | target repo |
 | Set up a new repo to use the bot | `.github/workflows/agent.yml` + secrets | target repo |
 | Change config parsing logic | `lib/config.py` | remote-dev-bot |
@@ -255,6 +255,6 @@ Config: base=remote-dev-bot, override=none
 
 Check the `uses:` line in your shim:
 ```yaml
-uses: gnovak/remote-dev-bot/.github/workflows/resolve.yml@main
+uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
 ```
 This tells you which remote-dev-bot repo (and branch) you're using.

--- a/lib/config.py
+++ b/lib/config.py
@@ -9,9 +9,7 @@ Commands follow the pattern: /agent-<verb>[-<model>]
   /agent-resolve-claude-large — resolve mode, specific model
   /agent-design            — design mode, default model
 
-Called by resolve.yml at runtime (checked out from main via sparse-checkout)
-and imported directly by unit tests. See CLAUDE.md "PR constraints" for why
-config parsing changes must be in their own PR, separate from workflow changes.
+Called by remote-dev-bot.yml at runtime and imported directly by unit tests.
 """
 
 import json

--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -35,5 +35,5 @@ modes:
       - lib/feedback.py
       - scripts/compile.py
       # rdb workflows (core of the system)
-      - .github/workflows/resolve.yml
+      - .github/workflows/remote-dev-bot.yml
       - .github/workflows/agent.yml

--- a/runbook.md
+++ b/runbook.md
@@ -570,7 +570,7 @@ gh pr list --repo {owner}/{repo}
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `ModuleNotFoundError: No module named 'yaml'` | PyYAML not installed before config parsing | **Compiled:** Re-download latest from [releases](https://github.com/gnovak/remote-dev-bot/releases). **Shim:** Should auto-fix (uses latest resolve.yml) |
+| `ModuleNotFoundError: No module named 'yaml'` | PyYAML not installed before config parsing | **Compiled:** Re-download latest from [releases](https://github.com/gnovak/remote-dev-bot/releases). **Shim:** Should auto-fix (uses latest remote-dev-bot.yml) |
 | `ImportError: cannot import name 'WorkspaceState'` | Old OpenHands version | **Compiled:** Re-download latest from [releases](https://github.com/gnovak/remote-dev-bot/releases). **Shim:** Should auto-fix |
 | `error: the following arguments are required: --selected-repo` | OpenHands 1.x API change | Update workflow — `--repo` was renamed to `--selected-repo` |
 | `ValueError: Username is required` | Missing env vars | Workflow needs `GITHUB_USERNAME` and `GIT_USERNAME` |
@@ -709,7 +709,7 @@ Built-in mitigations:
 
 ### Cross-repo reusable workflow access (shim install only)
 
-The shim calls `resolve.yml` from `gnovak/remote-dev-bot`. Since that repo is public, this works automatically — no special access settings needed.
+The shim calls `remote-dev-bot.yml` from `gnovak/remote-dev-bot`. Since that repo is public, this works automatically — no special access settings needed.
 
 **If using a private fork:** You must enable Actions access sharing on your fork:
 

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Compile two self-contained workflows from the reusable workflow + shim.
+"""Compile self-contained workflows from the reusable workflow + shim.
 
-Reads the reusable workflow (resolve.yml), the shim (agent.yml), and config
-(remote-dev-bot.yaml), then produces two compiled files:
+Reads the reusable workflow (remote-dev-bot.yml), the shim (agent.yml), and config
+(remote-dev-bot.yaml), then produces compiled files:
 
   dist/agent-resolve.yml  — triggers on /agent-resolve[-<model>]
   dist/agent-design.yml   — triggers on /agent-design[-<model>]
@@ -510,7 +510,7 @@ def main():
     """Main entry point."""
     workspace = Path(__file__).parent.parent
     shim_path = workspace / ".github" / "workflows" / "agent.yml"
-    workflow_path = workspace / ".github" / "workflows" / "resolve.yml"
+    workflow_path = workspace / ".github" / "workflows" / "remote-dev-bot.yml"
     config_path = workspace / "remote-dev-bot.yaml"
 
     # Output directory

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -19,7 +19,7 @@ def compiled_dir(tmp_path):
     from scripts.compile import compile_resolve, compile_design, load_yaml
 
     shim = load_yaml(str(WORKSPACE / ".github" / "workflows" / "agent.yml"))
-    workflow = load_yaml(str(WORKSPACE / ".github" / "workflows" / "resolve.yml"))
+    workflow = load_yaml(str(WORKSPACE / ".github" / "workflows" / "remote-dev-bot.yml"))
     config = load_yaml(str(WORKSPACE / "remote-dev-bot.yaml"))
 
     compile_resolve(shim, workflow, config, str(tmp_path / "agent-resolve.yml"))
@@ -268,7 +268,7 @@ def test_both_have_required_markers(compiled_dir):
 
 
 # --- Step count tripwire ---
-# These tests fail when steps are added to or removed from resolve.yml,
+# These tests fail when steps are added to or removed from remote-dev-bot.yml,
 # forcing you to check whether compile.py needs a corresponding update.
 
 
@@ -306,23 +306,23 @@ EXPECTED_DESIGN_STEPS = [
 
 
 def test_resolve_step_count(compiled_dir):
-    """Tripwire: fails if steps are added/removed from resolve.yml without updating compile.py."""
+    """Tripwire: fails if steps are added/removed from remote-dev-bot.yml without updating compile.py."""
     data = _load_compiled(compiled_dir / "agent-resolve.yml")
     job = list(data["jobs"].values())[0]
     actual = [s.get("name", "(unnamed)") for s in job["steps"]]
     assert actual == EXPECTED_RESOLVE_STEPS, (
-        f"Compiled resolve steps changed. If you added/removed a step in resolve.yml, "
+        f"Compiled resolve steps changed. If you added/removed a step in remote-dev-bot.yml, "
         f"update compile.py and this list.\n  Expected: {EXPECTED_RESOLVE_STEPS}\n  Actual:   {actual}"
     )
 
 
 def test_design_step_count(compiled_dir):
-    """Tripwire: fails if steps are added/removed from resolve.yml without updating compile.py."""
+    """Tripwire: fails if steps are added/removed from remote-dev-bot.yml without updating compile.py."""
     data = _load_compiled(compiled_dir / "agent-design.yml")
     job = list(data["jobs"].values())[0]
     actual = [s.get("name", "(unnamed)") for s in job["steps"]]
     assert actual == EXPECTED_DESIGN_STEPS, (
-        f"Compiled design steps changed. If you added/removed a step in resolve.yml, "
+        f"Compiled design steps changed. If you added/removed a step in remote-dev-bot.yml, "
         f"update compile.py and this list.\n  Expected: {EXPECTED_DESIGN_STEPS}\n  Actual:   {actual}"
     )
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,4 +1,4 @@
-"""Tests for the parse_litellm_logs function embedded in resolve.yml's cost step.
+"""Tests for the parse_litellm_logs function embedded in remote-dev-bot.yml's cost step.
 
 The function lives inside a bash heredoc in the workflow, so we extract it from
 the YAML at test time rather than importing it — this means the tests always
@@ -17,8 +17,8 @@ WORKSPACE = Path(__file__).parent.parent
 
 @pytest.fixture(scope="module")
 def parse_litellm_logs():
-    """Extract and return parse_litellm_logs from resolve.yml's cost step."""
-    with open(WORKSPACE / ".github/workflows/resolve.yml") as f:
+    """Extract and return parse_litellm_logs from remote-dev-bot.yml's cost step."""
+    with open(WORKSPACE / ".github/workflows/remote-dev-bot.yml") as f:
         workflow = yaml.safe_load(f)
 
     resolve_steps = workflow["jobs"]["resolve"]["steps"]

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -24,7 +24,7 @@ def load_yaml(path):
     "path",
     [
         "remote-dev-bot.yaml",
-        ".github/workflows/resolve.yml",
+        ".github/workflows/remote-dev-bot.yml",
         ".github/workflows/agent.yml",
     ],
 )
@@ -102,11 +102,11 @@ def test_openhands_has_max_iterations(bot_config):
 
 @pytest.fixture
 def resolve_yml():
-    return (REPO_ROOT / ".github/workflows/resolve.yml").read_text()
+    return (REPO_ROOT / ".github/workflows/remote-dev-bot.yml").read_text()
 
 
 def test_resolve_yml_injects_security_guardrails(resolve_yml):
-    """Verify the security microagent step exists in resolve.yml."""
+    """Verify the security microagent step exists in remote-dev-bot.yml."""
     assert "Inject security guardrails" in resolve_yml
     assert "remote-dev-bot-security.md" in resolve_yml
     assert "NEVER output, print, log, echo" in resolve_yml
@@ -149,20 +149,20 @@ def test_design_prompt_has_loop_prevention(bot_config):
 
 
 def test_resolve_yml_has_response_validation(resolve_yml):
-    """Verify resolve.yml blocks responses containing /agent commands."""
+    """Verify remote-dev-bot.yml blocks responses containing /agent commands."""
     # Check for the loop prevention comment
     assert "Loop prevention" in resolve_yml, (
-        "resolve.yml should have loop prevention comment"
+        "remote-dev-bot.yml should have loop prevention comment"
     )
     # Check for the blocking mechanism (not stripping)
     assert "agent_pattern" in resolve_yml, (
-        "resolve.yml should use agent_pattern to detect /agent commands"
+        "remote-dev-bot.yml should use agent_pattern to detect /agent commands"
     )
     assert "llm_blocked" in resolve_yml, (
-        "resolve.yml should write to llm_blocked file when /agent detected"
+        "remote-dev-bot.yml should write to llm_blocked file when /agent detected"
     )
     assert "Agent loop blocked" in resolve_yml, (
-        "resolve.yml should post a warning message when blocking"
+        "remote-dev-bot.yml should post a warning message when blocking"
     )
 
 
@@ -170,7 +170,7 @@ class TestLoopPreventionRegex:
     """Test the regex pattern used to detect /agent commands in responses."""
 
     import re
-    # This is the same pattern used in resolve.yml
+    # This is the same pattern used in remote-dev-bot.yml
     PATTERN = re.compile(r'^/agent', re.MULTILINE)
 
     def contains_agent_command(self, text):
@@ -229,14 +229,14 @@ class TestLoopPreventionRegex:
 class TestCommandExtractionRegex:
     """Test the regex pattern used to extract command from /agent comments.
 
-    This mirrors the regex in resolve.yml that extracts the command string
+    This mirrors the regex in remote-dev-bot.yml that extracts the command string
     from comments like "/agent-resolve-claude-large" or "/agent resolve claude large".
     """
 
     import re
 
     def extract_command(self, comment):
-        """Extract command using the same regex as resolve.yml, normalized to dashes."""
+        """Extract command using the same regex as remote-dev-bot.yml, normalized to dashes."""
         # This mirrors: grep -oP '^/agent[- ]\K[a-z0-9]+(?:[- ][a-z0-9]+){0,2}' | tr ' ' '-'
         match = self.re.search(r'^/agent[- ]([a-z0-9]+(?:[- ][a-z0-9]+){0,2})', comment)
         if match:


### PR DESCRIPTION
## Summary

- Rename `.github/workflows/resolve.yml` to `.github/workflows/remote-dev-bot.yml`
- Update all references across the codebase (14 files)

The reusable workflow handles three modes now (resolve, design, review coming in #214). Calling it `resolve.yml` is a misnomer. `remote-dev-bot.yml` is self-describing and won't conflict with `agent.yml` (the shim) or the compiled `agent-*.yml` files.

Note: This PR also includes the `github.workflow_ref` config-checkout fix from #216 (it was branched from that). Both fixes ship together.

## After merging

Update the four installed shims — change the `uses:` line from `resolve.yml@...` to `remote-dev-bot.yml@...`:
- `gnovak/remote-dev-bot-test` (points at `@e2e-test`)
- `gnovak/anglish`, `gnovak/blargish`, `gnovak/bridge-analysis` (point at `@main`)

## What does not change

- `agent.yml` (the shim filename stays `agent.yml`)
- Compiled output names: `dist/agent-resolve.yml`, `dist/agent-design.yml` (mode names, not workflow name)

## Test plan

- [x] All 160 unit tests pass
- [ ] Update 4 external shims after merge

Generated with [Claude Code](https://claude.com/claude-code)