### PR TITLE
Fix issue #223: Add target_branch as per-invocation argument

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -46,6 +46,7 @@ ALLOWED_ARGS = {
     "max_iterations": int,  # openhands.max_iterations
     "context": list,  # mode's context_files (alias)
     "context_files": list,  # mode's context_files
+    "target_branch": str,  # openhands.target_branch
 }
 
 
@@ -351,6 +352,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ar
     # Apply command-line arg overrides
     if "max_iterations" in args:
         max_iter = args["max_iterations"]
+    if "target_branch" in args:
+        target_branch = args["target_branch"]
 
     result = {
         "mode": mode,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,6 +190,12 @@ def test_parse_args_max_iterations():
     assert parse_args(["max_iterations=50"]) == {"max_iterations": 50}
 
 
+def test_parse_args_target_branch():
+    """target_branch should be parsed as str."""
+    assert parse_args(["target_branch = design/gemini"]) == {"target_branch": "design/gemini"}
+    assert parse_args(["target branch = my-feature"]) == {"target_branch": "my-feature"}
+
+
 def test_parse_args_context_files():
     """context_files should be parsed as list."""
     assert parse_args(["context = file1.txt file2.txt"]) == {"context_files": ["file1.txt", "file2.txt"]}
@@ -913,6 +919,13 @@ def test_resolve_config_args_context_files_appends_to_mode_config(config_dir):
 
     result = resolve_config(base_path, "nonexistent.yaml", "design", args={"context_files": ["custom.txt"]})
     assert result["context_files"] == ["README.md", "AGENTS.md", "custom.txt"]
+
+
+def test_resolve_config_args_target_branch(config_dir):
+    """args can override target_branch."""
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "resolve", args={"target_branch": "design/gemini"})
+    assert result["target_branch"] == "design/gemini"
 
 
 def test_resolve_config_args_empty_dict(config_dir):


### PR DESCRIPTION
This pull request fixes #223.

Adds `target_branch` to `ALLOWED_ARGS` so users can override it per-invocation:

```
/agent resolve
target_branch = design/gemini
```

This overrides the global `target_branch` from `remote-dev-bot.yaml` for that run only, enabling parallel workstreams where each invocation lands its PR on a dedicated branch.

The arg-passing infrastructure (PR #220) was already in place — this is a one-liner addition.
