### PR TITLE
Fix context arg to append to mode context_files, not replace

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -361,11 +361,12 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ar
     if "prompt_prefix" in mode_config:
         result["prompt_prefix"] = mode_config["prompt_prefix"]
 
-    # Include context_files: command-line args override mode config
-    if "context_files" in args:
+    # Include context_files: command-line args append to mode config
+    # (replace semantics would force users to re-type all existing files)
+    if "context_files" in mode_config:
+        result["context_files"] = mode_config["context_files"] + args.get("context_files", [])
+    elif "context_files" in args:
         result["context_files"] = args["context_files"]
-    elif "context_files" in mode_config:
-        result["context_files"] = mode_config["context_files"]
 
     # Log command-line args if any were provided
     if args:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -834,15 +834,15 @@ def test_resolve_config_args_max_iterations(config_dir):
     assert result["max_iterations"] == 75
 
 
-def test_resolve_config_args_context_files(config_dir):
-    """args can override context_files."""
+def test_resolve_config_args_context_files_no_mode_config(config_dir):
+    """args context_files used as-is when mode has no context_files."""
     tmp_path, base_path = config_dir
     result = resolve_config(base_path, "nonexistent.yaml", "design", args={"context_files": ["custom.txt"]})
     assert result["context_files"] == ["custom.txt"]
 
 
-def test_resolve_config_args_context_files_overrides_mode_config(config_dir):
-    """args context_files should override mode's context_files."""
+def test_resolve_config_args_context_files_appends_to_mode_config(config_dir):
+    """args context_files should append to mode's context_files, not replace."""
     tmp_path, base_path = config_dir
     # Add context_files to design mode
     with open(base_path) as f:
@@ -852,7 +852,7 @@ def test_resolve_config_args_context_files_overrides_mode_config(config_dir):
         yaml.dump(config, f)
 
     result = resolve_config(base_path, "nonexistent.yaml", "design", args={"context_files": ["custom.txt"]})
-    assert result["context_files"] == ["custom.txt"]
+    assert result["context_files"] == ["README.md", "AGENTS.md", "custom.txt"]
 
 
 def test_resolve_config_args_empty_dict(config_dir):
@@ -983,12 +983,12 @@ class TestConfigMain:
         assert "alias=claude-large\n" in content
         assert "max_iterations=100\n" in content
 
-    def test_comment_body_design_with_context_override(self, tmp_path):
-        """COMMENT_BODY can override context_files for design mode."""
+    def test_comment_body_design_with_context_append(self, tmp_path):
+        """COMMENT_BODY appends context_files to mode's existing list."""
         comment = "/agent design\ncontext = custom.txt"
         content = self._call_main_with_comment(comment, tmp_path)
         assert "mode=design\n" in content
-        assert 'context_files=["custom.txt"]' in content
+        assert "custom.txt" in content
 
     def test_comment_body_invalid_command_exits_one(self, tmp_path):
         """Invalid command in COMMENT_BODY exits with code 1."""


### PR DESCRIPTION
## Problem

When a user passes `context = file.txt` in their invocation comment, it replaced the mode's `context_files` list entirely. This forced users to re-type all the files already defined in the mode config, defeating the purpose of per-invocation overrides.

## Fix

Append the user-supplied files to the mode's existing list instead:

```
# Before (replace):
mode config:  [README.md, AGENTS.md]
user arg:     [custom.txt]
result:       [custom.txt]          ← mode files lost

# After (append):
mode config:  [README.md, AGENTS.md]
user arg:     [custom.txt]
result:       [README.md, AGENTS.md, custom.txt]  ← mode files preserved
```

If the mode has no `context_files`, user-supplied files are used as-is (same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)