### PR TITLE
Code review batch 1: workflow fixes, config cleanup, YAML restructure

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -28,7 +28,7 @@ jobs:
   resolve:
     if: >
       (github.event.issue || github.event.pull_request) &&
-      (startsWith(github.event.comment.body, '/dogfood-') || startsWith(github.event.comment.body, '/dogfood ') || github.event.comment.body == '/dogfood') &&
+      (startsWith(github.event.comment.body, '/dogfood-') || startsWith(github.event.comment.body, '/dogfood ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@dev
     with:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,7 +47,7 @@ jobs:
   e2e-shim:
     needs: unit-tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1,4 +1,4 @@
-name: Resolve Issue
+name: Remote Dev Bot
 
 # Reusable workflow — called by thin shims in target repos.
 # See .github/workflows/agent.yml for the shim template.
@@ -26,7 +26,7 @@ on:
         default: 'main'
         type: string
       command_prefix:
-        description: 'Command prefix the shim triggers on (e.g. "agent" for /agent-resolve, "dogfood" for /dogfood-resolve). Default: agent.'
+        description: 'Command prefix the shim triggers on (e.g. "agent" for /agent-resolve). Default: agent.'
         required: false
         default: 'agent'
         type: string
@@ -160,6 +160,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -662,6 +667,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -684,8 +694,8 @@ jobs:
           ISSUE_TITLE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
           ISSUE_BODY=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('body','') or '')")
 
-          # Fetch recent comments (last 10)
-          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=10&direction=desc")
+          # Fetch all comments (up to 100 — GitHub API max per page)
+          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=100")
           COMMENTS=$(echo "$COMMENTS_JSON" | python3 -c "
           import sys, json
           comments = json.load(sys.stdin)
@@ -958,6 +968,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -1105,10 +1120,20 @@ jobs:
           import json, os
           path = 'output/output.jsonl'
           if os.path.exists(path):
-              data = json.loads(open(path).read())
+              # output.jsonl is JSON Lines — read the last line (the final result)
+              lines = open(path).read().strip().splitlines()
+              data = json.loads(lines[-1]) if lines else {}
               val = data.get('result_explanation', '') or ''
+              # result_explanation may be a list or a JSON-encoded list string
               if isinstance(val, list):
                   val = '\n\n'.join(str(v) for v in val)
+              elif isinstance(val, str) and val.startswith('['):
+                  try:
+                      items = json.loads(val)
+                      if isinstance(items, list):
+                          val = '\n\n'.join(str(v) for v in items)
+                  except json.JSONDecodeError:
+                      pass
               print(val)
           " 2>/dev/null || echo "")
           fi
@@ -1331,6 +1356,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -1353,8 +1383,8 @@ jobs:
           ISSUE_TITLE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
           ISSUE_BODY=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('body','') or '')")
 
-          # Fetch recent comments (last 10)
-          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=10&direction=desc")
+          # Fetch all comments (up to 100 — GitHub API max per page)
+          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=100")
           COMMENTS=$(echo "$COMMENTS_JSON" | python3 -c "
           import sys, json
           comments = json.load(sys.stdin)

--- a/lib/config.py
+++ b/lib/config.py
@@ -4,16 +4,16 @@ Loads base config from remote-dev-bot repo, merges with optional
 per-repo override config, resolves model aliases and modes, and writes
 GitHub Actions outputs.
 
-Commands follow the pattern: /agent-<verb>[-<model>] [--timeout N]
-  /agent-resolve           — resolve mode, default model
+Commands follow the pattern: /agent-<verb>[-<model>]
+  /agent-resolve              — resolve mode, default model
   /agent-resolve-claude-large — resolve mode, specific model
-  /agent-design            — design mode, default model
-  /agent-resolve --timeout 120 — resolve mode, override timeout to 120 minutes
+  /agent-design               — design mode, default model
 
 Arguments can be passed on subsequent lines:
   /agent resolve
-  max iterations = 75
-  context = file1.txt file2.txt
+  max_iterations = 75
+  context_files = file1.txt file2.txt
+  timeout_minutes = 60
 
 Argument names are normalized (spaces/dashes/underscores are equivalent).
 Values after = can be single values or space-separated lists.
@@ -43,11 +43,12 @@ def deep_merge(base, override):
 
 KNOWN_PROVIDERS = ("anthropic/", "openai/", "gemini/")
 
-# Arguments that can be overridden via command-line args
+DEFAULT_TIMEOUT_MINUTES = 120
+
+# Arguments that can be overridden via inline args (lines after the command)
 ALLOWED_ARGS = {
     "max_iterations": int,  # openhands.max_iterations
     "timeout_minutes": int,  # openhands.timeout_minutes
-    "context": list,  # mode's context_files (alias)
     "context_files": list,  # mode's context_files
     "target_branch": str,  # openhands.target_branch
 }
@@ -79,7 +80,7 @@ def parse_args(lines):
     {'max_iterations': 75}
     >>> parse_args(["max-iterations = 100"])
     {'max_iterations': 100}
-    >>> parse_args(["context = file1.txt file2.txt"])
+    >>> parse_args(["context_files = file1.txt file2.txt"])
     {'context_files': ['file1.txt', 'file2.txt']}
     >>> parse_args(["context files = README.md"])
     {'context_files': ['README.md']}
@@ -102,10 +103,6 @@ def parse_args(lines):
 
         if not name or not value:
             continue
-
-        # Map 'context' alias to 'context_files'
-        if name == "context":
-            name = "context_files"
 
         if name not in ALLOWED_ARGS:
             raise ValueError(
@@ -142,7 +139,7 @@ def parse_invocation(comment_body, known_modes, command_prefix="agent"):
     ('resolve', 'claude-large', {})
     >>> parse_invocation("/agent resolve\\nmax iterations = 75", {"resolve", "design"})
     ('resolve', '', {'max_iterations': 75})
-    >>> parse_invocation("/agent-design-claude-small\\ncontext = a.txt b.txt", {"resolve", "design"})
+    >>> parse_invocation("/agent-design-claude-small\\ncontext_files = a.txt b.txt", {"resolve", "design"})
     ('design', 'claude-small', {'context_files': ['a.txt', 'b.txt']})
     >>> parse_invocation("/dogfood resolve", {"resolve", "design"}, command_prefix="dogfood")
     ('resolve', '', {})
@@ -256,9 +253,6 @@ def resolve_commit_trailer(template, alias, model_id, oh_version):
         model_id=model_id,
         oh_version=oh_version,
     )
-
-
-DEFAULT_TIMEOUT_MINUTES = 120
 
 
 def resolve_config(base_path, override_path, command_string, local_path=None, timeout_minutes=None, args=None):
@@ -429,8 +423,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     if "max_iterations" in mode_config:
         result["explore_max_iterations"] = mode_config["max_iterations"]
 
-    # Resolve commit_trailer template (for resolve mode)
-    commit_trailer_template = config.get("commit_trailer", "")
+    # Resolve commit_trailer template (for resolve mode) — lives under openhands:
+    commit_trailer_template = config.get("openhands", {}).get("commit_trailer", "")
     result["commit_trailer"] = resolve_commit_trailer(
         commit_trailer_template, alias, model_id, oh_version
     )

--- a/lib/config.py
+++ b/lib/config.py
@@ -308,6 +308,11 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         print("Local extension (remote-dev-bot.local.yaml):")
         print(yaml.dump(local_config, default_flow_style=False, sort_keys=False).rstrip())
         print()
+    if args:
+        print("Runtime args (from comment body):")
+        for k, v in args.items():
+            print(f"  {k} = {v}")
+        print()
     print("Merged:")
     print(yaml.dump(config, default_flow_style=False, sort_keys=False).rstrip())
     print("===================")

--- a/lib/feedback.py
+++ b/lib/feedback.py
@@ -19,6 +19,14 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Optional
 
+# Repository where installation feedback issues are filed.
+# If you fork remote-dev-bot, update this to your fork's repo path.
+# All report_problems() callers accept a repo= parameter to override.
+DEFAULT_REPO = "gnovak/remote-dev-bot"
+
+# Maximum individual issues to file per install; beyond this, file a summary issue.
+MAX_ISSUES_PER_INSTALL = 3
+
 
 @dataclass
 class InstallProblem:
@@ -145,11 +153,6 @@ class InstallReport:
     def to_json(self) -> str:
         """Convert to JSON string."""
         return json.dumps(self.to_dict(), indent=2)
-
-
-# Default repository for filing issues
-DEFAULT_REPO = "gnovak/remote-dev-bot"
-MAX_ISSUES_PER_INSTALL = 3
 
 
 def get_environment_info() -> dict:

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -1,25 +1,20 @@
 # Remote Dev Bot Configuration
 # Usage: /agent-<mode>[-<model>]
-#   /agent-resolve             — resolve issue, open PR (default model)
+#   /agent-resolve              — resolve issue, open PR (default model)
 #   /agent-resolve-claude-large — resolve issue with specific model
-#   /agent-design              — design discussion, post comment
+#   /agent-design               — design discussion, post comment
 #   /agent-design-claude-large  — design discussion with specific model
+#   /agent-review               — code review on a PR, post comment
+#   /agent-review-claude-large  — code review with specific model
 
 default_model: claude-small
-
-# Commit trailer appended to OpenHands commits (resolve mode only).
-# Supported variables: {model_alias}, {model_id}, {oh_version}
-# Set to empty string to disable.
-commit_trailer: "Model: {model_alias} ({model_id}), openhands-ai v{oh_version}"
 
 # Modes define what the agent does. Each mode has an action and optional defaults.
 modes:
   resolve:
     action: pr               # Run OpenHands, open a draft PR
-    default_model: claude-small
   design:
     action: comment           # Post analysis as an issue comment (no code changes)
-    default_model: claude-small
     context_files:
       - README.md
       - CONTRIBUTING.md
@@ -36,7 +31,6 @@ modes:
 
   review:
     action: review            # Run OpenHands on the PR, post review as a PR comment (no code changes)
-    default_model: claude-small
 
   explore:
     action: explore           # Multi-round agentic loop with tool calling for design analysis
@@ -50,7 +44,7 @@ modes:
       - .gemini/GEMINI.md
       - .openhands/microagents/repo.md
       - how-it-works.md
-    prompt_prefix: >
+    additional_instructions: >
       You are analyzing this issue for design discussion using an agentic exploration loop.
       You have access to tools to read files and search the codebase.
       Use these tools to gather the information you need before providing your analysis.
@@ -109,10 +103,10 @@ openhands:
   assign_pr: true
   # Watchdog timeout in minutes. The runner kills the OpenHands process after this
   # many minutes, then cleanup steps (cost report, artifact upload) still run.
-  # Override per-invocation with: timeout = 120 (inline arg in comment body)
+  # Override per-invocation with: timeout_minutes = 60 (inline arg in comment body)
   # Note: GitHub Actions has a hard 6-hour cap. If you need longer runs, set
   # timeout-minutes in your calling workflow's job definition.
-  timeout_minutes: 120
+  timeout_minutes: 60
   # Graceful wrap-up: inject instructions when approaching max iterations
   # This helps the agent commit partial work before hitting the limit
   graceful_wrapup:
@@ -121,3 +115,9 @@ openhands:
     # Threshold as fraction of max_iterations (0.8 = 80%)
     # At this point, the agent receives instructions to wrap up
     threshold: 0.8
+  # Commit trailer appended to OpenHands commits (resolve mode only).
+  # Supported variables: {model_alias}, {model_id}, {oh_version}
+  # Set to empty string to disable.
+  # Note: the amend step does `git commit --amend` after OpenHands pushes,
+  # which requires a force-push to update the branch.
+  commit_trailer: "Model: {model_alias} ({model_id}), openhands-ai v{oh_version}"

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -91,8 +91,8 @@ def inline_config_parsing(config_yaml, mode):
     assign_issue = oh.get("assign_issue", True)
     assign_pr = oh.get("assign_pr", True)
 
-    # Commit trailer template (resolve mode only)
-    commit_trailer_template = config_yaml.get("commit_trailer", "")
+    # Commit trailer template (resolve mode only) — lives under openhands:
+    commit_trailer_template = config_yaml.get("openhands", {}).get("commit_trailer", "")
     # Escape for Python string literal
     commit_trailer_escaped = commit_trailer_template.replace('\\', '\\\\').replace('"', '\\"')
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -200,8 +200,12 @@ def test_design_comment_footer_includes_model(compiled_dir):
     assert "(${MODEL})_" in content or "(${{ steps.parse.outputs.model }})_" in content
     # Also check the blocked case footer
     assert "_Blocked by " in content
-    # Verify MODEL variable is assigned in the Post comment step
-    assert 'MODEL="${{ steps.parse.outputs.model }}"' in content
+    # Verify MODEL variable is assigned in the Post comment step.
+    # May appear as a block scalar (unescaped) or quoted YAML string (escaped).
+    assert (
+        'MODEL="${{ steps.parse.outputs.model }}"' in content
+        or r'MODEL=\"${{ steps.parse.outputs.model }}\"' in content
+    )
 
 
 # --- Both: model aliases ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,22 +205,17 @@ def test_parse_args_target_branch():
 
 
 def test_parse_args_context_files():
-    """context_files should be parsed as list."""
-    assert parse_args(["context = file1.txt file2.txt"]) == {"context_files": ["file1.txt", "file2.txt"]}
+    """context_files should be parsed as list (various normalized name forms)."""
+    assert parse_args(["context_files = file1.txt file2.txt"]) == {"context_files": ["file1.txt", "file2.txt"]}
     assert parse_args(["context files = README.md"]) == {"context_files": ["README.md"]}
     assert parse_args(["context-files = a.txt b.txt c.txt"]) == {"context_files": ["a.txt", "b.txt", "c.txt"]}
-
-
-def test_parse_args_context_alias():
-    """'context' should be an alias for 'context_files'."""
-    assert parse_args(["context = file.txt"]) == {"context_files": ["file.txt"]}
 
 
 def test_parse_args_multiple():
     """Multiple args should all be parsed."""
     result = parse_args([
         "max iterations = 75",
-        "context = file1.txt file2.txt",
+        "context_files = file1.txt file2.txt",
     ])
     assert result == {
         "max_iterations": 75,
@@ -234,7 +229,7 @@ def test_parse_args_skip_empty_lines():
         "",
         "max iterations = 75",
         "",
-        "context = file.txt",
+        "context_files = file.txt",
         "",
     ])
     assert result == {
@@ -258,7 +253,7 @@ def test_parse_args_skip_lines_without_equals():
     result = parse_args([
         "max iterations = 75",
         "some random text",
-        "context = file.txt",
+        "context_files = file.txt",
     ])
     assert result == {
         "max_iterations": 75,
@@ -286,7 +281,7 @@ def test_parse_args_empty_name():
 
 def test_parse_args_empty_value():
     """Lines with empty value after = should be skipped."""
-    result = parse_args(["max iterations =", "context = file.txt"])
+    result = parse_args(["max iterations =", "context_files = file.txt"])
     assert result == {"context_files": ["file.txt"]}
 
 
@@ -298,7 +293,7 @@ def test_parse_args_whitespace_only_name():
 
 def test_parse_args_whitespace_only_value():
     """Lines with whitespace-only value should be skipped."""
-    result = parse_args(["max iterations =   ", "context = file.txt"])
+    result = parse_args(["max iterations =   ", "context_files = file.txt"])
     assert result == {"context_files": ["file.txt"]}
 
 
@@ -335,7 +330,7 @@ def test_parse_invocation_with_args():
 
 def test_parse_invocation_with_model_and_args():
     """Command with model and args."""
-    comment = "/agent resolve claude-large\nmax iterations = 100\ncontext = file.txt"
+    comment = "/agent resolve claude-large\nmax iterations = 100\ncontext_files = file.txt"
     mode, alias, args = parse_invocation(comment, KNOWN_MODES)
     assert mode == "resolve"
     assert alias == "claude-large"
@@ -344,7 +339,7 @@ def test_parse_invocation_with_model_and_args():
 
 def test_parse_invocation_dash_syntax():
     """Dash syntax should work with args."""
-    comment = "/agent-design-claude-small\ncontext = a.txt b.txt"
+    comment = "/agent-design-claude-small\ncontext_files = a.txt b.txt"
     mode, alias, args = parse_invocation(comment, KNOWN_MODES)
     assert mode == "design"
     assert alias == "claude-small"
@@ -438,7 +433,7 @@ def config_dir(tmp_path):
                 "action": "explore",
                 "default_model": "claude-small",
                 "max_iterations": 10,
-                "prompt_prefix": "You are exploring this issue.",
+                "additional_instructions": "You are exploring this issue.",
                 "context_files": ["README.md", "AGENTS.md"],
             },
         },
@@ -510,8 +505,8 @@ def test_resolve_config_explore_mode(config_dir):
     assert result["action"] == "explore"
     assert result["alias"] == "claude-small"
     assert result["model"] == "anthropic/claude-sonnet-4-5"
-    assert "prompt_prefix" in result
-    assert "exploring" in result["prompt_prefix"]
+    assert "additional_instructions" in result
+    assert "exploring" in result["additional_instructions"]
     assert "context_files" in result
     assert result["context_files"] == ["README.md", "AGENTS.md"]
     assert "explore_max_iterations" in result
@@ -890,8 +885,7 @@ def test_resolve_config_commit_trailer_with_template():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "openhands": {"version": "1.3.0"},
-                "commit_trailer": "Model: {model_alias} ({model_id}), v{oh_version}",
+                "openhands": {"version": "1.3.0", "commit_trailer": "Model: {model_alias} ({model_id}), v{oh_version}"},
             },
             f,
         )
@@ -911,8 +905,7 @@ def test_resolve_config_commit_trailer_override():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "openhands": {"version": "1.3.0"},
-                "commit_trailer": "Base trailer: {model_alias}",
+                "openhands": {"version": "1.3.0", "commit_trailer": "Base trailer: {model_alias}"},
             },
             base_f,
         )
@@ -921,7 +914,7 @@ def test_resolve_config_commit_trailer_override():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as override_f:
         yaml.dump(
             {
-                "commit_trailer": "Override trailer: {model_id}",
+                "openhands": {"commit_trailer": "Override trailer: {model_id}"},
             },
             override_f,
         )
@@ -943,7 +936,7 @@ def test_resolve_config_commit_trailer_disable_via_override():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "commit_trailer": "Base trailer: {model_alias}",
+                "openhands": {"commit_trailer": "Base trailer: {model_alias}"},
             },
             base_f,
         )
@@ -952,7 +945,7 @@ def test_resolve_config_commit_trailer_disable_via_override():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as override_f:
         yaml.dump(
             {
-                "commit_trailer": "",
+                "openhands": {"commit_trailer": ""},
             },
             override_f,
         )
@@ -1338,7 +1331,7 @@ class TestConfigMain:
 
     def test_comment_body_design_with_context_append(self, tmp_path):
         """COMMENT_BODY appends context_files to mode's existing list."""
-        comment = "/agent design\ncontext = custom.txt"
+        comment = "/agent design\ncontext_files = custom.txt"
         content = self._call_main_with_comment(comment, tmp_path)
         assert "mode=design\n" in content
         assert "custom.txt" in content
@@ -1363,9 +1356,9 @@ class TestConfigMain:
         assert "alias=claude-large\n" in content
 
     def test_timeout_minutes_default_when_not_specified(self, tmp_path):
-        """timeout_minutes is the hardcoded default (120) when not specified."""
+        """timeout_minutes comes from the config file (60) when not overridden."""
         content = self._call_main("resolve", tmp_path)
-        assert "timeout_minutes=120\n" in content
+        assert "timeout_minutes=60\n" in content
 
     def test_timeout_minutes_value_when_specified(self, tmp_path):
         """timeout_minutes contains the per-invocation value when specified."""


### PR DESCRIPTION
## Summary

Addresses ~30 of the 47 items from the code review. This PR covers code/config changes; a companion docs PR will follow.

**Workflow fixes:**
- `dogfood.yml`: Remove dead `== '/dogfood'` check -- bare command is rejected by config.py before it gets here
- `full-test-suite.yml`: Bump unit-tests timeout 5->10 min, e2e-shim 30->60 min
- `remote-dev-bot.yml`: Rename workflow to "Remote Dev Bot", simplify `command_prefix` desc, add GITHUB_OUTPUT masking explanation to API key steps, fix issue comment fetch to `per_page=100`, fix review body parsing (read last JSONL line, handle JSON-encoded list)

**Config restructure (`remote-dev-bot.yaml`):**
- Move `commit_trailer` inside `openhands:` block (more logical home; add force-push note)
- Remove redundant per-mode `default_model` (resolve/design/review all matched top-level)
- Fix default timeout 120->60 min (matches actual usage; 120 was leftover)
- Fix inline arg docs: `--timeout N` -> `timeout_minutes = N`
- Rename `explore` mode's `prompt_prefix` -> `additional_instructions` (aligns with PR #264)
- Add review usage examples to header comment

**Library fixes:**
- `config.py`: Remove `context` alias from `ALLOWED_ARGS` and `parse_args`, move `DEFAULT_TIMEOUT_MINUTES` constant to top, fix `commit_trailer` lookup to read from `openhands:` block
- `feedback.py`: Move `DEFAULT_REPO` and `MAX_ISSUES_PER_INSTALL` constants to top of file
- `compile.py`: Fix `commit_trailer` lookup to read from `openhands:` block

**Tests:**
- Update all `context =` -> `context_files =` (alias removed)
- Update all `commit_trailer` fixtures to use nested `openhands: {commit_trailer: ...}` structure
- Update timeout default test expectation 120->60
- Fix explore mode fixture (`prompt_prefix` -> `additional_instructions`)
- Fix compile test for MODEL assignment (handle both block-scalar and quoted-YAML forms)

## Test plan
- [x] `python -m pytest tests/ -q` -- 278 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)
