### PR TITLE
Add dogfood shim for rdb self-development on dev branch

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -15,7 +15,8 @@
 # Note: secrets must be passed explicitly (not via `secrets: inherit`) because
 # GitHub Actions does not pass inherited secrets across different repo owners.
 #
-# To get unreleased features from the dev branch, change @main to @dev in the uses: line below.
+# To get unreleased features from the dev branch, change @main to @dev in the uses: line below,
+# and add `with: rdb_ref: dev` to match (so the config files are also fetched from dev).
 
 name: Remote Dev Bot
 
@@ -43,6 +44,8 @@ jobs:
       (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
+    with:
+      rdb_ref: main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,42 @@
+# Dogfood shim — for rdb self-development only. NOT for users.
+#
+# Fires on /dogfood[-<mode>[-<model>]] comments and calls remote-dev-bot.yml@dev,
+# so rdb can test pre-release features against its own issues without changing agent.yml
+# (which users copy and which must always point at @main).
+#
+# Usage:
+#   /dogfood                      — resolve with default model, dev branch
+#   /dogfood-resolve-claude-large — resolve with a specific model
+#   /dogfood-design               — design analysis, dev branch
+#
+# Only repo owners/collaborators/members can trigger this (same gate as agent.yml).
+
+name: Remote Dev Bot (dogfood)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    if: >
+      (github.event.issue || github.event.pull_request) &&
+      (startsWith(github.event.comment.body, '/dogfood-') || startsWith(github.event.comment.body, '/dogfood ') || github.event.comment.body == '/dogfood') &&
+      contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
+    uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@dev
+    with:
+      rdb_ref: dev
+      command_prefix: dogfood
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      RDB_PAT_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
+      RDB_APP_PRIVATE_KEY: ${{ secrets.RDB_APP_PRIVATE_KEY }}

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: 'main'
         type: string
+      command_prefix:
+        description: 'Command prefix the shim triggers on (e.g. "agent" for /agent-resolve, "dogfood" for /dogfood-resolve). Default: agent.'
+        required: false
+        default: 'agent'
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -91,7 +96,8 @@ jobs:
           # Supports both dash and space separators; normalizes to lowercase dashes
           # Matches up to 3 tokens (mode + optional model alias parts) to avoid capturing extra text
           # Bare "/agent" produces empty string, which config.py will reject
-          COMMAND=$(echo "$COMMENT" | grep -oP '^/agent[- ]\K[a-zA-Z0-9]+(?:[- ][a-zA-Z0-9]+){0,2}' | tr ' ' '-' || echo "")
+          PREFIX="${{ inputs.command_prefix || 'agent' }}"
+          COMMAND=$(echo "$COMMENT" | grep -oP "^/${PREFIX}[- ]\K[a-zA-Z0-9]+(?:[- ][a-zA-Z0-9]+){0,2}" | tr ' ' '-' || echo "")
           COMMAND=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
 
           python3 .remote-dev-bot/lib/config.py "$COMMAND"

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -11,6 +11,12 @@ name: Resolve Issue
 
 on:
   workflow_call:
+    inputs:
+      rdb_ref:
+        description: 'Branch or tag of remote-dev-bot to use for config and lib files. Must match the @ref used in the shim''s `uses:` line.'
+        required: false
+        default: 'main'
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -57,22 +63,12 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
-      - name: Set config ref from workflow branch
-        run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
-          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
-          WF="${{ github.workflow_ref }}"
-          BRANCH="${WF##*@}"
-          BRANCH="${BRANCH#refs/heads/}"
-          BRANCH="${BRANCH#refs/tags/}"
-          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
-
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          ref: ${{ env.RDB_CONFIG_REF }}
+          ref: ${{ inputs.rdb_ref }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml
@@ -500,22 +496,12 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v4
 
-      - name: Set config ref from workflow branch
-        run: |
-          # github.workflow_ref = "owner/repo/.github/workflows/remote-dev-bot.yml@refs/heads/dev"
-          # Extract the part after "@" and strip "refs/heads/" or "refs/tags/" prefix.
-          WF="${{ github.workflow_ref }}"
-          BRANCH="${WF##*@}"
-          BRANCH="${BRANCH#refs/heads/}"
-          BRANCH="${BRANCH#refs/tags/}"
-          echo "RDB_CONFIG_REF=${BRANCH:-main}" >> "$GITHUB_ENV"
-
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v4
         with:
           repository: gnovak/remote-dev-bot
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          ref: ${{ env.RDB_CONFIG_REF }}
+          ref: ${{ inputs.rdb_ref }}
           path: .remote-dev-bot
           sparse-checkout: |
             /remote-dev-bot.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to reso
 - `remote-dev-bot.yaml` — model aliases and OpenHands settings
 - `runbook.md` — setup instructions (designed to be followed by humans or AI assistants)
 - `.github/workflows/remote-dev-bot.yml` — the reusable workflow (all the real logic)
-- `.github/workflows/agent.yml` — thin shim that calls remote-dev-bot.yml
+- `.github/workflows/agent.yml` — thin shim that calls remote-dev-bot.yml (users copy this; points at @main)
+- `.github/workflows/dogfood.yml` — internal shim for rdb self-dev; fires on /dogfood commands, points at @dev
 - `.github/workflows/test.yml` — CI: runs pytest on PRs to main
 - `.github/workflows/e2e.yml` — manual trigger for E2E tests
 - `lib/config.py` — config parsing logic (used by remote-dev-bot.yml and unit tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,11 +115,23 @@ already covers all user customisation needs.
 
 | Branch | Purpose | Who points here |
 |--------|---------|-----------------|
-| `main` | Stable, released, tagged | External users' shims |
-| `dev` | Long-lived integration branch, accumulates work ahead of `main` | Owner's own repo shims |
+| `main` | Stable, released, tagged | External users' shims (`agent.yml@main`) |
+| `dev` | Long-lived integration branch, accumulates work ahead of `main` | `dogfood.yml@dev` (rdb self-dev) |
 | `e2e-test` | Ephemeral test pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim |
 
 **PRs go to `dev`, not `main`**, unless the change is a hotfix to something already released. When `dev` is ready to release: run the full test suite (with `e2e-test` pointing at `dev`), then merge `dev` → `main` and tag.
+
+### Dogfood shim (`dogfood.yml`)
+
+`agent.yml` in this repo points at `@main` — it is the canonical shim users copy, so it must stay stable. To test pre-release features from `dev` against rdb's own issues, use the `/dogfood` command instead of `/agent`:
+
+```
+/dogfood                        — resolve with default model (uses dev branch)
+/dogfood-resolve-claude-large   — resolve with a specific model
+/dogfood-design                 — design analysis
+```
+
+`dogfood.yml` is internal to this repo and is never distributed to users.
 
 ## Dev Cycle
 

--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -37,3 +37,4 @@ modes:
       # rdb workflows (core of the system)
       - .github/workflows/remote-dev-bot.yml
       - .github/workflows/agent.yml
+      - .github/workflows/dogfood.yml


### PR DESCRIPTION
## Summary

- `agent.yml` must point at `@main` because users copy it verbatim — so `/agent` commands on rdb's own issues always use the stable release
- `dogfood.yml` (new) fires on `/dogfood[-mode[-model]]` and calls `remote-dev-bot.yml@dev`, letting rdb test pre-release features against its own issues
- Adds `command_prefix` input to `remote-dev-bot.yml` (default: `agent`) so the parse step's regex uses the right trigger prefix
- Updates CONTRIBUTING.md (branch model table + new Dogfood shim section), AGENTS.md (Key Files), and `remote-dev-bot.local.yaml` (add `dogfood.yml` to context_files)

## Usage

```
/dogfood                        — resolve with default model (dev branch)
/dogfood-resolve-claude-large   — resolve with specific model
/dogfood-design                 — design analysis
```

## Test plan

- [ ] 173 unit tests pass
- [ ] `/dogfood-resolve` on an rdb issue triggers the dogfood workflow, creates a PR targeting `dev`
- [ ] `/agent-resolve` on the same issue still triggers `agent.yml` targeting `main` (no interference)