### PR TITLE
Fix silent failures when resolver crashes and strengthen e2e cleanup

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -66,6 +66,32 @@ jobs:
       - name: Install PyYAML
         run: pip install PyYAML
 
+      - name: Sanity check rdb-test shim
+        env:
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
+        run: |
+          # Verify that agent.yml in rdb-test is the shim (calls uses: gnovak/remote-dev-bot),
+          # not a compiled workflow. If it has been left in a compiled state (e.g., from a
+          # previous e2e-compiled run that was cancelled mid-cleanup), restore the shim now.
+          TEST_REPO="gnovak/remote-dev-bot-test"
+          echo "Checking rdb-test agent.yml..."
+          agent_content=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" --jq '.content' | base64 -d)
+          if echo "$agent_content" | grep -q "uses: gnovak/remote-dev-bot"; then
+            echo "OK: agent.yml is the shim."
+          else
+            echo "WARNING: agent.yml does not look like a shim — it may be a compiled workflow."
+            echo "Restoring shim from this repo's .github/workflows/agent.yml..."
+            shim_content=$(base64 < .github/workflows/agent.yml | tr -d '\n')
+            current_sha=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" --jq '.sha')
+            gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" \
+              --method PUT \
+              -f message="E2E sanity: restore shim before e2e-shim run" \
+              -f content="$shim_content" \
+              -f sha="$current_sha" >/dev/null
+            echo "Shim restored. Waiting 10s for GitHub to register..."
+            sleep 10
+          fi
+
       - name: Run E2E tests (shim, all models)
         env:
           GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
@@ -75,7 +101,10 @@ jobs:
     needs: [unit-tests, e2e-shim]
     if: always() && needs.unit-tests.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Longer timeout than e2e-shim: this job installs the compiled workflow, runs all-models
+    # tests, then restores the shim. The compiled workflow swap adds overhead, and we need
+    # headroom for the always-run cleanup step to complete even if tests fill the window.
+    timeout-minutes: 60
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -95,9 +124,54 @@ jobs:
         run: pip install PyYAML
 
       - name: Run E2E tests (compiled, all models)
+        # Note: install_compiled_workflow() in e2e.sh replaces rdb-test's agent.yml with
+        # the compiled workflow. The always-run "Restore shim after compiled e2e" step
+        # below handles cleanup even if this step is cancelled or the job times out.
         env:
           GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
         run: ./tests/e2e.sh --branch ${{ inputs.branch }} --compiled --all-models
+
+      - name: Restore shim after compiled e2e
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
+        run: |
+          # Always restore rdb-test's agent.yml to the shim after a compiled e2e run,
+          # even if the run was cancelled or failed. This is a belt-and-suspenders guard
+          # on top of e2e.sh's trap (which can't survive SIGKILL from a job timeout).
+          TEST_REPO="gnovak/remote-dev-bot-test"
+          echo "Checking rdb-test agent.yml after compiled e2e..."
+          agent_content=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" --jq '.content' | base64 -d 2>/dev/null || echo "")
+          if echo "$agent_content" | grep -q "uses: gnovak/remote-dev-bot"; then
+            echo "agent.yml is already the shim — no restore needed."
+          else
+            echo "agent.yml is compiled workflow — restoring shim..."
+            shim_content=$(base64 < .github/workflows/agent.yml | tr -d '\n')
+            current_sha=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" --jq '.sha' 2>/dev/null || echo "")
+            if [[ -z "$current_sha" ]]; then
+              echo "ERROR: Could not get current SHA of agent.yml — manual restore required!"
+              exit 1
+            fi
+            gh api "repos/$TEST_REPO/contents/.github/workflows/agent.yml" \
+              --method PUT \
+              -f message="E2E cleanup: restore shim after compiled e2e run" \
+              -f content="$shim_content" \
+              -f sha="$current_sha" >/dev/null
+            echo "Shim restored."
+          fi
+          # Also remove agent-design.yml if it exists (installed by e2e.sh for compiled tests)
+          design_sha=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent-design.yml" \
+            --jq '.sha' 2>/dev/null || echo "")
+          if [[ -n "$design_sha" ]]; then
+            echo "Removing agent-design.yml..."
+            gh api "repos/$TEST_REPO/contents/.github/workflows/agent-design.yml" \
+              -X DELETE \
+              -f message="E2E cleanup: remove compiled design workflow after compiled e2e run" \
+              -f sha="$design_sha" >/dev/null 2>&1 || true
+            echo "agent-design.yml removed."
+          else
+            echo "agent-design.yml not present — nothing to remove."
+          fi
 
   e2e-security:
     needs: [unit-tests, e2e-compiled]

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -263,6 +263,7 @@ jobs:
           exit $RESOLVE_EXIT_CODE
 
       - name: Create pull request
+        if: always()
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
@@ -281,33 +282,54 @@ jobs:
           # contains "Agent reached maximum iteration") because the completion
           # function (LLM call) can false-positive when the agent did substantial
           # work but ran out of iterations mid-task.
+          # When output.jsonl is missing or empty (resolver crashed), treat as unknown.
           SUCCESS=$(python3 -c "
           import json, os, sys
           path = 'output/output.jsonl'
-          if os.path.exists(path):
-              data = json.loads(open(path).read())
-              error = data.get('error') or ''
-              if 'Agent reached maximum iteration' in error:
-                  # Agent hit max iterations - treat as failure regardless of
-                  # what the completion function returned
-                  print('false')
-              else:
-                  print('true' if data.get('success') else 'false')
-          else:
+          if not os.path.exists(path):
               print('unknown')
+              sys.exit(0)
+          content = open(path).read().strip()
+          if not content:
+              print('unknown')
+              sys.exit(0)
+          data = json.loads(content)
+          error = data.get('error') or ''
+          if 'Agent reached maximum iteration' in error:
+              # Agent hit max iterations - treat as failure regardless of
+              # what the completion function returned
+              print('false')
+          else:
+              print('true' if data.get('success') else 'false')
           " 2>/dev/null || echo "unknown")
 
-          if [[ "$SUCCESS" == "false" ]]; then
+          if [[ "$SUCCESS" == "unknown" ]]; then
+            # Resolver crashed before writing output (OOM, Docker failure, API key exhausted, etc.)
+            {
+              echo "### ⚠️ Agent process exited unexpectedly"
+              echo ""
+              echo "The agent process exited unexpectedly — see run logs for details."
+              echo ""
+              echo "See the [workflow run logs]($RUN_URL) for full details."
+            } > /tmp/failure_comment.md
+
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/failure_comment.md
+
+          elif [[ "$SUCCESS" == "false" ]]; then
             # Extract the agent's self-evaluation from the output
             EXPLANATION=$(python3 -c "
           import json, os
           path = 'output/output.jsonl'
           if os.path.exists(path):
-              data = json.loads(open(path).read())
-              val = data.get('result_explanation', '') or ''
-              if isinstance(val, list):
-                  val = '\n\n'.join(str(v) for v in val)
-              print(val)
+              content = open(path).read().strip()
+              if content:
+                  data = json.loads(content)
+                  val = data.get('result_explanation', '') or ''
+                  if isinstance(val, list):
+                      val = '\n\n'.join(str(v) for v in val)
+                  print(val)
           " 2>/dev/null || echo "")
 
             # Post a comment with the agent's evaluation
@@ -488,22 +510,27 @@ jobs:
           agent_state = "unknown"
           if os.path.exists(path):
               with open(path) as f:
-                  data = json.loads(f.read().strip())
-              m = data.get("metrics", {})
-              cost = m.get("accumulated_cost", 0) or 0
-              atu = m.get("accumulated_token_usage", {})
-              input_tokens = atu.get("prompt_tokens", 0) or 0
-              output_tokens = atu.get("completion_tokens", 0) or 0
-              if cost > 0 or input_tokens > 0 or output_tokens > 0:
-                  source = "openhands"
-              error = data.get("error", "") or ""
-              success = data.get("success")
-              if "reached maximum iteration" in str(error):
-                  agent_state = "hit_limit"
-              elif success is True:
-                  agent_state = "completed"
-              elif success is False:
-                  agent_state = "failed"
+                  content = f.read().strip()
+              if not content:
+                  # Resolver crashed before writing output
+                  agent_state = "crashed"
+              else:
+                  data = json.loads(content)
+                  m = data.get("metrics", {})
+                  cost = m.get("accumulated_cost", 0) or 0
+                  atu = m.get("accumulated_token_usage", {})
+                  input_tokens = atu.get("prompt_tokens", 0) or 0
+                  output_tokens = atu.get("completion_tokens", 0) or 0
+                  if cost > 0 or input_tokens > 0 or output_tokens > 0:
+                      source = "openhands"
+                  error = data.get("error", "") or ""
+                  success = data.get("success")
+                  if "reached maximum iteration" in str(error):
+                      agent_state = "hit_limit"
+                  elif success is True:
+                      agent_state = "completed"
+                  elif success is False:
+                      agent_state = "failed"
 
           # If OpenHands metrics are empty, try LiteLLM logs
           if source == "none" or (cost == 0 and input_tokens == 0 and output_tokens == 0):
@@ -538,6 +565,7 @@ jobs:
             completed)  STATE_LABEL="✓ Completed" ;;
             hit_limit)  STATE_LABEL="⚠️ Hit iteration limit" ;;
             failed)     STATE_LABEL="✗ Agent reported failure" ;;
+            crashed)    STATE_LABEL="💥 Agent process crashed" ;;
             *)          STATE_LABEL="Unknown" ;;
           esac
 
@@ -548,6 +576,10 @@ jobs:
             echo "**Model:** \`${ALIAS}\` (${MODEL})"
             echo "**Mode:** ${MODE}"
             echo ""
+            if [[ "$AGENT_STATE" == "crashed" ]]; then
+              echo "Agent process crashed — no output data available."
+              echo ""
+            fi
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Agent outcome | ${STATE_LABEL} |"
@@ -1145,22 +1177,27 @@ jobs:
           agent_state = "unknown"
           if os.path.exists(path):
               with open(path) as f:
-                  data = json.loads(f.read().strip())
-              m = data.get("metrics", {})
-              cost = m.get("accumulated_cost", 0) or 0
-              atu = m.get("accumulated_token_usage", {})
-              input_tokens = atu.get("prompt_tokens", 0) or 0
-              output_tokens = atu.get("completion_tokens", 0) or 0
-              if cost > 0 or input_tokens > 0 or output_tokens > 0:
-                  source = "openhands"
-              error = data.get("error", "") or ""
-              success = data.get("success")
-              if "reached maximum iteration" in str(error):
-                  agent_state = "hit_limit"
-              elif success is True:
-                  agent_state = "completed"
-              elif success is False:
-                  agent_state = "failed"
+                  content = f.read().strip()
+              if not content:
+                  # Resolver crashed before writing output
+                  agent_state = "crashed"
+              else:
+                  data = json.loads(content)
+                  m = data.get("metrics", {})
+                  cost = m.get("accumulated_cost", 0) or 0
+                  atu = m.get("accumulated_token_usage", {})
+                  input_tokens = atu.get("prompt_tokens", 0) or 0
+                  output_tokens = atu.get("completion_tokens", 0) or 0
+                  if cost > 0 or input_tokens > 0 or output_tokens > 0:
+                      source = "openhands"
+                  error = data.get("error", "") or ""
+                  success = data.get("success")
+                  if "reached maximum iteration" in str(error):
+                      agent_state = "hit_limit"
+                  elif success is True:
+                      agent_state = "completed"
+                  elif success is False:
+                      agent_state = "failed"
 
           # If OpenHands metrics are empty, try LiteLLM logs
           if source == "none" or (cost == 0 and input_tokens == 0 and output_tokens == 0):
@@ -1193,6 +1230,7 @@ jobs:
             completed)  STATE_LABEL="✓ Completed" ;;
             hit_limit)  STATE_LABEL="⚠️ Hit iteration limit" ;;
             failed)     STATE_LABEL="✗ Agent reported failure" ;;
+            crashed)    STATE_LABEL="💥 Agent process crashed" ;;
             *)          STATE_LABEL="Unknown" ;;
           esac
 
@@ -1203,6 +1241,10 @@ jobs:
             echo "**Model:** \`${ALIAS}\` (${MODEL})"
             echo "**Mode:** ${MODE}"
             echo ""
+            if [[ "$AGENT_STATE" == "crashed" ]]; then
+              echo "Agent process crashed — no output data available."
+              echo ""
+            fi
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Agent outcome | ${STATE_LABEL} |"


### PR DESCRIPTION
## Summary

- **Bug A**: The "Create pull request" step had no `if: always()`, so when the resolver process exited non-zero (OOM kill, API exhaustion, Docker failure), GitHub Actions skipped the step entirely — leaving zero feedback on the issue. Now posts a "process exited unexpectedly" comment in that case. Also guards `output.jsonl` reads against missing/empty file.
- **Bug B**: The "Calculate and post cost" steps (resolve and review jobs) called `json.loads(f.read().strip())` directly, crashing with `JSONDecodeError` when the file was empty. Now reads content first, guards on empty, and sets `agent_state="crashed"` to post a graceful cost comment.
- **e2e-shim sanity check**: New step at the start of `e2e-shim` that verifies rdb-test's `agent.yml` is the shim. Auto-restores it if a previous compiled run was cancelled before cleanup finished.
- **e2e-compiled always-run cleanup**: New `if: always()` step at the end of `e2e-compiled` that restores the shim and removes `agent-design.yml`, even when the job is cancelled or times out (belt-and-suspenders on top of e2e.sh EXIT trap, which cannot survive SIGKILL).
- **e2e-compiled timeout**: Increased from 30 to 60 minutes to give headroom for the always-run cleanup step after a full all-models run.

## Test plan

- [x] `python -m pytest tests/ -q` -- 269 passed
- [x] `bash -n tests/e2e.sh` -- syntax OK
- [ ] Verify "Create pull request" posts comment when resolver crashes (requires a real crash scenario in CI)
- [ ] Verify cost step posts gracefully when output.jsonl is empty
- [ ] Verify sanity check detects and restores compiled workflow in rdb-test

Generated with [Claude Code](https://claude.com/claude-code)