### PR TITLE
Consolidate design prompt: remove prompt_prefix, add additional_instructions

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -702,18 +702,12 @@ jobs:
 
           model = "${{ needs.parse.outputs.model }}"
 
-          # Load prompt_prefix from config
-          prompt_prefix = ""
-          config_path = ".remote-dev-bot/lib/../remote-dev-bot.yaml"
-          # Try the target repo's override first, fall back to base config
-          for path in ["remote-dev-bot.yaml", ".remote-dev-bot/remote-dev-bot.yaml"]:
-              if os.path.exists(path):
-                  with open(path) as f:
-                      cfg = yaml.safe_load(f) or {}
-                  mode_cfg = cfg.get("modes", {}).get("design", {})
-                  if "prompt_prefix" in mode_cfg:
-                      prompt_prefix = mode_cfg["prompt_prefix"]
-                      break
+          # Load additional_instructions from target repo's config (appended to canonical prompt)
+          additional_instructions = ""
+          if os.path.exists("remote-dev-bot.yaml"):
+              with open("remote-dev-bot.yaml") as f:
+                  cfg = yaml.safe_load(f) or {}
+              additional_instructions = cfg.get("modes", {}).get("design", {}).get("additional_instructions", "")
 
           # Generate repository file listing (tracked files only)
           import subprocess
@@ -750,14 +744,24 @@ jobs:
           {comments}
           """
 
-          system_prompt = prompt_prefix or (
+          system_prompt = (
               "You are analyzing a GitHub issue for design discussion. "
-              "Provide thoughtful analysis, surface trade-offs, suggest approaches, "
-              "and ask clarifying questions. Format your response as markdown suitable "
-              "for a GitHub comment. "
+              "Do NOT write code or open a PR. Instead, provide thoughtful "
+              "analysis, surface trade-offs, suggest approaches, and ask "
+              "clarifying questions. Respond in a GitHub comment. "
               "IMPORTANT: Never begin your response with a slash command like /agent "
-              "or any text that could trigger another bot action."
+              "or any text that could trigger another bot action. "
+              "Do NOT end your response with conversational invitations like "
+              '"Want me to elaborate?" or "Let me know if you have questions." '
+              "Your response is a design document, not a chat message. "
+              "IMPORTANT: You have been given a limited set of context files. If the "
+              "issue touches code or behavior you cannot verify from those files, say "
+              "so explicitly. Do NOT invent function names, describe behavior you "
+              "haven't seen, or assume how unshared code works. Acknowledging what "
+              "you cannot see is more useful than a confident answer based on guesses."
           )
+          if additional_instructions:
+              system_prompt += "\n\n" + additional_instructions
 
           if repo_context:
               system_prompt = "# Repository Context\n" + repo_context + "\n\n# Instructions\n\n" + system_prompt

--- a/lib/config.py
+++ b/lib/config.py
@@ -391,9 +391,9 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         "timeout_minutes": resolved_timeout,
     }
 
-    # Include prompt_prefix if the mode defines one
-    if "prompt_prefix" in mode_config:
-        result["prompt_prefix"] = mode_config["prompt_prefix"]
+    # Include additional_instructions if the mode defines one (appended to canonical prompt)
+    if "additional_instructions" in mode_config:
+        result["additional_instructions"] = mode_config["additional_instructions"]
 
     # Include context_files: command-line args append to mode config
     # (replace semantics would force users to re-type all existing files)

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -28,37 +28,15 @@ modes:
       - .gemini/GEMINI.md
       - .openhands/microagents/repo.md
       - how-it-works.md
-    prompt_prefix: >
-      You are analyzing this issue for design discussion.
-      Do NOT write code or open a PR. Instead, provide thoughtful
-      analysis, surface trade-offs, suggest approaches, and ask
-      clarifying questions. Respond in a GitHub comment.
-      IMPORTANT: Never begin your response with a slash command like /agent
-      or any text that could trigger another bot action.
-      Do NOT end your response with conversational invitations like
-      "Want me to elaborate?" or "Let me know if you have questions."
-      Your response is a design document, not a chat message.
-      IMPORTANT: You have been given a limited set of context files. If the
-      issue touches code or behavior you cannot verify from those files, say
-      so explicitly. Do NOT invent function names, describe behavior you
-      haven't seen, or assume how unshared code works. Acknowledging what
-      you cannot see is more useful than a confident answer based on guesses.
+    # Optional: additional_instructions appended to the canonical design prompt.
+    # Use this to add project-specific guidance (e.g., preferred patterns,
+    # areas to focus on, or terminology). Do not duplicate the base prompt.
+    # additional_instructions: |
+    #   When analyzing issues, always consider the impact on our deploy pipeline.
 
   review:
     action: review            # Run OpenHands on the PR, post review as a PR comment (no code changes)
     default_model: claude-small
-    prompt_prefix: >
-      You are reviewing this pull request. Provide a substantive critique:
-      what is strong, what is weak or unclear, what you would change and why.
-      Be specific — quote or reference actual content rather than speaking
-      in generalities. Do NOT simply summarize the changes (the diff is already
-      visible in the PR). Do NOT describe changes as addressing prior review
-      feedback unless you can see an explicit prior review comment in the PR
-      thread. IMPORTANT: Never begin your response with a slash command like
-      /agent or any text that could trigger another bot action. Do NOT end
-      with conversational invitations like "Want me to elaborate?" or "Let me
-      know if you have questions." Your response is a review document, not a
-      chat message.
 
 models:
   claude-small:

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -381,10 +381,8 @@ def compile_design(shim, workflow, config_yaml, output_path):
     security_roles = extract_security_gate(shim)
     design_steps = workflow["jobs"]["design"]["steps"]
 
-    # Build the prompt_prefix as a Python string for inlining
     modes_config = config_yaml.get("modes", {})
     design_config = modes_config.get("design", {})
-    prompt_prefix = design_config.get("prompt_prefix", "")
 
     steps = []
 
@@ -440,30 +438,9 @@ def compile_design(shim, workflow, config_yaml, output_path):
     gather_step["env"]["GH_TOKEN"] = "${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}"
     steps.append(gather_step)
 
-    # Call LLM for design analysis — rewrite to inline prompt_prefix and context_files
+    # Call LLM for design analysis — rewrite to inline context_files
     llm_step = find_step(design_steps, "Call LLM for design analysis").copy()
-    # The step reads prompt_prefix from config files on disk. In compiled mode,
-    # we inline it. Replace the config-loading Python code.
-    if prompt_prefix:
-        escaped_prefix = prompt_prefix.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
-    else:
-        escaped_prefix = ""
     llm_run = llm_step.get("run", "")
-    # Replace the config-loading block with a simple variable assignment
-    # Note: re.sub interprets backslash sequences in the replacement string,
-    # so we need to escape backslashes again to preserve \n as literal \n
-    replacement = f'prompt_prefix = "{escaped_prefix}"\n'
-    replacement_escaped = replacement.replace('\\', '\\\\')
-    llm_run = re.sub(
-        r'# Load prompt_prefix from config.*?break\n',
-        replacement_escaped,
-        llm_run,
-        flags=re.DOTALL,
-    )
-    # Remove the remote-dev-bot checkout reference
-    llm_run = llm_run.replace(
-        'config_path = ".remote-dev-bot/lib/../remote-dev-bot.yaml"\n', ''
-    )
     # Inline the context_files list (compiled workflows can't read from config at runtime)
     context_files = design_config.get("context_files", [])
     context_files_repr = repr(context_files)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -169,27 +169,6 @@ def test_design_has_inlined_context_files(compiled_dir):
     assert 'CONTEXT_FILES' not in content
 
 
-def test_design_prompt_prefix_has_valid_python_syntax(compiled_dir):
-    """Compiled design workflow's prompt_prefix should be valid Python syntax.
-
-    Regression test for: prompt_prefix with newlines was causing
-    'SyntaxError: unterminated string literal' because re.sub was
-    interpreting \\n as a newline character in the replacement string.
-    """
-    import re
-    content = _read_text(compiled_dir / "agent-design.yml")
-
-    # Find the prompt_prefix assignment line
-    match = re.search(r'prompt_prefix = "([^"]*(?:\\.[^"]*)*)"', content)
-    assert match is not None, "Could not find prompt_prefix assignment"
-
-    # The string should be on a single line (no literal newlines inside)
-    prompt_line = match.group(0)
-    assert '\n' not in prompt_line, (
-        "prompt_prefix contains a literal newline, which would cause a Python syntax error. "
-        "The \\n escape sequence should be preserved as literal backslash-n."
-    )
-
 
 # --- Cost transparency ---
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -428,7 +428,7 @@ def config_dir(tmp_path):
             "design": {
                 "action": "comment",
                 "default_model": "claude-small",
-                "prompt_prefix": "You are analyzing this issue.",
+                "additional_instructions": "Focus on scalability.",
             },
             "review": {
                 "action": "review",
@@ -468,8 +468,8 @@ def test_resolve_config_design_mode(config_dir):
     assert result["mode"] == "design"
     assert result["action"] == "comment"
     assert result["alias"] == "claude-small"
-    assert "prompt_prefix" in result
-    assert "analyzing" in result["prompt_prefix"]
+    assert "additional_instructions" in result
+    assert "scalability" in result["additional_instructions"]
 
 
 def test_resolve_config_design_with_model(config_dir):
@@ -585,11 +585,11 @@ def test_resolve_config_no_context_files_for_resolve(config_dir):
     assert "context_files" not in result
 
 
-def test_resolve_config_no_prompt_prefix_for_resolve(config_dir):
-    """Resolve mode should not have a prompt_prefix."""
+def test_resolve_config_no_additional_instructions_for_resolve(config_dir):
+    """Resolve mode should not have additional_instructions."""
     tmp_path, base_path = config_dir
     result = resolve_config(base_path, "nonexistent.yaml", "resolve")
-    assert "prompt_prefix" not in result
+    assert "additional_instructions" not in result
 
 
 def test_resolve_config_openhands_defaults():

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -237,15 +237,16 @@ def test_design_mode_has_context_files(bot_config):
     assert len(design_mode["context_files"]) > 0, "context_files should not be empty"
 
 
-def test_design_prompt_has_loop_prevention(bot_config):
-    """Verify the design mode prompt instructs LLM not to start with /agent."""
-    design_mode = bot_config["modes"]["design"]
-    prompt_prefix = design_mode.get("prompt_prefix", "")
-    assert "/agent" in prompt_prefix.lower(), (
-        "Design mode prompt_prefix should warn against starting with /agent"
+def test_design_prompt_has_loop_prevention(resolve_yml):
+    """Verify the design mode canonical prompt instructs LLM not to start with /agent.
+
+    The canonical prompt lives in the workflow, not in remote-dev-bot.yaml.
+    """
+    assert "/agent" in resolve_yml.lower(), (
+        "Design mode canonical prompt should warn against starting with /agent"
     )
-    assert "never" in prompt_prefix.lower() or "do not" in prompt_prefix.lower(), (
-        "Design mode prompt_prefix should contain prohibition language"
+    assert "never begin your response with a slash command" in resolve_yml.lower(), (
+        "Design mode canonical prompt should contain loop-prevention language"
     )
 
 


### PR DESCRIPTION
## Summary

- The design mode prompt was split across two places: hardcoded fallback in the workflow AND \`prompt_prefix\` in \`remote-dev-bot.yaml\`. A target repo could set \`prompt_prefix\` to fully replace the prompt, bypassing safety instructions (\`/agent\` loop prevention, etc.)
- The review mode had a dead \`prompt_prefix\` in config that was never read (review uses a hardcoded \`REVIEW_EOF\` heredoc in the workflow)

**After this PR:**
- Canonical design prompt lives exclusively in the workflow — one place, owned by RDB
- Users extend it via \`additional_instructions\` in their \`remote-dev-bot.yaml\`, which is *appended* (not replacing)
- \`prompt_prefix\` removed from \`remote-dev-bot.yaml\` for both modes
- \`compile.py\` prompt inlining logic removed (no longer needed)
- \`lib/config.py\`: \`prompt_prefix\` → \`additional_instructions\`

## Test plan

- [x] 272 tests pass
- [x] Canonical prompt is richer than the old hardcoded fallback (uses yaml version as the base)
- [x] \`additional_instructions\` example shown as a comment in \`remote-dev-bot.yaml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)