### PR TITLE
Protect explore job reference in AGENTS.md on dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to reso
 ### Key Files
 
 **Workflows** (`.github/workflows/`):
-- `remote-dev-bot.yml` — the reusable workflow; all real logic; jobs: `parse`, `resolve`, `design`, `review`, `explore`
+- `remote-dev-bot.yml` — the reusable workflow; all real logic; jobs: `parse`, `resolve`, `design`, `review`, `explore` (`explore` is dev-only, not yet released to `main`)
 - `agent.yml` — thin shim users copy into their repos; calls `remote-dev-bot.yml@main`
 - `dogfood.yml` — internal shim for rdb self-dev; fires on `/dogfood` comments; calls `remote-dev-bot.yml@dev`
 - `test.yml` — CI: runs pytest on PRs to main


### PR DESCRIPTION
## Summary

- PR #252 (fixes #250, documentation cleanup) will be merged to `main` and correctly removes the `explore` job from AGENTS.md on `main`, since the explore job does not exist on `main`.
- However, `main` and `dev` currently have identical AGENTS.md content. After PR #252 merges to `main`, a subsequent `main -> dev` merge would silently drop the `explore` reference from `dev`'s AGENTS.md too -- even though the explore job absolutely does exist on `dev` (added via PR #190/#240).
- This PR diverges `dev`'s AGENTS.md from `main`'s on that specific line by annotating it as dev-only. This means the eventual `main -> dev` merge will surface a conflict on this line rather than silently losing the note, making the situation unambiguous.

## What changed

`AGENTS.md` line 19: appended `(explore is dev-only, not yet released to main)` to the jobs list entry for `remote-dev-bot.yml`.

## Merge order

1. Merge this PR into `dev` first (or at any time -- it's independent)
2. Merge PR #252 into `main`
3. When doing `main -> dev` merge: if git produces a conflict on this line, keep the `dev` version (which has the explore annotation). If git resolves it automatically by keeping the longer/newer line, verify the result still includes `explore`.

Generated with Claude Code
