### PR TITLE
Add timeout_minutes as inline per-invocation arg

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -15,7 +15,7 @@ name: Resolve Issue
 #   context = file1.txt file2.txt
 #
 # Argument names are normalized (spaces/dashes/underscores are equivalent).
-# Supported arguments: max_iterations, context (alias for context_files).
+# Supported arguments: max_iterations, timeout_minutes, target_branch, context (alias for context_files).
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ context = extra-context.md
 | Argument | Type | Description |
 |----------|------|-------------|
 | `max iterations` | integer | Override the iteration limit for this run |
+| `timeout minutes` | integer | Override the watchdog timeout in minutes for this run |
 | `target branch` | string | Target branch for the PR (default: `main`) |
 | `context` | list | Additional context files for the agent to read (space-separated) |
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -46,6 +46,7 @@ KNOWN_PROVIDERS = ("anthropic/", "openai/", "gemini/")
 # Arguments that can be overridden via command-line args
 ALLOWED_ARGS = {
     "max_iterations": int,  # openhands.max_iterations
+    "timeout_minutes": int,  # openhands.timeout_minutes
     "context": list,  # mode's context_files (alias)
     "context_files": list,  # mode's context_files
     "target_branch": str,  # openhands.target_branch
@@ -369,6 +370,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     # Apply command-line arg overrides
     if "max_iterations" in args:
         max_iter = args["max_iterations"]
+    if "timeout_minutes" in args:
+        resolved_timeout = args["timeout_minutes"]
     if "target_branch" in args:
         target_branch = args["target_branch"]
 

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -640,9 +640,9 @@ timeout_issue_url=$(gh issue create --repo "$TEST_REPO" \
 timeout_issue_num="${timeout_issue_url##*/}"
 cleanup_issues+=("$timeout_issue_num")
 
-log "  Issue #$timeout_issue_num. Posting /agent-resolve with timeout = 5..."
+log "  Issue #$timeout_issue_num. Posting /agent-resolve with timeout_minutes = 5..."
 gh issue comment "$timeout_issue_num" --repo "$TEST_REPO" \
-    --body $'/agent-resolve\ntimeout = 5'
+    --body $'/agent-resolve\ntimeout_minutes = 5'
 
 log "  Waiting 15s for workflow to start..."
 sleep 15


### PR DESCRIPTION
Fixes Phase 3 of the e2e test suite, which was always failing because 'timeout' was not a recognized inline arg key.

Changes:
- Add timeout_minutes (int) to ALLOWED_ARGS in lib/config.py
- Apply it in resolve_config args override block (inline arg takes highest precedence)
- Fix e2e.sh Phase 3 to post timeout_minutes = 5 instead of timeout = 5
- Update workflow header comment with full supported args list
- Add timeout minutes row to README per-invocation args table

Generated with Claude Code