### PR TITLE
Fix config checkout ref: use explicit rdb_ref input instead of github.workflow_ref

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -15,7 +15,8 @@
 # Note: secrets must be passed explicitly (not via `secrets: inherit`) because
 # GitHub Actions does not pass inherited secrets across different repo owners.
 #
-# To get unreleased features from the dev branch, change @main to @dev in the uses: line below.
+# To get unreleased features from the dev branch, change @main to @dev in the uses: line below,
+# and add `with: rdb_ref: dev` to match (so the config files are also fetched from dev).
 
 name: Remote Dev Bot
 
@@ -43,6 +44,8 @@ jobs:
       (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
+    with:
+      rdb_ref: main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -11,6 +11,12 @@ name: Resolve Issue
 
 on:
   workflow_call:
+    inputs:
+      rdb_ref:
+        description: 'Branch or tag of remote-dev-bot to use for config and lib files. Must match the @ref used in the shim''s `uses:` line.'
+        required: false
+        default: 'main'
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -56,22 +62,12 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
-      - name: Set config ref from workflow branch
-        run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
-          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
-          WF="${{ github.workflow_ref }}"
-          BRANCH="${WF##*@}"
-          BRANCH="${BRANCH#refs/heads/}"
-          BRANCH="${BRANCH#refs/tags/}"
-          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
-
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          ref: ${{ env.RDB_CONFIG_REF }}
+          ref: ${{ inputs.rdb_ref }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml
@@ -472,22 +468,12 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v4
 
-      - name: Set config ref from workflow branch
-        run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
-          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
-          WF="${{ github.workflow_ref }}"
-          BRANCH="${WF##*@}"
-          BRANCH="${BRANCH#refs/heads/}"
-          BRANCH="${BRANCH#refs/tags/}"
-          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
-
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          ref: ${{ env.RDB_CONFIG_REF }}
+          ref: ${{ inputs.rdb_ref }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml


### PR DESCRIPTION
## Problem

The \`Set config ref from workflow branch\` step used \`github.workflow_ref\` to detect whether the reusable workflow was called from \`@dev\` or \`@main\`, then checked out config files from the matching branch. In practice, \`github.workflow_ref\` inside a reusable workflow returns the **caller's** ref (the shim's \`main\` branch, not the reusable workflow's own ref. So `RDB_CONFIG_REF` always fell back to `main`, and modes only defined on `dev` (like `review`) were not found.

Observed failure: `/agent review` on a repo with `@dev` shim → `ERROR: Unknown mode: 'review'. Available modes: ['design', 'resolve']`

## Fix

- Add an explicit `rdb_ref` input to the reusable workflow (default: `main`)
- Use `inputs.rdb_ref` directly in the config checkout `ref:` field
- Remove the now-redundant `Set config ref from workflow branch` steps (both occurrences)
- Update `agent.yml` template to include `with: rdb_ref: main` with a comment explaining it must match the `@ref` in the `uses:` line

Target repos using `@dev` will need a matching `rdb_ref: dev` added to their shims (separate PRs).

## Test plan
- [ ] Trigger `/agent review` on a repo with shim pointing at `@dev` + `rdb_ref: dev` — should parse successfully
- [ ] Trigger `/agent resolve` on a repo with `@main` + `rdb_ref: main` — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)