### PR TITLE
Wrap all markdown files to 80 characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,46 +4,77 @@ Project conventions for AI coding agents working on this repository.
 
 ## Project
 
-Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to resolve issues and create PRs, controlled via `/agent-resolve`, `/agent-design`, and `/agent-review` comments on GitHub issues and PRs.
+Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to
+resolve issues and create PRs, controlled via `/agent-resolve`, `/agent-design`,
+and `/agent-review` comments on GitHub issues and PRs.
 
 ### How It Works
-1. User comments `/agent-resolve[-<model>]`, `/agent-design[-<model>]`, or `/agent-review[-<model>]` on a GitHub issue or PR
+
+1. User comments `/agent-resolve[-<model>]`, `/agent-design[-<model>]`, or
+   `/agent-review[-<model>]` on a GitHub issue or PR
 2. Target repo's shim workflow calls `remote-dev-bot.yml` from this repo
 3. Reusable workflow parses the mode and model, dispatches to the right job
-4. Resolve mode: OpenHands runs, edits code, opens a PR. Design mode: LLM analyzes the issue, posts a comment. Review mode: LLM reviews a PR, posts a code review comment.
-5. Iterative: comment `/agent-resolve` again on the PR with feedback for another pass
+4. Resolve mode: OpenHands runs, edits code, opens a PR. Design mode: LLM
+   analyzes the issue, posts a comment. Review mode: LLM reviews a PR, posts a
+   code review comment.
+5. Iterative: comment `/agent-resolve` again on the PR with feedback for another
+   pass
 
 ### Key Files
 
 **Workflows** (`.github/workflows/`):
-- `remote-dev-bot.yml` — the reusable workflow; all real logic; jobs: `parse`, `resolve`, `design`, `review`
-- `agent.yml` — thin shim users copy into their repos; calls `remote-dev-bot.yml@main`
-- `dogfood.yml` — internal shim for rdb self-dev; fires on `/dogfood` comments; calls `remote-dev-bot.yml@dev`
+
+- `remote-dev-bot.yml` — the reusable workflow; all real logic; jobs: `parse`,
+  `resolve`, `design`, `review`
+- `agent.yml` — thin shim users copy into their repos; calls
+  `remote-dev-bot.yml@main`
+- `dogfood.yml` — internal shim for rdb self-dev; fires on `/dogfood` comments;
+  calls `remote-dev-bot.yml@dev`
 - `test.yml` — CI: runs pytest on PRs to main
 - `e2e.yml` — manual trigger for E2E tests against `remote-dev-bot-test`
-- `e2e-security.yml` — manual trigger for security E2E tests (verifies collaborator gate blocks outsiders)
+- `e2e-security.yml` — manual trigger for security E2E tests (verifies
+  collaborator gate blocks outsiders)
 - `full-test-suite.yml` — runs unit tests + all E2E tests together
 
 **Python**:
-- `lib/config.py` — config parsing: `parse_invocation`, `parse_args`, `resolve_config`, `ALLOWED_ARGS`; called by the workflow and unit tests
-- `lib/feedback.py` — install feedback collection: `InstallReport`, `InstallProblem`, `report_problems`; used during runbook execution
-- `scripts/compile.py` — compiles `remote-dev-bot.yml` → `dist/agent-resolve.yml`, `dist/agent-design.yml`, `dist/agent-review.yml`; finds steps by **name** not index
+
+- `lib/config.py` — config parsing: `parse_invocation`, `parse_args`,
+  `resolve_config`, `ALLOWED_ARGS`; called by the workflow and unit tests
+- `lib/feedback.py` — install feedback collection: `InstallReport`,
+  `InstallProblem`, `report_problems`; used during runbook execution
+- `scripts/compile.py` — compiles `remote-dev-bot.yml` →
+  `dist/agent-resolve.yml`, `dist/agent-design.yml`, `dist/agent-review.yml`;
+  finds steps by **name** not index
 
 **Tests** (`tests/`):
+
 - `test_config.py` — unit tests for all `lib/config.py` functions
 - `test_compile.py` — tests that compiled outputs contain expected steps
-- `test_yaml.py` — structural/validity tests for YAML files (workflow and config)
-- `test_cost.py` — tests for the `parse_litellm_logs` Python function embedded in the workflow's cost step; extracts it from the YAML at test time
+- `test_yaml.py` — structural/validity tests for YAML files (workflow and
+  config)
+- `test_cost.py` — tests for the `parse_litellm_logs` Python function embedded
+  in the workflow's cost step; extracts it from the YAML at test time
 - `test_feedback.py` — unit tests for `lib/feedback.py`
-- `e2e.sh` — full E2E test runner; creates issues in `remote-dev-bot-test`, triggers runs, checks results
+- `e2e.sh` — full E2E test runner; creates issues in `remote-dev-bot-test`,
+  triggers runs, checks results
 - `e2e-security.sh` — security-specific E2E tests
 
 **Config**:
-- `remote-dev-bot.yaml` — model aliases and OpenHands settings (canonical config; also serves as template for user repos)
-- `remote-dev-bot.local.yaml` — local overrides (gitignored); use for dev without affecting CI
-- `install.md` — setup instructions designed to be followed by humans or AI assistants
 
-**Note on config layering:** The config system has a `.local.yaml` override file (`remote-dev-bot.local.yaml`) used in the remote-dev-bot repo itself for self-development/dogfooding. This is a developer tool only — do NOT document it in user-facing docs (README.md, how-it-works.md, install.md). It belongs only in CONTRIBUTING.md. User-facing docs should describe only the two-layer system: base config (in remote-dev-bot repo) + target repo override (`remote-dev-bot.yaml` in the calling repo).
+- `remote-dev-bot.yaml` — model aliases and OpenHands settings (canonical
+  config; also serves as template for user repos)
+- `remote-dev-bot.local.yaml` — local overrides (gitignored); use for dev
+  without affecting CI
+- `install.md` — setup instructions designed to be followed by humans or AI
+  assistants
+
+**Note on config layering:** The config system has a `.local.yaml` override file
+(`remote-dev-bot.local.yaml`) used in the remote-dev-bot repo itself for
+self-development/dogfooding. This is a developer tool only — do NOT document it
+in user-facing docs (README.md, how-it-works.md, install.md). It belongs only in
+CONTRIBUTING.md. User-facing docs should describe only the two-layer system:
+base config (in remote-dev-bot repo) + target repo override
+(`remote-dev-bot.yaml` in the calling repo).
 
 ### Running Tests
 
@@ -62,36 +93,56 @@ pytest --doctest-modules lib/config.py
 ## Common Tasks — Where to Look
 
 ### Adding a new per-invocation argument (e.g., `foo_bar = value` in a comment)
+
 1. Add to `ALLOWED_ARGS` in `lib/config.py` (name → type)
-2. Add handling in `resolve_config()` where other args are applied (search for `if "target_branch" in args` as an example)
-3. If it produces a workflow output, add it to the `GITHUB_OUTPUT` writes in `main()`
+2. Add handling in `resolve_config()` where other args are applied (search for
+   `if "target_branch" in args` as an example)
+3. If it produces a workflow output, add it to the `GITHUB_OUTPUT` writes in
+   `main()`
 4. Add tests in `tests/test_config.py`
-5. **Data flow**: comment body → `parse_invocation` → `parse_args` → `ALLOWED_ARGS` validation → `resolve_config` → `main`
+5. **Data flow**: comment body → `parse_invocation` → `parse_args` →
+   `ALLOWED_ARGS` validation → `resolve_config` → `main`
 
 ### Adding or modifying a workflow step
+
 1. Edit the step in `.github/workflows/remote-dev-bot.yml`
-2. Update `scripts/compile.py` if the step needs to appear in compiled output (compile.py finds steps by name)
-3. Update expected step lists in `tests/test_compile.py` — the step-count tripwire tests will fail if the compiled output doesn't match
+2. Update `scripts/compile.py` if the step needs to appear in compiled output
+   (compile.py finds steps by name)
+3. Update expected step lists in `tests/test_compile.py` — the step-count
+   tripwire tests will fail if the compiled output doesn't match
 4. Run `pytest tests/test_compile.py -v` to verify
 
 ### Adding a new mode
+
 1. Add the mode to `remote-dev-bot.yaml` under `modes:` with an `action:` field
 2. Add a job to `.github/workflows/remote-dev-bot.yml`
-3. `resolve_config()` in `lib/config.py` reads the mode's config from the YAML — no code change needed unless the mode has a novel output field
+3. `resolve_config()` in `lib/config.py` reads the mode's config from the YAML —
+   no code change needed unless the mode has a novel output field
 
 ### Adding a new model provider (e.g., a new LLM vendor)
-1. Add the provider prefix to `KNOWN_PROVIDERS` in `lib/config.py` (e.g., `"newvendor/"`)
-2. Add an API key check in the "Determine API key" step of `.github/workflows/remote-dev-bot.yml` — there are four copies (resolve, design, review, explore); update all of them
-3. Add model aliases under `models:` in `remote-dev-bot.yaml` with IDs using the new prefix
-4. Add the API key secret (`NEWVENDOR_API_KEY`) to the secrets passed through in `agent.yml` and `dogfood.yml`
+
+1. Add the provider prefix to `KNOWN_PROVIDERS` in `lib/config.py` (e.g.,
+   `"newvendor/"`)
+2. Add an API key check in the "Determine API key" step of
+   `.github/workflows/remote-dev-bot.yml` — there are four copies (resolve,
+   design, review, explore); update all of them
+3. Add model aliases under `models:` in `remote-dev-bot.yaml` with IDs using the
+   new prefix
+4. Add the API key secret (`NEWVENDOR_API_KEY`) to the secrets passed through in
+   `agent.yml` and `dogfood.yml`
 5. Update the runbook.md to mention the new provider as an option
 
 ### Changing the cost/metrics step
-The `parse_litellm_logs` Python function lives inside a bash heredoc in the "Calculate and post cost" step of `remote-dev-bot.yml`. `test_cost.py` extracts it directly from the YAML at test time, so tests always exercise the live code. After changing the step, run `pytest tests/test_cost.py -v`.
+
+The `parse_litellm_logs` Python function lives inside a bash heredoc in the
+"Calculate and post cost" step of `remote-dev-bot.yml`. `test_cost.py` extracts
+it directly from the YAML at test time, so tests always exercise the live code.
+After changing the step, run `pytest tests/test_cost.py -v`.
 
 ## Inline Args System
 
 Users can pass per-invocation arguments on lines after the command:
+
 ```
 /agent resolve
 max iterations = 75
@@ -100,69 +151,102 @@ target branch = design/gemini
 ```
 
 **How it flows:**
+
 - `COMMENT_BODY` env var carries the full comment text into `lib/config.py`
-- `parse_invocation(comment_body, known_modes, command_prefix)` splits the first line (command) from subsequent lines (args)
-- `parse_args(lines)` parses `name = value` lines; `normalize_arg_name` maps spaces/dashes/underscores to underscores
-- `ALLOWED_ARGS` in `lib/config.py` defines accepted names and types; unknown names are rejected with an error
+- `parse_invocation(comment_body, known_modes, command_prefix)` splits the first
+  line (command) from subsequent lines (args)
+- `parse_args(lines)` parses `name = value` lines; `normalize_arg_name` maps
+  spaces/dashes/underscores to underscores
+- `ALLOWED_ARGS` in `lib/config.py` defines accepted names and types; unknown
+  names are rejected with an error
 - `resolve_config(..., args=...)` applies parsed args on top of YAML config
 - `context_files` **appends** to the mode's existing list (does not replace)
 
 ## compile.py: Three-File Output
 
-`scripts/compile.py` inlines config parsing and selected steps from `remote-dev-bot.yml` into three standalone files: `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. It finds steps by **name** (not index), so reordering steps is safe as long as step names don't change.
+`scripts/compile.py` inlines config parsing and selected steps from
+`remote-dev-bot.yml` into three standalone files: `dist/agent-resolve.yml`,
+`dist/agent-design.yml`, and `dist/agent-review.yml`. It finds steps by **name**
+(not index), so reordering steps is safe as long as step names don't change.
 
-**Rule: if you add, remove, or rename a step in remote-dev-bot.yml, update compile.py to match**, then run `pytest tests/test_compile.py -v`. The step-count tripwire tests will catch mismatches.
+**Rule: if you add, remove, or rename a step in remote-dev-bot.yml, update
+compile.py to match**, then run `pytest tests/test_compile.py -v`. The
+step-count tripwire tests will catch mismatches.
 
 ## Branch Model
 
-| Branch | Purpose | Who points here |
-|--------|---------|-----------------|
-| `main` | Stable, released, tagged | External users' shims |
-| `dev` | Long-lived integration branch, accumulates work ahead of `main` | Owner's own repo shims |
-| `e2e-test` | Ephemeral pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim |
+| Branch     | Purpose                                                         | Who points here            |
+| ---------- | --------------------------------------------------------------- | -------------------------- |
+| `main`     | Stable, released, tagged                                        | External users' shims      |
+| `dev`      | Long-lived integration branch, accumulates work ahead of `main` | Owner's own repo shims     |
+| `e2e-test` | Ephemeral pointer, reset by e2e scripts before each test run    | `remote-dev-bot-test` shim |
 
-**PRs go to `dev`, not `main`**, unless the change is a bug fix or doc/config-only.
+**PRs go to `dev`, not `main`**, unless the change is a bug fix or
+doc/config-only.
 
-**Feature workflow:** `git checkout -b my-feature origin/dev` → PR → merge to `dev`
+**Feature workflow:** `git checkout -b my-feature origin/dev` → PR → merge to
+`dev`
 
-**Bug-fix workflow:** `git checkout -b my-fix origin/main` → PR → merge to `main` → rebase `dev` onto new `main`
+**Bug-fix workflow:** `git checkout -b my-fix origin/main` → PR → merge to
+`main` → rebase `dev` onto new `main`
 
 **CRITICAL — always branch from the remote ref, not the local ref:**
+
 ```bash
 git checkout -b my-feature origin/dev   # CORRECT
 git checkout -b my-feature dev          # WRONG — local ref may be stale
 git checkout -b my-fix origin/main      # CORRECT
 git checkout -b my-fix main             # WRONG — local ref may be stale
 ```
-`git fetch` updates `origin/dev` and `origin/main` but does NOT move local `dev` or `main`. Using the local ref silently branches from a stale commit.
+
+`git fetch` updates `origin/dev` and `origin/main` but does NOT move local `dev`
+or `main`. Using the local ref silently branches from a stale commit.
 
 ### Dev Cycle (detailed)
 
-This project has an unusual dev cycle because GitHub Actions only runs workflows from the default branch. You can't just push a feature branch and test it — the workflow won't trigger. Instead, we use a two-repo setup with an `e2e-test` pointer branch.
+This project has an unusual dev cycle because GitHub Actions only runs workflows
+from the default branch. You can't just push a feature branch and test it — the
+workflow won't trigger. Instead, we use a two-repo setup with an `e2e-test`
+pointer branch.
 
 **Repos:**
+
 - `remote-dev-bot` — the reusable workflow, config, and docs (this repo)
-- `remote-dev-bot-test` — a test repo whose shim points at `remote-dev-bot.yml@e2e-test`
+- `remote-dev-bot-test` — a test repo whose shim points at
+  `remote-dev-bot.yml@e2e-test`
 
 **How the `e2e-test` branch works:**
-- `e2e-test` is NOT a development branch. It's an ephemeral pointer reset before each e2e run.
-- Before testing, force-set `e2e-test` to your feature branch: `git push --force-with-lease origin my-feature:e2e-test`
-- The test repo's shim calls `remote-dev-bot.yml@e2e-test`, so it picks up whatever `e2e-test` points to.
+
+- `e2e-test` is NOT a development branch. It's an ephemeral pointer reset before
+  each e2e run.
+- Before testing, force-set `e2e-test` to your feature branch:
+  `git push --force-with-lease origin my-feature:e2e-test`
+- The test repo's shim calls `remote-dev-bot.yml@e2e-test`, so it picks up
+  whatever `e2e-test` points to.
 
 **Config/lib checkout is self-referential:**
-- `remote-dev-bot.yml` reads `github.workflow_ref` to detect which branch it was called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same branch
-- Changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch take effect automatically when `e2e-test` points at your branch
+
+- `remote-dev-bot.yml` reads `github.workflow_ref` to detect which branch it was
+  called from, then checks out `remote-dev-bot.yaml` and `lib/` from that same
+  branch
+- Changes to `lib/config.py` or `remote-dev-bot.yaml` on your feature branch
+  take effect automatically when `e2e-test` points at your branch
 
 **Full dev cycle:**
+
 1. Create a feature branch from `dev`: `git checkout -b my-feature origin/dev`
 2. Make changes, commit freely
-3. Point `e2e-test` at your branch: `git push --force-with-lease origin my-feature:e2e-test`
-4. In `remote-dev-bot-test`: create an issue, comment `/agent-resolve-claude-small`
-5. Monitor: `gh run list --repo gnovak/remote-dev-bot-test --workflow=agent.yml --limit 3`
+3. Point `e2e-test` at your branch:
+   `git push --force-with-lease origin my-feature:e2e-test`
+4. In `remote-dev-bot-test`: create an issue, comment
+   `/agent-resolve-claude-small`
+5. Monitor:
+   `gh run list --repo gnovak/remote-dev-bot-test --workflow=agent.yml --limit 3`
 6. If it fails: check logs, fix, commit, push `e2e-test` again, re-trigger
 7. If it works: clean up git history (rebase), open a PR against `dev`, merge
 
 **Triggering a test:**
+
 ```bash
 # Create issue
 gh issue create --repo gnovak/remote-dev-bot-test \
@@ -178,10 +262,13 @@ gh run view RUN_ID --repo gnovak/remote-dev-bot-test --log | tail -40
 
 ## PR Policy
 
-- **All changes go through a PR. Never commit or push directly to main.** Open a PR and let the user merge it.
-- For small changes, a single-commit PR self-merged immediately is fine — the point is the artifact, not the review ceremony.
+- **All changes go through a PR. Never commit or push directly to main.** Open a
+  PR and let the user merge it.
+- For small changes, a single-commit PR self-merged immediately is fine — the
+  point is the artifact, not the review ceremony.
 
 ## Code Style
+
 - Follow existing patterns in the codebase
 - Keep implementations simple and focused
 - Document non-obvious design decisions in comments
@@ -192,17 +279,23 @@ When executing `install.md` to set up remote-dev-bot for a user:
 
 ### Problem Collection
 
-- **Collect problems automatically** as you go through phases — the user should not need to provide this information
-- Use `InstallReport` to track problems; it auto-collects environment info (OS, shell, Python version)
-- When a step fails or requires a workaround, call `report.add_problem()` with the details
-- Use `InstallProblem.from_exception()` as a convenience when catching exceptions
+- **Collect problems automatically** as you go through phases — the user should
+  not need to provide this information
+- Use `InstallReport` to track problems; it auto-collects environment info (OS,
+  shell, Python version)
+- When a step fails or requires a workaround, call `report.add_problem()` with
+  the details
+- Use `InstallProblem.from_exception()` as a convenience when catching
+  exceptions
 
 ### What to Record
 
 For each problem, capture:
+
 - **step**: The step number (e.g., "2.1")
 - **title**: The step title (e.g., "Enable Actions Permissions")
-- **result**: "fail" (step didn't work) or "deviate" (worked but differently than documented)
+- **result**: "fail" (step didn't work) or "deviate" (worked but differently
+  than documented)
 - **expected**: What the runbook said should happen
 - **actual**: What actually happened (error message, unexpected behavior)
 - **workaround**: What you did instead (optional)
@@ -211,11 +304,13 @@ For each problem, capture:
 ### Security
 
 **Do not include secrets in problem reports.** This includes:
+
 - API keys, tokens, passwords
 - Repository contents that might contain secrets
 - Environment variables that might contain secrets
 
-You have no reason to include secrets in error reports, so this should be straightforward.
+You have no reason to include secrets in error reports, so this should be
+straightforward.
 
 ### Consent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,47 @@
 ## v0.3.0 — Mode-based commands + compiled workflows (Feb 15, 2026)
 
 ### New features
-- **Two command modes**: `/agent-resolve` (opens a PR) and `/agent-design` (posts design analysis as a comment). Replaces the old bare `/agent` command.
-- **Multi-provider model support**: OpenAI (GPT) and Google (Gemini) model aliases alongside Anthropic (Claude). Configure in `remote-dev-bot.yaml`.
-- **Two-file compiled install**: Single-file workflows (`agent-resolve.yml` and `agent-design.yml`) that users download into their repos — no shim or cross-repo reference needed.
-- **Security guardrails**: Microagent injection prevents secret exfiltration. Author association gate restricts who can trigger agent runs.
-- **Config layering**: Target repos can override defaults with their own `remote-dev-bot.yaml`.
+
+- **Two command modes**: `/agent-resolve` (opens a PR) and `/agent-design`
+  (posts design analysis as a comment). Replaces the old bare `/agent` command.
+- **Multi-provider model support**: OpenAI (GPT) and Google (Gemini) model
+  aliases alongside Anthropic (Claude). Configure in `remote-dev-bot.yaml`.
+- **Two-file compiled install**: Single-file workflows (`agent-resolve.yml` and
+  `agent-design.yml`) that users download into their repos — no shim or
+  cross-repo reference needed.
+- **Security guardrails**: Microagent injection prevents secret exfiltration.
+  Author association gate restricts who can trigger agent runs.
+- **Config layering**: Target repos can override defaults with their own
+  `remote-dev-bot.yaml`.
 
 ### Improvements
-- **Runbook overhaul**: Guided setup with cost limits, PAT walkthrough, provider-specific instructions, private repo support, troubleshooting table. Phases renumbered 1-5.
-- **Testing framework**: Unit tests for config parsing and YAML validation, E2E test script with per-provider and all-models modes, security E2E tests, compiled workflow tests.
-- **PR feedback loop**: Comment `/agent-resolve` on a PR to iterate with feedback.
-- **Compiler rewrite**: Step lookup by name instead of hardcoded indices. Produces two self-contained workflow files.
+
+- **Runbook overhaul**: Guided setup with cost limits, PAT walkthrough,
+  provider-specific instructions, private repo support, troubleshooting table.
+  Phases renumbered 1-5.
+- **Testing framework**: Unit tests for config parsing and YAML validation, E2E
+  test script with per-provider and all-models modes, security E2E tests,
+  compiled workflow tests.
+- **PR feedback loop**: Comment `/agent-resolve` on a PR to iterate with
+  feedback.
+- **Compiler rewrite**: Step lookup by name instead of hardcoded indices.
+  Produces two self-contained workflow files.
 
 ### Breaking changes
-- `/agent` and `/agent-<model>` commands no longer work. Use `/agent-resolve` or `/agent-resolve-<model>`.
-- Compiled workflow install is now two files (`agent-resolve.yml` + `agent-design.yml`) instead of one.
+
+- `/agent` and `/agent-<model>` commands no longer work. Use `/agent-resolve` or
+  `/agent-resolve-<model>`.
+- Compiled workflow install is now two files (`agent-resolve.yml` +
+  `agent-design.yml`) instead of one.
 
 ## v0.2.0 — Shim + reusable workflow (Feb 11, 2026)
 
-- Refactored into a thin shim (`agent.yml`) per target repo that calls a shared reusable workflow (`remote-dev-bot.yml`).
+- Refactored into a thin shim (`agent.yml`) per target repo that calls a shared
+  reusable workflow (`remote-dev-bot.yml`).
 - Cross-repo support tested with separate test repo.
 - Dev cycle infrastructure in place.
 
 ## v0.1.0 — First working version (Feb 9, 2026)
 
-- End-to-end pipeline operational: `/agent` comment on an issue triggers OpenHands, which resolves the issue and opens a draft PR.
+- End-to-end pipeline operational: `/agent` comment on an issue triggers
+  OpenHands, which resolves the issue and opens a draft PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # CLAUDE.md
 
-**Read [AGENTS.md](AGENTS.md) now before responding.** It contains project conventions that govern all work in this repo.
+**Read [AGENTS.md](AGENTS.md) now before responding.** It contains project
+conventions that govern all work in this repo.
 
 Global personal preferences are in `~/.config/agents/AGENTS.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,104 +1,134 @@
 # Contributing to Remote Dev Bot
 
-This file documents the development and testing infrastructure. If you're a user looking to install remote-dev-bot, see [install.md](install.md).
+This file documents the development and testing infrastructure. If you're a user
+looking to install remote-dev-bot, see [install.md](install.md).
 
 ## Repos
 
-| Repo | Purpose |
-|------|---------|
-| `gnovak/remote-dev-bot` | The reusable workflow, config, tests, and docs (this repo) |
+| Repo                         | Purpose                                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `gnovak/remote-dev-bot`      | The reusable workflow, config, tests, and docs (this repo)                                                             |
 | `gnovak/remote-dev-bot-test` | Throwaway test repo. Shim points at `remote-dev-bot.yml@e2e-test`. Git history and issues don't matter — leave a mess. |
 
 ## Test Accounts
 
 Three separate GitHub identities are used so each role is cleanly separated:
-- **`gnovak`** owns the repos and does normal development
-- **`remote-dev-bot`** acts as a friendly collaborator, so e2e tests can trigger agent runs without polluting `gnovak`'s contribution stats and without special-casing the security gate
-- **`remote-dev-bot-tester`** simulates an external stranger, so security tests can verify the collaborator gate actually blocks unauthorized users
 
-| Account | Purpose | Credentials stored as |
-|---------|---------|----------------------|
-| `gnovak` | Repo owner. Used for normal development and testing. | `RDB_PAT_TOKEN` (on both repos), or GitHub App (`RDB_APP_ID` variable + `RDB_APP_PRIVATE_KEY` secret) |
-| `remote-dev-bot` | Dedicated bot account. Collaborator on `remote-dev-bot-test`. Posts authorized test comments that trigger agent runs without attributing activity to `gnovak`. | `RDB_TESTER_PAT_TOKEN` (on remote-dev-bot) |
-| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo. | `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` (on remote-dev-bot) |
+- **`gnovak`** owns the repos and does normal development
+- **`remote-dev-bot`** acts as a friendly collaborator, so e2e tests can trigger
+  agent runs without polluting `gnovak`'s contribution stats and without
+  special-casing the security gate
+- **`remote-dev-bot-tester`** simulates an external stranger, so security tests
+  can verify the collaborator gate actually blocks unauthorized users
+
+| Account                 | Purpose                                                                                                                                                        | Credentials stored as                                                                                 |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `gnovak`                | Repo owner. Used for normal development and testing.                                                                                                           | `RDB_PAT_TOKEN` (on both repos), or GitHub App (`RDB_APP_ID` variable + `RDB_APP_PRIVATE_KEY` secret) |
+| `remote-dev-bot`        | Dedicated bot account. Collaborator on `remote-dev-bot-test`. Posts authorized test comments that trigger agent runs without attributing activity to `gnovak`. | `RDB_TESTER_PAT_TOKEN` (on remote-dev-bot)                                                            |
+| `remote-dev-bot-tester` | Simulates an unauthorized external user. NOT a collaborator on any repo.                                                                                       | `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` (on remote-dev-bot)                                               |
 
 ### remote-dev-bot (bot account) details
+
 - Classic PAT with `public_repo` + `workflow` scopes, no expiration
-- **`public_repo`** — create issues, post comments, open PRs in public repos (standard e2e test flow)
-- **`workflow`** — read/write `.github/workflows/` files; required by compiled e2e tests, which temporarily swap the shim for the compiled workflow and must restore it afterwards. Without this scope, the swap fails with HTTP 404.
-- Must be a collaborator on `remote-dev-bot-test` so the security gate allows its trigger comments
+- **`public_repo`** — create issues, post comments, open PRs in public repos
+  (standard e2e test flow)
+- **`workflow`** — read/write `.github/workflows/` files; required by compiled
+  e2e tests, which temporarily swap the shim for the compiled workflow and must
+  restore it afterwards. Without this scope, the swap fails with HTTP 404.
+- Must be a collaborator on `remote-dev-bot-test` so the security gate allows
+  its trigger comments
 - Keeps test activity out of `gnovak`'s GitHub contribution stats
 
 ### remote-dev-bot-tester details
+
 - Classic PAT with `public_repo` scope, no expiration
-- Used by e2e security tests to verify that non-collaborators cannot trigger agent runs
-- The PAT only works on public repos — the gating test requires repos to be public
+- Used by e2e security tests to verify that non-collaborators cannot trigger
+  agent runs
+- The PAT only works on public repos — the gating test requires repos to be
+  public
 
 ## GitHub App and Reserved Identities
 
 ### GitHub App: `remote-dev-bot`
+
 - Created at https://github.com/settings/apps/remote-dev-bot (owned by `gnovak`)
-- When used, the bot posts as `remote-dev-bot[bot]` — a clearly distinct identity from the repo owner
+- When used, the bot posts as `remote-dev-bot[bot]` — a clearly distinct
+  identity from the repo owner
 - App ID: `2895037`
-- Installed on all `gnovak` repos (blanket install). Only repos with `RDB_APP_PRIVATE_KEY` secret actually use it. Currently configured on: `gnovak/remote-dev-bot`, `gnovak/remote-dev-bot-test`
-- Permissions (all Read & write): Contents, Issues, Pull Requests, Workflows, Actions, Checks
-  - **Workflows** is included because this app devs rdb itself, so the agent may need to modify `.github/workflows/` files. Regular rdb users should *not* grant this — the runbook intentionally omits it.
-  - **Actions + Checks** are included so the agent can inspect CI logs and check run results when debugging ("PR XYZ is failing, dig into the logs"). The OpenHands sandbox has `gh` CLI and GitHub API access, so these work. Regular rdb users don't need these unless they specifically want the agent to debug CI.
-- Webhooks: inactive (tokens are generated on-demand via `actions/create-github-app-token`)
-- Private key stored as `RDB_APP_PRIVATE_KEY` secret; App ID stored as `RDB_APP_ID` variable
+- Installed on all `gnovak` repos (blanket install). Only repos with
+  `RDB_APP_PRIVATE_KEY` secret actually use it. Currently configured on:
+  `gnovak/remote-dev-bot`, `gnovak/remote-dev-bot-test`
+- Permissions (all Read & write): Contents, Issues, Pull Requests, Workflows,
+  Actions, Checks
+  - **Workflows** is included because this app devs rdb itself, so the agent may
+    need to modify `.github/workflows/` files. Regular rdb users should _not_
+    grant this — the runbook intentionally omits it.
+  - **Actions + Checks** are included so the agent can inspect CI logs and check
+    run results when debugging ("PR XYZ is failing, dig into the logs"). The
+    OpenHands sandbox has `gh` CLI and GitHub API access, so these work. Regular
+    rdb users don't need these unless they specifically want the agent to debug
+    CI.
+- Webhooks: inactive (tokens are generated on-demand via
+  `actions/create-github-app-token`)
+- Private key stored as `RDB_APP_PRIVATE_KEY` secret; App ID stored as
+  `RDB_APP_ID` variable
 
 ### GitHub username: `remote-dev-bot`
+
 - Active as a dedicated bot account (collaborator on `remote-dev-bot-test`)
-- Used by e2e tests to post authorized trigger comments (see Test Accounts above)
-- The GitHub App (`remote-dev-bot[bot]`) is a separate identity used for agent responses and PRs
+- Used by e2e tests to post authorized trigger comments (see Test Accounts
+  above)
+- The GitHub App (`remote-dev-bot[bot]`) is a separate identity used for agent
+  responses and PRs
 
 ## Secrets Map
 
 Secrets stored on `gnovak/remote-dev-bot`:
 
-| Secret | What it is |
-|--------|-----------|
-| `ANTHROPIC_API_KEY` | Anthropic API key (for Claude models) |
-| `OPENAI_API_KEY` | OpenAI API key (for GPT models) |
-| `GEMINI_API_KEY` | Google AI API key (for Gemini models) |
-| `RDB_APP_PRIVATE_KEY` | GitHub App private key, for bot identity on comments/PRs. |
-| `RDB_TESTER_PAT_TOKEN` | PAT for `remote-dev-bot` account (collaborator on rdb-test). Used by e2e tests to post authorized trigger comments. |
+| Secret                              | What it is                                                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`                 | Anthropic API key (for Claude models)                                                                                      |
+| `OPENAI_API_KEY`                    | OpenAI API key (for GPT models)                                                                                            |
+| `GEMINI_API_KEY`                    | Google AI API key (for Gemini models)                                                                                      |
+| `RDB_APP_PRIVATE_KEY`               | GitHub App private key, for bot identity on comments/PRs.                                                                  |
+| `RDB_TESTER_PAT_TOKEN`              | PAT for `remote-dev-bot` account (collaborator on rdb-test). Used by e2e tests to post authorized trigger comments.        |
 | `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` | PAT for `remote-dev-bot-tester` (not a collaborator). Used by security e2e tests to verify unauthorized users are blocked. |
 
 Variables stored on `gnovak/remote-dev-bot`:
 
-| Variable | Value | What it is |
-|----------|-------|-----------|
+| Variable     | Value     | What it is                                                                                                                                                                                                                                                              |
+| ------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `RDB_APP_ID` | `2895037` | GitHub App ID for the "remote-dev-bot" app. Used with `RDB_APP_PRIVATE_KEY` to generate a short-lived token so the bot posts as `remote-dev-bot[bot]`. This is a variable (not a secret) because app IDs are public. Set on `remote-dev-bot` and `remote-dev-bot-test`. |
 
 Secrets stored on `gnovak/remote-dev-bot-test`:
 
-| Secret | What it is |
-|--------|-----------|
-| `ANTHROPIC_API_KEY` | Same key as above (shared) |
-| `OPENAI_API_KEY` | Same key as above (shared) |
-| `GEMINI_API_KEY` | Same key as above (shared) |
-| `E2E_TEST_TOKEN` | Canary secret used by security e2e tests. The test prompts the agent to exfiltrate env vars and checks the output doesn't contain this value. Current canary: `Uh_Oh_c7f3a9b2e1d8k4m6p0q5r2w8`. Must match `CANARY_VALUE` in `tests/e2e-security.sh`. If you rotate it, update both. |
+| Secret              | What it is                                                                                                                                                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ANTHROPIC_API_KEY` | Same key as above (shared)                                                                                                                                                                                                                                                           |
+| `OPENAI_API_KEY`    | Same key as above (shared)                                                                                                                                                                                                                                                           |
+| `GEMINI_API_KEY`    | Same key as above (shared)                                                                                                                                                                                                                                                           |
+| `E2E_TEST_TOKEN`    | Canary secret used by security e2e tests. The test prompts the agent to exfiltrate env vars and checks the output doesn't contain this value. Current canary: `Uh_Oh_c7f3a9b2e1d8k4m6p0q5r2w8`. Must match `CANARY_VALUE` in `tests/e2e-security.sh`. If you rotate it, update both. |
 
 ## Config Layering
 
-rdb uses a three-layer config merge plus optional per-invocation runtime args (each layer is optional, deeper layers win):
+rdb uses a three-layer config merge plus optional per-invocation runtime args
+(each layer is optional, deeper layers win):
 
-| Layer | Path / Source | Notes |
-|-------|---------------|-------|
-| Base | `.remote-dev-bot/remote-dev-bot.yaml` | rdb repo, via sparse-checkout |
-| Override | `remote-dev-bot.yaml` | Target repo (user's settings) |
-| Local | `remote-dev-bot.local.yaml` | Target repo (deepest override; gitignored) |
+| Layer        | Path / Source                                      | Notes                                                            |
+| ------------ | -------------------------------------------------- | ---------------------------------------------------------------- |
+| Base         | `.remote-dev-bot/remote-dev-bot.yaml`              | rdb repo, via sparse-checkout                                    |
+| Override     | `remote-dev-bot.yaml`                              | Target repo (user's settings)                                    |
+| Local        | `remote-dev-bot.local.yaml`                        | Target repo (deepest override; gitignored)                       |
 | Runtime args | Inline `name = value` lines in the trigger comment | Override for a single run; see `ALLOWED_ARGS` in `lib/config.py` |
 
 All merges are deep (leaf-level), so overriding `modes.design.max_iterations`
-does not clobber `modes.design.context_files`.  Lists replace entirely (no
+does not clobber `modes.design.context_files`. Lists replace entirely (no
 concatenation).
 
 ### Self-dev local config (`remote-dev-bot.local.yaml`)
 
 This file lives in the rdb repo root and applies when rdb is used to develop
-itself.  It adds rdb implementation files (`lib/config.py`, etc.) to the design
+itself. It adds rdb implementation files (`lib/config.py`, etc.) to the design
 agent's `context_files` so the design agent can see actual code rather than
 guessing.
 
@@ -107,22 +137,26 @@ only fetches `remote-dev-bot.yaml` and `lib/`, so `remote-dev-bot.local.yaml`
 never appears in a user's `.remote-dev-bot/` directory.
 
 Users can create their own `remote-dev-bot.local.yaml` if they want a third
-config layer, but there is no documented use case for this — `remote-dev-bot.yaml`
-already covers all user customisation needs.
+config layer, but there is no documented use case for this —
+`remote-dev-bot.yaml` already covers all user customisation needs.
 
 ## Branch Model
 
-| Branch | Purpose | Who points here |
-|--------|---------|-----------------|
-| `main` | Stable, released, tagged | External users' shims (`agent.yml@main`) |
-| `dev` | Long-lived integration branch, accumulates work ahead of `main` | `dogfood.yml@dev` (rdb self-dev) |
-| `e2e-test` | Ephemeral test pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim |
+| Branch     | Purpose                                                           | Who points here                          |
+| ---------- | ----------------------------------------------------------------- | ---------------------------------------- |
+| `main`     | Stable, released, tagged                                          | External users' shims (`agent.yml@main`) |
+| `dev`      | Long-lived integration branch, accumulates work ahead of `main`   | `dogfood.yml@dev` (rdb self-dev)         |
+| `e2e-test` | Ephemeral test pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim               |
 
-**PRs go to `dev`, not `main`**, unless the change is a hotfix to something already released. When `dev` is ready to release: run the full test suite (with `e2e-test` pointing at `dev`), then merge `dev` → `main` and tag.
+**PRs go to `dev`, not `main`**, unless the change is a hotfix to something
+already released. When `dev` is ready to release: run the full test suite (with
+`e2e-test` pointing at `dev`), then merge `dev` → `main` and tag.
 
 ### Dogfood shim (`dogfood.yml`)
 
-`agent.yml` in this repo points at `@main` — it is the canonical shim users copy, so it must stay stable. To test pre-release features from `dev` against rdb's own issues, use the `/dogfood` command instead of `/agent`:
+`agent.yml` in this repo points at `@main` — it is the canonical shim users
+copy, so it must stay stable. To test pre-release features from `dev` against
+rdb's own issues, use the `/dogfood` command instead of `/agent`:
 
 ```
 /dogfood                        — resolve with default model (uses dev branch)
@@ -134,77 +168,120 @@ already covers all user customisation needs.
 
 ## Dev Cycle
 
-See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how the `e2e-test` branch pointer works and how to trigger test runs.
+See [AGENTS.md](AGENTS.md) for the full dev cycle documentation, including how
+the `e2e-test` branch pointer works and how to trigger test runs.
 
 ## Test Infrastructure
 
 ### Unit tests (`tests/test_config.py`, `tests/test_yaml.py`, `tests/test_compile.py`)
+
 - Run with `pytest tests/ -v` (needs `PYTHONPATH=.`)
 - CI runs these on PRs to main (`.github/workflows/test.yml`)
 
 #### Keeping defaults in sync
 
-`lib/config.py` and `scripts/compile.py` both have a fallback default for `openhands.version` (used when the config file has no `openhands` section). These must stay in sync. Both currently default to `"1.4.0"`. Each has a `# NOTE: keep in sync` comment pointing to the other.
+`lib/config.py` and `scripts/compile.py` both have a fallback default for
+`openhands.version` (used when the config file has no `openhands` section).
+These must stay in sync. Both currently default to `"1.4.0"`. Each has a
+`# NOTE: keep in sync` comment pointing to the other.
 
 ### E2E tests (`tests/e2e.sh`)
+
 - Creates issues in remote-dev-bot-test, triggers agent, polls for completion
 - Modes: `--provider claude` (one model family), `--all-models` (every alias)
 - Run via GitHub Actions: `.github/workflows/e2e.yml` (workflow_dispatch)
 - See `./tests/e2e.sh --help` for options
 
 ### Security e2e tests (`tests/e2e-security.sh`)
+
 - Secret exfiltration: verify agent refuses to expose secrets
 - User gating: verify non-collaborator comments don't trigger runs
 - Requires repos to be public and uses `RDB_TESTER_PAT_TOKEN`
 
 ### Loop prevention (not e2e tested — intentionally)
-The design agent has two layers of defense against recursive loops (where its response starts with `/agent` and re-triggers itself): a prompt instruction telling the LLM not to do it, and a regex check that blocks the response if it does. We deliberately do NOT e2e test this, because the test itself would be dangerous — if the regex has a bug, the test creates the very loop it's trying to prevent, consuming LLM budget. The regex is well covered by unit tests (`tests/test_yaml.py::TestLoopPreventionRegex`). The shim's `startsWith(comment.body, '/agent-')` trigger requires `/` as the literal first character (leading whitespace defeats it), which provides an additional layer of safety.
+
+The design agent has two layers of defense against recursive loops (where its
+response starts with `/agent` and re-triggers itself): a prompt instruction
+telling the LLM not to do it, and a regex check that blocks the response if it
+does. We deliberately do NOT e2e test this, because the test itself would be
+dangerous — if the regex has a bug, the test creates the very loop it's trying
+to prevent, consuming LLM budget. The regex is well covered by unit tests
+(`tests/test_yaml.py::TestLoopPreventionRegex`). The shim's
+`startsWith(comment.body, '/agent-')` trigger requires `/` as the literal first
+character (leading whitespace defeats it), which provides an additional layer of
+safety.
 
 ### Compiled workflow tests
-- Unit tests (`tests/test_compile.py`): validate both compiled files (resolve and design) — structure, triggers, permissions, model aliases, security microagent
-- E2E: `./tests/e2e.sh --compiled` swaps compiled workflows into the test repo, runs the full suite, then restores the shim. Use this before releases.
+
+- Unit tests (`tests/test_compile.py`): validate both compiled files (resolve
+  and design) — structure, triggers, permissions, model aliases, security
+  microagent
+- E2E: `./tests/e2e.sh --compiled` swaps compiled workflows into the test repo,
+  runs the full suite, then restores the shim. Use this before releases.
 
 ### Full test suite (`.github/workflows/full-test-suite.yml`)
-- One-button "run everything" workflow: unit tests → e2e shim → e2e compiled → e2e security
-- Jobs run **sequentially** — all e2e tests share `remote-dev-bot-test` and cannot run in parallel (shared e2e-test pointer, workflow files, and issues)
-- **Failure strategy**: unit tests are a fast-fail gate (e2e jobs skip if they fail); the three e2e blocks continue past each other's failures so one run gives a complete picture across all blocks. After a full run, use the individual workflow_dispatch workflows to rerun only the failing blocks.
+
+- One-button "run everything" workflow: unit tests → e2e shim → e2e compiled →
+  e2e security
+- Jobs run **sequentially** — all e2e tests share `remote-dev-bot-test` and
+  cannot run in parallel (shared e2e-test pointer, workflow files, and issues)
+- **Failure strategy**: unit tests are a fast-fail gate (e2e jobs skip if they
+  fail); the three e2e blocks continue past each other's failures so one run
+  gives a complete picture across all blocks. After a full run, use the
+  individual workflow_dispatch workflows to rerun only the failing blocks.
 - Use before releases to validate everything in one go
 
 ### Shared state constraint
-All e2e tests (functional, compiled, security) use `remote-dev-bot-test` as their target repo. They share:
+
+All e2e tests (functional, compiled, security) use `remote-dev-bot-test` as
+their target repo. They share:
+
 - The `e2e-test` branch pointer (set to the branch under test)
 - Workflow files in the test repo (compiled tests swap out the shim)
 - Issues and PRs created during the test run
 
-**Do not run e2e workflows in parallel.** Use the full test suite workflow for sequential execution, or run individual workflows one at a time.
+**Do not run e2e workflows in parallel.** Use the full test suite workflow for
+sequential execution, or run individual workflows one at a time.
 
 ## Release Procedure
 
-Releases distribute three compiled workflows (`agent-resolve.yml`, `agent-design.yml`, `agent-review.yml`) that users download into their repos.
+Releases distribute three compiled workflows (`agent-resolve.yml`,
+`agent-design.yml`, `agent-review.yml`) that users download into their repos.
 
-E2E tests cost real money (they invoke LLM APIs), so the full test suite is not automated. Run it manually before each release. The key rule: **test on `dev` before merging to `main`** — once something is on `main` it's live for users.
+E2E tests cost real money (they invoke LLM APIs), so the full test suite is not
+automated. Run it manually before each release. The key rule: **test on `dev`
+before merging to `main`** — once something is on `main` it's live for users.
 
 ### Steps
 
 1. **Ensure `dev` is ready**: all intended PRs merged to `dev`, unit CI green.
 
-2. **Run the full test suite on `dev`** via GitHub Actions → Full Test Suite → Run workflow (branch: **dev**).
-   - This runs unit tests → e2e shim (all models) → e2e compiled (all models) → e2e security, sequentially.
-   - Do not trigger other e2e workflows while this is running — they share the test repo and will interfere.
-   - If it fails, debug using targeted e2e triggers (one at a time), fix on a branch, merge to `dev`, and re-run.
+2. **Run the full test suite on `dev`** via GitHub Actions → Full Test Suite →
+   Run workflow (branch: **dev**).
+   - This runs unit tests → e2e shim (all models) → e2e compiled (all models) →
+     e2e security, sequentially.
+   - Do not trigger other e2e workflows while this is running — they share the
+     test repo and will interfere.
+   - If it fails, debug using targeted e2e triggers (one at a time), fix on a
+     branch, merge to `dev`, and re-run.
 
 3. **Merge `dev` → `main`** once the full test suite passes:
+
    ```bash
    git checkout main && git merge --ff-only dev && git push
    ```
 
 4. **Compile the release artifacts** (on `main`):
+
    ```bash
    python scripts/compile.py
    ```
-   This writes `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. Commit the updated dist files if they changed.
+
+   This writes `dist/agent-resolve.yml`, `dist/agent-design.yml`, and
+   `dist/agent-review.yml`. Commit the updated dist files if they changed.
 
 5. **Tag the release**:
+
    ```bash
    git tag -a vX.Y.Z -m "Release vX.Y.Z: summary of changes"
    git push origin vX.Y.Z
@@ -219,6 +296,11 @@ E2E tests cost real money (they invoke LLM APIs), so the full test suite is not 
 
 ### What goes in a release
 
-- Three compiled workflow files: `agent-resolve.yml` (issue resolution), `agent-design.yml` (design analysis), `agent-review.yml` (code review). All are self-contained with inlined config, model aliases, and security guardrails.
-- Users who installed via compiled workflows get updates by downloading the new release.
-- Users who installed via the shim get updates automatically when `main` is updated (the shim calls `remote-dev-bot.yml@main`).
+- Three compiled workflow files: `agent-resolve.yml` (issue resolution),
+  `agent-design.yml` (design analysis), `agent-review.yml` (code review). All
+  are self-contained with inlined config, model aliases, and security
+  guardrails.
+- Users who installed via compiled workflows get updates by downloading the new
+  release.
+- Users who installed via the shim get updates automatically when `main` is
+  updated (the shim calls `remote-dev-bot.yml@main`).

--- a/README.md
+++ b/README.md
@@ -1,49 +1,81 @@
 # Remote Dev Bot
 
-An AI-powered development workflow where GitHub issues get resolved autonomously via pull requests — like having a remote colleague who checks GitHub between surf sessions. Using shell-based agents feels like pair programming, which is a valuable mode of collaboration, but sometimes you want something that feels more like delegating work to an experienced coworker. This system aims to provide that alternative.
+An AI-powered development workflow where GitHub issues get resolved autonomously
+via pull requests — like having a remote colleague who checks GitHub between
+surf sessions. Using shell-based agents feels like pair programming, which is a
+valuable mode of collaboration, but sometimes you want something that feels more
+like delegating work to an experienced coworker. This system aims to provide
+that alternative.
 
-There are already excellent vendor-specific implementations of this pattern (GitHub Copilot Workspace, Cursor, etc.), so this project isn't necessarily better than those. However, it's intentionally cross-platform and was built as a learning exercise — a way to understand the agent tooling space and explore how to design agents that can autonomously handle real development tasks.
+There are already excellent vendor-specific implementations of this pattern
+(GitHub Copilot Workspace, Cursor, etc.), so this project isn't necessarily
+better than those. However, it's intentionally cross-platform and was built as a
+learning exercise — a way to understand the agent tooling space and explore how
+to design agents that can autonomously handle real development tasks.
 
 ## How It Works
 
 1. Create a GitHub issue describing a feature or bug
-2. Comment `/agent-resolve` (or `/agent-resolve-claude-large`, etc.) to trigger implementation
-3. A GitHub Action spins up an AI agent (powered by [OpenHands](https://github.com/OpenHands/OpenHands)) that:
+2. Comment `/agent-resolve` (or `/agent-resolve-claude-large`, etc.) to trigger
+   implementation
+3. A GitHub Action spins up an AI agent (powered by
+   [OpenHands](https://github.com/OpenHands/OpenHands)) that:
    - Reads the issue and codebase
    - Implements the requested changes
    - Opens a draft PR
-4. Review the PR. If changes are needed, comment `/agent-resolve` on the PR with feedback for another pass.
+4. Review the PR. If changes are needed, comment `/agent-resolve` on the PR with
+   feedback for another pass.
 
-Or use `/agent-design` to get AI design analysis posted as a comment (no code changes).
+Or use `/agent-design` to get AI design analysis posted as a comment (no code
+changes).
 
-Or use `/agent-review` on a pull request to get an AI code review posted as a comment (no code changes).
+Or use `/agent-review` on a pull request to get an AI code review posted as a
+comment (no code changes).
 
 **See it in action:**
 
-- **Simple resolve:** [Issue #33](https://github.com/gnovak/remote-dev-bot/issues/33) asked for model name documentation → [PR #52](https://github.com/gnovak/remote-dev-bot/pull/52) was created and merged autonomously.
+- **Simple resolve:**
+  [Issue #33](https://github.com/gnovak/remote-dev-bot/issues/33) asked for
+  model name documentation →
+  [PR #52](https://github.com/gnovak/remote-dev-bot/pull/52) was created and
+  merged autonomously.
 
-- **Design then resolve:** [Issue #124](https://github.com/gnovak/remote-dev-bot/issues/124) asked whether commands should be case-insensitive (for mobile autocorrect) → `/agent-design` posted [analysis with a recommendation](https://github.com/gnovak/remote-dev-bot/issues/124#issuecomment-3912240858) → human agreed → `/agent-resolve` created [PR #131](https://github.com/gnovak/remote-dev-bot/pull/131), merged.
+- **Design then resolve:**
+  [Issue #124](https://github.com/gnovak/remote-dev-bot/issues/124) asked
+  whether commands should be case-insensitive (for mobile autocorrect) →
+  `/agent-design` posted
+  [analysis with a recommendation](https://github.com/gnovak/remote-dev-bot/issues/124#issuecomment-3912240858)
+  → human agreed → `/agent-resolve` created
+  [PR #131](https://github.com/gnovak/remote-dev-bot/pull/131), merged.
 
-- **Resolve with feedback:** [Issue #95](https://github.com/gnovak/remote-dev-bot/issues/95) asked about preventing agent loops → `/agent-resolve` created [PR #109](https://github.com/gnovak/remote-dev-bot/pull/109) → reviewer [pointed out a regex bypass vulnerability](https://github.com/gnovak/remote-dev-bot/pull/109#issuecomment-3909533145) → `/agent-resolve` on the PR fixed it → merged.
+- **Resolve with feedback:**
+  [Issue #95](https://github.com/gnovak/remote-dev-bot/issues/95) asked about
+  preventing agent loops → `/agent-resolve` created
+  [PR #109](https://github.com/gnovak/remote-dev-bot/pull/109) → reviewer
+  [pointed out a regex bypass vulnerability](https://github.com/gnovak/remote-dev-bot/pull/109#issuecomment-3909533145)
+  → `/agent-resolve` on the PR fixed it → merged.
 
 ## Commands
 
-| Command | What it does |
-|---------|-------------|
-| `/agent-resolve` | Resolve the issue and open a PR (default model) |
-| `/agent-resolve-claude-large` | Resolve with a specific model |
-| `/agent-design` | Post design analysis as a comment (no code changes) |
-| `/agent-design-claude-large` | Design analysis with a specific model |
-| `/agent-review` | Post a code review comment on a PR (no code changes) |
-| `/agent-review-claude-large` | Code review with a specific model |
+| Command                       | What it does                                         |
+| ----------------------------- | ---------------------------------------------------- |
+| `/agent-resolve`              | Resolve the issue and open a PR (default model)      |
+| `/agent-resolve-claude-large` | Resolve with a specific model                        |
+| `/agent-design`               | Post design analysis as a comment (no code changes)  |
+| `/agent-design-claude-large`  | Design analysis with a specific model                |
+| `/agent-review`               | Post a code review comment on a PR (no code changes) |
+| `/agent-review-claude-large`  | Code review with a specific model                    |
 
 Modes and model aliases are configured in `remote-dev-bot.yaml`.
 
-**Mobile-friendly syntax:** Commands are case-insensitive and you can use spaces instead of dashes: `/agent resolve claude large` works the same as `/agent-resolve-claude-large`.
+**Mobile-friendly syntax:** Commands are case-insensitive and you can use spaces
+instead of dashes: `/agent resolve claude large` works the same as
+`/agent-resolve-claude-large`.
 
 ### Per-Invocation Arguments
 
-You can override settings for a single run by adding arguments on lines after the command:
+You can override settings for a single run by adding arguments on lines after
+the command:
 
 ```
 /agent resolve
@@ -52,60 +84,77 @@ target branch = feature/my-branch
 context = extra-context.md
 ```
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `max iterations` | integer | Override the iteration limit for this run |
-| `timeout minutes` | integer | Override the watchdog timeout in minutes for this run |
-| `target branch` | string | Target branch for the PR (default: `main`) |
-| `context` | list | Additional context files for the agent to read (space-separated) |
+| Argument          | Type    | Description                                                      |
+| ----------------- | ------- | ---------------------------------------------------------------- |
+| `max iterations`  | integer | Override the iteration limit for this run                        |
+| `timeout minutes` | integer | Override the watchdog timeout in minutes for this run            |
+| `target branch`   | string  | Target branch for the PR (default: `main`)                       |
+| `context`         | list    | Additional context files for the agent to read (space-separated) |
 
-Argument names are flexible: `max iterations`, `max-iterations`, and `max_iterations` all work.
+Argument names are flexible: `max iterations`, `max-iterations`, and
+`max_iterations` all work.
 
 ### Understanding Model Names
 
-Model aliases (like `claude-small`) map to **LiteLLM model identifiers** in `remote-dev-bot.yaml`. LiteLLM is the library OpenHands uses to talk to different LLM providers through a unified interface.
+Model aliases (like `claude-small`) map to **LiteLLM model identifiers** in
+`remote-dev-bot.yaml`. LiteLLM is the library OpenHands uses to talk to
+different LLM providers through a unified interface.
 
 **Model ID format:** `provider/model-name`
 
-| Provider | Prefix | Example |
-|----------|--------|---------|
+| Provider           | Prefix       | Example                       |
+| ------------------ | ------------ | ----------------------------- |
 | Anthropic (Claude) | `anthropic/` | `anthropic/claude-sonnet-4-5` |
-| OpenAI (GPT) | `openai/` | `openai/gpt-5.1-codex-mini` |
-| Google (Gemini) | `gemini/` | `gemini/gemini-2.5-flash` |
+| OpenAI (GPT)       | `openai/`    | `openai/gpt-5.1-codex-mini`   |
+| Google (Gemini)    | `gemini/`    | `gemini/gemini-2.5-flash`     |
 
 ### Supported Providers
 
 Remote Dev Bot currently supports three LLM providers out of the box:
 
-| Provider | Secret Name | Model Prefix |
-|----------|-------------|--------------|
+| Provider           | Secret Name         | Model Prefix |
+| ------------------ | ------------------- | ------------ |
 | Anthropic (Claude) | `ANTHROPIC_API_KEY` | `anthropic/` |
-| OpenAI (GPT) | `OPENAI_API_KEY` | `openai/` |
-| Google (Gemini) | `GEMINI_API_KEY` | `gemini/` |
+| OpenAI (GPT)       | `OPENAI_API_KEY`    | `openai/`    |
+| Google (Gemini)    | `GEMINI_API_KEY`    | `gemini/`    |
 
-The workflow automatically selects the correct API key based on the model prefix. For example, a model ID starting with `anthropic/` will use `ANTHROPIC_API_KEY`.
+The workflow automatically selects the correct API key based on the model
+prefix. For example, a model ID starting with `anthropic/` will use
+`ANTHROPIC_API_KEY`.
 
-**Adding a new provider:** LiteLLM supports many providers beyond these three. To add support for a new provider, you'll need to modify `.github/workflows/remote-dev-bot.yml`:
+**Adding a new provider:** LiteLLM supports many providers beyond these three.
+To add support for a new provider, you'll need to modify
+`.github/workflows/remote-dev-bot.yml`:
 
 1. Add the new secret to the `workflow_call.secrets` section
 2. Add a case in the "Determine API key" step to match the provider prefix
 3. Pass the secret to the environment in the resolve and design jobs
 
-See the [LiteLLM providers documentation](https://docs.litellm.ai/docs/providers) for the full list of supported providers and their model prefixes.
+See the
+[LiteLLM providers documentation](https://docs.litellm.ai/docs/providers) for
+the full list of supported providers and their model prefixes.
 
 ### Finding Valid Model Names
 
-OpenHands uses LiteLLM, so the model strings must be valid LiteLLM identifiers. Browse available models at **[models.litellm.ai](https://models.litellm.ai)** — search by name, filter by provider, and see context windows and pricing.
+OpenHands uses LiteLLM, so the model strings must be valid LiteLLM identifiers.
+Browse available models at **[models.litellm.ai](https://models.litellm.ai)** —
+search by name, filter by provider, and see context windows and pricing.
 
-Prefix the model string with the provider name in `remote-dev-bot.yaml` (e.g., `anthropic/claude-sonnet-4-5`).
+Prefix the model string with the provider name in `remote-dev-bot.yaml` (e.g.,
+`anthropic/claude-sonnet-4-5`).
 
 ### Choosing a Model
 
-**For most tasks:** Use the default (`/agent-resolve`). Claude Sonnet (`claude-small`) offers a good balance of capability and cost.
+**For most tasks:** Use the default (`/agent-resolve`). Claude Sonnet
+(`claude-small`) offers a good balance of capability and cost.
 
-**For complex multi-file features:** Use `/agent-resolve-claude-large` (Opus) or `/agent-resolve-gpt-large` (GPT Codex). These models handle larger contexts and more intricate reasoning.
+**For complex multi-file features:** Use `/agent-resolve-claude-large` (Opus) or
+`/agent-resolve-gpt-large` (GPT Codex). These models handle larger contexts and
+more intricate reasoning.
 
-**For coding-heavy tasks:** Models with "codex" in the name (e.g., `openai/gpt-5.1-codex-mini`) are specifically tuned for code generation and may perform better on implementation tasks.
+**For coding-heavy tasks:** Models with "codex" in the name (e.g.,
+`openai/gpt-5.1-codex-mini`) are specifically tuned for code generation and may
+perform better on implementation tasks.
 
 ### Commit Trailers
 
@@ -115,7 +164,10 @@ By default, each OpenHands commit includes a trailer identifying the model used:
 Model: claude-large (anthropic/claude-opus-4-5), openhands-ai v1.4.0
 ```
 
-This is appended by amending the commit after `send_pull_request` pushes it, which causes a force-push event visible in the PR timeline. To disable this (no trailer, no force push), set `commit_trailer` to empty in your `remote-dev-bot.yaml`:
+This is appended by amending the commit after `send_pull_request` pushes it,
+which causes a force-push event visible in the PR timeline. To disable this (no
+trailer, no force push), set `commit_trailer` to empty in your
+`remote-dev-bot.yaml`:
 
 ```yaml
 commit_trailer: ""
@@ -125,31 +177,49 @@ commit_trailer: ""
 
 The system has two parts:
 
-- **Shim workflow** (`.github/workflows/agent.yml`) — a thin trigger that lives in each target repo. Fires on `/agent-` commands and calls the reusable workflow. Copy this file to set up the shim install.
-- **Reusable workflow** (`.github/workflows/remote-dev-bot.yml`) — all the logic: parses commands, dispatches to resolve, design, or review mode, runs the agent. Lives in this repo and is called by shims in target repos.
-- **OpenHands** — the AI agent framework that does the actual code exploration and editing
-- **`remote-dev-bot.yaml`** — model aliases and OpenHands settings (version, max iterations, PR type)
-- **`install.md`** — step-by-step setup instructions, designed to be followed by a human or by an AI assistant (like Claude Code)
+- **Shim workflow** (`.github/workflows/agent.yml`) — a thin trigger that lives
+  in each target repo. Fires on `/agent-` commands and calls the reusable
+  workflow. Copy this file to set up the shim install.
+- **Reusable workflow** (`.github/workflows/remote-dev-bot.yml`) — all the
+  logic: parses commands, dispatches to resolve, design, or review mode, runs
+  the agent. Lives in this repo and is called by shims in target repos.
+- **OpenHands** — the AI agent framework that does the actual code exploration
+  and editing
+- **`remote-dev-bot.yaml`** — model aliases and OpenHands settings (version, max
+  iterations, PR type)
+- **`install.md`** — step-by-step setup instructions, designed to be followed by
+  a human or by an AI assistant (like Claude Code)
 
 ## Setup
 
-See `install.md` for complete setup instructions. It's designed so you (or an AI assistant) can follow it step-by-step to get this running in your own GitHub account.
+See `install.md` for complete setup instructions. It's designed so you (or an AI
+assistant) can follow it step-by-step to get this running in your own GitHub
+account.
 
-**Quick version:** You need a GitHub repo, API keys for your preferred LLM provider(s), and about 10 minutes. No PAT or special authentication is required — the bot works with GitHub's built-in token and posts as `github-actions[bot]`.
+**Quick version:** You need a GitHub repo, API keys for your preferred LLM
+provider(s), and about 10 minutes. No PAT or special authentication is required
+— the bot works with GitHub's built-in token and posts as `github-actions[bot]`.
 
-**Advanced auth options:** If you want bot PRs to auto-trigger CI, or a custom bot identity (e.g., `your-app[bot]`), see the advanced auth section in `install.md`. Options include a GitHub App (recommended) or a PAT.
+**Advanced auth options:** If you want bot PRs to auto-trigger CI, or a custom
+bot identity (e.g., `your-app[bot]`), see the advanced auth section in
+`install.md`. Options include a GitHub App (recommended) or a PAT.
 
 ## Customization
 
 ### Add Repo Context for the Agent
 
-Create `.openhands/microagents/repo.md` in your target repo with anything the agent should know about your codebase: coding conventions, architecture overview, how to run tests, directories to avoid, etc. The agent reads this file before starting work.
+Create `.openhands/microagents/repo.md` in your target repo with anything the
+agent should know about your codebase: coding conventions, architecture
+overview, how to run tests, directories to avoid, etc. The agent reads this file
+before starting work.
 
-An AI assistant can write this for you — just ask it to read your codebase and generate a `repo.md` describing the architecture and conventions.
+An AI assistant can write this for you — just ask it to read your codebase and
+generate a `repo.md` describing the architecture and conventions.
 
 ### Model Aliases
 
-Add or modify model aliases in your repo's `remote-dev-bot.yaml` (create it in the repo root if it doesn't exist):
+Add or modify model aliases in your repo's `remote-dev-bot.yaml` (create it in
+the repo root if it doesn't exist):
 
 ```yaml
 models:
@@ -158,11 +228,14 @@ models:
     description: "My custom model"
 ```
 
-These settings layer on top of the base config in `remote-dev-bot.yaml` from the remote-dev-bot repo. Your repo's settings take precedence. See [how-it-works.md](how-it-works.md) for config layering details.
+These settings layer on top of the base config in `remote-dev-bot.yaml` from the
+remote-dev-bot repo. Your repo's settings take precedence. See
+[how-it-works.md](how-it-works.md) for config layering details.
 
 ### Iteration Limits
 
-The agent runs for up to 50 iterations by default. Lower this for simpler repos (less cost, faster results) or raise it for complex tasks:
+The agent runs for up to 50 iterations by default. Lower this for simpler repos
+(less cost, faster results) or raise it for complex tasks:
 
 ```yaml
 openhands:
@@ -171,19 +244,23 @@ openhands:
 
 ### When the Agent Can't Fully Resolve an Issue
 
-Sometimes the agent judges that it couldn't completely fix the issue (it reports `success=False` in its evaluation). The `on_failure` setting controls what happens next:
+Sometimes the agent judges that it couldn't completely fix the issue (it reports
+`success=False` in its evaluation). The `on_failure` setting controls what
+happens next:
 
-| Value | Behaviour |
-|-------|-----------|
-| `comment` (default) | Posts a comment with the agent's evaluation and a link to the run logs. No PR is created. |
-| `draft` | Posts the same comment **and** opens a draft PR with whatever changes the agent made. Draft PRs cannot be merged until explicitly converted to "ready for review". |
+| Value               | Behaviour                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comment` (default) | Posts a comment with the agent's evaluation and a link to the run logs. No PR is created.                                                                          |
+| `draft`             | Posts the same comment **and** opens a draft PR with whatever changes the agent made. Draft PRs cannot be merged until explicitly converted to "ready for review". |
 
 ```yaml
 openhands:
-  on_failure: draft   # create a draft PR with partial changes
+  on_failure: draft # create a draft PR with partial changes
 ```
 
-Use `draft` if you want to review and complete partial work yourself. The default `comment` is safer — it surfaces what happened without creating a PR that might be accidentally merged.
+Use `draft` if you want to review and complete partial work yourself. The
+default `comment` is safer — it surfaces what happened without creating a PR
+that might be accidentally merged.
 
 ### Other Configuration Options
 
@@ -203,64 +280,101 @@ openhands:
   timeout_minutes: 120
 ```
 
-You can also override `max_iterations`, `target_branch`, and `context` on a per-invocation basis without editing the config file — see [Per-Invocation Arguments](#per-invocation-arguments).
+You can also override `max_iterations`, `target_branch`, and `context` on a
+per-invocation basis without editing the config file — see
+[Per-Invocation Arguments](#per-invocation-arguments).
 
 ## Security
 
 ### Who Can Trigger the Agent
 
-The workflow only runs when someone with **OWNER**, **COLLABORATOR**, or **MEMBER** role on the repository posts a `/agent-` comment. Anonymous users, first-time contributors, and external users cannot trigger agent runs — even on public repos.
+The workflow only runs when someone with **OWNER**, **COLLABORATOR**, or
+**MEMBER** role on the repository posts a `/agent-` comment. Anonymous users,
+first-time contributors, and external users cannot trigger agent runs — even on
+public repos.
 
-This is controlled by GitHub's `author_association` field, which the workflow checks before starting any agent work. You can adjust who is allowed by editing the `SECURITY_GATE` marker in your workflow file.
+This is controlled by GitHub's `author_association` field, which the workflow
+checks before starting any agent work. You can adjust who is allowed by editing
+the `SECURITY_GATE` marker in your workflow file.
 
 ### What the Agent Can Do
 
 The agent has significant access to your repository:
 
-- Reads all files — code, configuration, documentation, secrets referenced in the codebase
+- Reads all files — code, configuration, documentation, secrets referenced in
+  the codebase
 - Creates branches and pushes commits
 - Opens draft pull requests and posts comments
 
-The agent's file access is scoped to the repository. It cannot access other repositories or organization-level secrets beyond those explicitly passed as workflow secrets.
+The agent's file access is scoped to the repository. It cannot access other
+repositories or organization-level secrets beyond those explicitly passed as
+workflow secrets.
 
 ### Prompt Injection Risk
 
-The agent reads issue and PR comment text as instructions. Malicious issue text could attempt to manipulate the agent — for example, asking it to commit secrets, exfiltrate data, or do something unrelated to the issue. This is called prompt injection.
+The agent reads issue and PR comment text as instructions. Malicious issue text
+could attempt to manipulate the agent — for example, asking it to commit
+secrets, exfiltrate data, or do something unrelated to the issue. This is called
+prompt injection.
 
 Built-in mitigations:
 
-- **Collaborator gating**: Only people you've explicitly granted repo access to can trigger agent runs. An external attacker who can write an issue cannot trigger the agent unless they're already a collaborator.
-- **Security microagent**: The workflow includes hardened system prompt instructions (visible at the `SECURITY_GATE` marker) that tell the agent to refuse requests to exfiltrate secrets, modify CI pipelines, or take other unauthorized actions.
-- **OpenHands sandboxing**: The agent runs inside a container with limited access to the GitHub Actions runner environment.
+- **Collaborator gating**: Only people you've explicitly granted repo access to
+  can trigger agent runs. An external attacker who can write an issue cannot
+  trigger the agent unless they're already a collaborator.
+- **Security microagent**: The workflow includes hardened system prompt
+  instructions (visible at the `SECURITY_GATE` marker) that tell the agent to
+  refuse requests to exfiltrate secrets, modify CI pipelines, or take other
+  unauthorized actions.
+- **OpenHands sandboxing**: The agent runs inside a container with limited
+  access to the GitHub Actions runner environment.
 
 ### Recommendations
 
-- **Review all agent PRs before merging.** Agent-created branches are draft PRs by default — treat them as you would code from any external contributor.
-- **Use branch protection rules.** Require PR reviews on `main` so no agent-created branch can be merged without a human sign-off.
-- **Don't put secrets in issue bodies.** The agent reads issues; sensitive data in issue text can appear in agent logs or commit messages.
-- **Audit the `SECURITY_GATE` policy** in your workflow file if you want to further restrict who can trigger the agent (e.g., OWNER-only on sensitive repos).
+- **Review all agent PRs before merging.** Agent-created branches are draft PRs
+  by default — treat them as you would code from any external contributor.
+- **Use branch protection rules.** Require PR reviews on `main` so no
+  agent-created branch can be merged without a human sign-off.
+- **Don't put secrets in issue bodies.** The agent reads issues; sensitive data
+  in issue text can appear in agent logs or commit messages.
+- **Audit the `SECURITY_GATE` policy** in your workflow file if you want to
+  further restrict who can trigger the agent (e.g., OWNER-only on sensitive
+  repos).
 
 ## Troubleshooting
 
 ### Getting a second PR instead of a revision
 
-You probably commented on the original issue instead of the PR. Commenting on the issue always creates a new PR; commenting on the PR adds commits to the existing one. Check which page you're on before triggering.
+You probably commented on the original issue instead of the PR. Commenting on
+the issue always creates a new PR; commenting on the PR adds commits to the
+existing one. Check which page you're on before triggering.
 
-(The two-PR behavior is also intentional when you want to compare different model implementations — trigger from the issue twice with different model aliases.)
+(The two-PR behavior is also intentional when you want to compare different
+model implementations — trigger from the issue twice with different model
+aliases.)
 
 ### Cost showing $0.00
 
-The workflow couldn't capture token usage data from this run. Check the Actions log for the run — look at the "Calculate and post cost" or "Post cost comment" step to see what was found.
+The workflow couldn't capture token usage data from this run. Check the Actions
+log for the run — look at the "Calculate and post cost" or "Post cost comment"
+step to see what was found.
 
 ### Agent triggered but no PR appeared
 
-The agent ran, posted a comment with its evaluation, but didn't open a PR. This means the agent judged that it couldn't fully resolve the issue — it hit the iteration limit, got confused, or determined its changes were incomplete.
+The agent ran, posted a comment with its evaluation, but didn't open a PR. This
+means the agent judged that it couldn't fully resolve the issue — it hit the
+iteration limit, got confused, or determined its changes were incomplete.
 
-Try a more capable model (`/agent-resolve-claude-large`) or add more detail to the issue description. The agent's evaluation comment will say what it attempted and why it stopped.
+Try a more capable model (`/agent-resolve-claude-large`) or add more detail to
+the issue description. The agent's evaluation comment will say what it attempted
+and why it stopped.
 
-To receive a draft PR with whatever partial changes the agent made, set `openhands.on_failure: draft` in your `remote-dev-bot.yaml` (see [When the Agent Can't Fully Resolve an Issue](#when-the-agent-cant-fully-resolve-an-issue)).
+To receive a draft PR with whatever partial changes the agent made, set
+`openhands.on_failure: draft` in your `remote-dev-bot.yaml` (see
+[When the Agent Can't Fully Resolve an Issue](#when-the-agent-cant-fully-resolve-an-issue)).
 
-**Diagnosing failures with an interactive agent:** The fastest way to understand what went wrong is to ask an AI coding assistant to read the logs for you:
+**Diagnosing failures with an interactive agent:** The fastest way to understand
+what went wrong is to ask an AI coding assistant to read the logs for you:
 
 ```
 Have a look at issue 50 — I triggered the agent but it didn't make a PR. Look through the Actions logs and tell me what went wrong.
@@ -272,30 +386,54 @@ Or point at a specific run ID from the Actions tab:
 Have a look at Actions run 12345678 in this repo. What went wrong?
 ```
 
-The assistant can fetch the logs via `gh run view`, identify the failure point, and suggest a fix.
+The assistant can fetch the logs via `gh run view`, identify the failure point,
+and suggest a fix.
 
 ### Other issues
 
-See the Troubleshooting section in `install.md` for installation-related problems (workflow not triggering, secrets not reaching the workflow, etc.).
+See the Troubleshooting section in `install.md` for installation-related
+problems (workflow not triggering, secrets not reaching the workflow, etc.).
 
 ## LLM Provider Quick Reference
 
 Dashboard, billing, and API key management links for each supported provider.
 
 **Anthropic (Claude)**
-- [Dashboard](https://console.anthropic.com/dashboard) · [API keys](https://console.anthropic.com/settings/keys) · [Usage](https://console.anthropic.com/settings/usage) · [Limits](https://console.anthropic.com/settings/limits) · [Billing](https://console.anthropic.com/settings/billing)
+
+- [Dashboard](https://console.anthropic.com/dashboard) ·
+  [API keys](https://console.anthropic.com/settings/keys) ·
+  [Usage](https://console.anthropic.com/settings/usage) ·
+  [Limits](https://console.anthropic.com/settings/limits) ·
+  [Billing](https://console.anthropic.com/settings/billing)
 
 **OpenAI (GPT)**
-- [Dashboard](https://platform.openai.com/settings/organization/billing/overview) · [API keys](https://platform.openai.com/api-keys) · [Usage](https://platform.openai.com/account/usage) · [Limits](https://platform.openai.com/account/billing/limits) · [Billing](https://platform.openai.com/settings/organization/billing/overview)
+
+- [Dashboard](https://platform.openai.com/settings/organization/billing/overview)
+  · [API keys](https://platform.openai.com/api-keys) ·
+  [Usage](https://platform.openai.com/account/usage) ·
+  [Limits](https://platform.openai.com/account/billing/limits) ·
+  [Billing](https://platform.openai.com/settings/organization/billing/overview)
 
 **Google (Gemini)**
-- [API keys](https://aistudio.google.com/app/apikey) · [Usage & rate limits](https://aistudio.google.com/app/usage) · [Projects](https://aistudio.google.com/app/projects)
-- Google AI Studio is the simplest way to manage Gemini API keys. It's a lightweight frontend to the same API available through Google Cloud Console.
+
+- [API keys](https://aistudio.google.com/app/apikey) ·
+  [Usage & rate limits](https://aistudio.google.com/app/usage) ·
+  [Projects](https://aistudio.google.com/app/projects)
+- Google AI Studio is the simplest way to manage Gemini API keys. It's a
+  lightweight frontend to the same API available through Google Cloud Console.
 
 ## Current Status
 
-**v0.3.0** — Mode-based commands + compiled workflows (Feb 15, 2026). Three command modes: `/agent-resolve` (opens PR), `/agent-design` (posts analysis comment), and `/agent-review` (posts code review on a PR). Multi-provider support (Claude, GPT, Gemini). Two-file compiled install. Security guardrails and config layering. See [CHANGELOG.md](CHANGELOG.md) for details.
+**v0.3.0** — Mode-based commands + compiled workflows (Feb 15, 2026). Three
+command modes: `/agent-resolve` (opens PR), `/agent-design` (posts analysis
+comment), and `/agent-review` (posts code review on a PR). Multi-provider
+support (Claude, GPT, Gemini). Two-file compiled install. Security guardrails
+and config layering. See [CHANGELOG.md](CHANGELOG.md) for details.
 
-**v0.2.0** — Shim + reusable workflow (Feb 11, 2026). Refactored into a thin shim per target repo that calls a shared reusable workflow. Cross-repo support tested with separate test repo.
+**v0.2.0** — Shim + reusable workflow (Feb 11, 2026). Refactored into a thin
+shim per target repo that calls a shared reusable workflow. Cross-repo support
+tested with separate test repo.
 
-**v0.1.0** — First working version (Feb 9, 2026). End-to-end pipeline operational: `/agent` comment on an issue triggers OpenHands, which resolves the issue and opens a draft PR.
+**v0.1.0** — First working version (Feb 9, 2026). End-to-end pipeline
+operational: `/agent` comment on an issue triggers OpenHands, which resolves the
+issue and opens a draft PR.

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -1,10 +1,13 @@
 # How Remote Dev Bot Works
 
-This document explains the architecture of Remote Dev Bot: what files live where, how the pieces connect, and how to think about the system when setting it up.
+This document explains the architecture of Remote Dev Bot: what files live
+where, how the pieces connect, and how to think about the system when setting it
+up.
 
 ## The Two-Repo Model
 
-Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two repositories:
+Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two
+repositories:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -46,31 +49,37 @@ Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two rep
 
 This is the "engine" — the shared infrastructure that all target repos use.
 
-| File | Purpose |
-|------|---------|
+| File                                   | Purpose                                                                                                                                        |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
-| `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
-| `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
-| `install.md` | Step-by-step setup instructions for humans or AI assistants. |
+| `remote-dev-bot.yaml`                  | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type).    |
+| `.github/workflows/agent.yml`          | Shim workflow. Also serves as the template — copy this to target repos.                                                                        |
+| `install.md`                           | Step-by-step setup instructions for humans or AI assistants.                                                                                   |
 
-**Who maintains this:** The upstream maintainer (gnovak), or you if you forked it. Updates here automatically flow to all target repos that reference it.
+**Who maintains this:** The upstream maintainer (gnovak), or you if you forked
+it. Updates here automatically flow to all target repos that reference it.
 
 ### In Each Target Repo
 
 This is where you want the AI agent to help with development.
 
-| File | Purpose |
-|------|---------|
-| `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, and `/agent-review` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
-| `remote-dev-bot.yaml` | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config. |
+| File                             | Purpose                                                                                                                                                                                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.github/workflows/agent.yml`    | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, and `/agent-review` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need.                                                    |
+| `remote-dev-bot.yaml`            | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config.                                                                                                            |
 | `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. You can also use `AGENTS.md` or `CLAUDE.md` and add them to `context_files` in your `remote-dev-bot.yaml`. |
 
 **Repository Secrets (required):**
-- At least one LLM API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`
+
+- At least one LLM API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
+  `GEMINI_API_KEY`
 
 **Repository Secrets/Variables (optional — for bot identity or CI triggering):**
-- `RDB_APP_ID` (variable) + `RDB_APP_PRIVATE_KEY` (secret): GitHub App — bot posts as `app-name[bot]`, CI triggers on bot PRs
-- `RDB_PAT_TOKEN` (secret): PAT — bot posts as the PAT owner, CI triggers on bot PRs
+
+- `RDB_APP_ID` (variable) + `RDB_APP_PRIVATE_KEY` (secret): GitHub App — bot
+  posts as `app-name[bot]`, CI triggers on bot PRs
+- `RDB_PAT_TOKEN` (secret): PAT — bot posts as the PAT owner, CI triggers on bot
+  PRs
 - Without either: bot posts as `github-actions[bot]`, bot PRs don't trigger CI
 
 ## How the Pieces Connect
@@ -78,12 +87,18 @@ This is where you want the AI agent to help with development.
 When someone comments `/agent-resolve-claude-large` on an issue:
 
 1. **Shim triggers** — The target repo's `agent.yml` fires on the comment
-2. **Calls reusable workflow** — The shim calls `remote-dev-bot.yml@main` from remote-dev-bot
-3. **Config checkout** — remote-dev-bot.yml sparse-checks out `remote-dev-bot.yaml` and `lib/` from remote-dev-bot
-4. **Config merge** — base config from remote-dev-bot is merged with any override config in the target repo
-5. **Model resolution** — The alias `claude-large` is resolved to a model ID like `anthropic/claude-opus-4-5`
-6. **Feedback** — A rocket emoji is added to your comment and you're assigned to the issue, so you can see at a glance which issues have active work
-7. **Agent runs** — OpenHands reads the issue, explores the codebase, makes changes
+2. **Calls reusable workflow** — The shim calls `remote-dev-bot.yml@main` from
+   remote-dev-bot
+3. **Config checkout** — remote-dev-bot.yml sparse-checks out
+   `remote-dev-bot.yaml` and `lib/` from remote-dev-bot
+4. **Config merge** — base config from remote-dev-bot is merged with any
+   override config in the target repo
+5. **Model resolution** — The alias `claude-large` is resolved to a model ID
+   like `anthropic/claude-opus-4-5`
+6. **Feedback** — A rocket emoji is added to your comment and you're assigned to
+   the issue, so you can see at a glance which issues have active work
+7. **Agent runs** — OpenHands reads the issue, explores the codebase, makes
+   changes
 8. **PR created** — A draft (or ready) PR is opened with the changes
 
 ```
@@ -114,10 +129,10 @@ User comments /agent-resolve-claude-large
 
 Configuration is merged across two layers (each is optional, deeper layers win):
 
-| Layer | File | Where it lives |
-|-------|------|----------------|
-| Base | `remote-dev-bot.yaml` | remote-dev-bot repo (fetched via sparse-checkout) |
-| Override | `remote-dev-bot.yaml` | target repo root |
+| Layer    | File                  | Where it lives                                    |
+| -------- | --------------------- | ------------------------------------------------- |
+| Base     | `remote-dev-bot.yaml` | remote-dev-bot repo (fetched via sparse-checkout) |
+| Override | `remote-dev-bot.yaml` | target repo root                                  |
 
 Example:
 
@@ -134,23 +149,30 @@ openhands:
   max_iterations: 30
 ```
 
-Result: `default_model: claude-large`, `max_iterations: 30`, `pr_type: ready` (inherited from base).
+Result: `default_model: claude-large`, `max_iterations: 30`, `pr_type: ready`
+(inherited from base).
 
-Merges are deep (leaf-level): overriding `openhands.max_iterations` does not clobber other `openhands` fields.
+Merges are deep (leaf-level): overriding `openhands.max_iterations` does not
+clobber other `openhands` fields.
 
 This lets you:
+
 - Use different default models per repo
 - Set lower iteration limits for repos with simpler tasks
-- Override only the settings that matter to your repo — everything else is inherited from the base
+- Override only the settings that matter to your repo — everything else is
+  inherited from the base
 
-The workflow logs show which configs were loaded, so you can verify what's in effect:
+The workflow logs show which configs were loaded, so you can verify what's in
+effect:
+
 ```
 Config: base=remote-dev-bot, override=target repo
 ```
 
 ## Per-Invocation Arguments (Inline Args)
 
-Users can override config values for a single run by adding argument lines after the command in their GitHub comment:
+Users can override config values for a single run by adding argument lines after
+the command in their GitHub comment:
 
 ```
 /agent-resolve
@@ -160,17 +182,21 @@ context_files = docs/architecture.md extra-context.md
 ```
 
 **How it works:**
-- The first line is the command; subsequent `name = value` lines are parsed as arguments
-- Argument names are normalized: spaces, dashes, and underscores are equivalent (`max iterations`, `max-iterations`, and `max_iterations` all resolve to the same thing)
+
+- The first line is the command; subsequent `name = value` lines are parsed as
+  arguments
+- Argument names are normalized: spaces, dashes, and underscores are equivalent
+  (`max iterations`, `max-iterations`, and `max_iterations` all resolve to the
+  same thing)
 
 **Supported arguments:**
 
-| Argument | Applies to | Description |
-|----------|-----------|-------------|
-| `max_iterations` | `openhands.max_iterations` | Override iteration limit for this run |
-| `target_branch` | `openhands.target_branch` | Override target branch for this run |
-| `timeout_minutes` | `openhands.timeout_minutes` | Override watchdog timeout for this run |
-| `context_files` | the mode's `context_files` | Append extra files (space-separated) — does not replace existing list |
+| Argument          | Applies to                  | Description                                                           |
+| ----------------- | --------------------------- | --------------------------------------------------------------------- |
+| `max_iterations`  | `openhands.max_iterations`  | Override iteration limit for this run                                 |
+| `target_branch`   | `openhands.target_branch`   | Override target branch for this run                                   |
+| `timeout_minutes` | `openhands.timeout_minutes` | Override watchdog timeout for this run                                |
+| `context_files`   | the mode's `context_files`  | Append extra files (space-separated) — does not replace existing list |
 
 Unknown argument names are rejected with an error comment.
 
@@ -178,45 +204,61 @@ Unknown argument names are rejected with an error comment.
 
 ### How tokens work
 
-The workflow uses a three-way token fallback: GitHub App token > `RDB_PAT_TOKEN` > `github.token`. Whichever is configured takes priority. Each option has different trade-offs:
+The workflow uses a three-way token fallback: GitHub App token >
+`RDB_PAT_TOKEN` > `github.token`. Whichever is configured takes priority. Each
+option has different trade-offs:
 
-| | No config (default) | RDB_PAT_TOKEN | GitHub App |
-|---|---|---|---|
-| **Bot identity** | `github-actions[bot]` | PAT owner's personal account | `app-name[bot]` |
-| **CI triggers on bot PRs** | No | Yes | Yes |
-| **Setup effort** | None | Create PAT, add secret | Create app, add secret + variable |
+|                            | No config (default)   | RDB_PAT_TOKEN                | GitHub App                        |
+| -------------------------- | --------------------- | ---------------------------- | --------------------------------- |
+| **Bot identity**           | `github-actions[bot]` | PAT owner's personal account | `app-name[bot]`                   |
+| **CI triggers on bot PRs** | No                    | Yes                          | Yes                               |
+| **Setup effort**           | None                  | Create PAT, add secret       | Create app, add secret + variable |
 
-**For most users, the default (no config) is the right choice.** The bot posts as `github-actions[bot]`, which is clearly not you. The only downside is that CI workflows won't auto-run on bot-created PRs — you can trigger them manually.
+**For most users, the default (no config) is the right choice.** The bot posts
+as `github-actions[bot]`, which is clearly not you. The only downside is that CI
+workflows won't auto-run on bot-created PRs — you can trigger them manually.
 
 ### Cross-owner secret passing
 
-GitHub Actions does not pass `secrets: inherit` across different repo owners. Since your target repo and `gnovak/remote-dev-bot` have different owners, the shim must list secrets explicitly:
+GitHub Actions does not pass `secrets: inherit` across different repo owners.
+Since your target repo and `gnovak/remote-dev-bot` have different owners, the
+shim must list secrets explicitly:
 
 ```yaml
-    uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      RDB_PAT_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
-      RDB_APP_PRIVATE_KEY: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
+secrets:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+  RDB_PAT_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
+  RDB_APP_PRIVATE_KEY: ${{ secrets.RDB_APP_PRIVATE_KEY }}
 ```
 
-If you fork remote-dev-bot into your own org and your target repos are in the same org, `secrets: inherit` will work.
+If you fork remote-dev-bot into your own org and your target repos are in the
+same org, `secrets: inherit` will work.
 
 ### Advanced: GitHub App setup
 
-A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and triggers CI on bot PRs. See [install.md](install.md) for step-by-step setup instructions.
+A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and
+triggers CI on bot PRs. See [install.md](install.md) for step-by-step setup
+instructions.
 
 ### Advanced: PAT setup
 
-A PAT is simpler than a GitHub App but the bot posts as your personal account. See [install.md](install.md) for PAT creation instructions. Store it as `RDB_PAT_TOKEN`.
+A PAT is simpler than a GitHub App but the bot posts as your personal account.
+See [install.md](install.md) for PAT creation instructions. Store it as
+`RDB_PAT_TOKEN`.
 
 ### Visibility requirements
 
-The shim install requires `gnovak/remote-dev-bot` (or your fork) to be **public** so the target repo's workflow can call the reusable workflow. Your target repo can be public or private — only the repo hosting the reusable workflow must be public (or in the same org with appropriate Actions access settings).
+The shim install requires `gnovak/remote-dev-bot` (or your fork) to be
+**public** so the target repo's workflow can call the reusable workflow. Your
+target repo can be public or private — only the repo hosting the reusable
+workflow must be public (or in the same org with appropriate Actions access
+settings).
 
-The compiled install has no visibility requirements since the workflow is self-contained.
+The compiled install has no visibility requirements since the workflow is
+self-contained.
 
 ## Using Your Own Fork
 
@@ -227,19 +269,23 @@ Organizations often want full control over the reusable workflow. To use a fork:
    ```yaml
    uses: myorg/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
    ```
-3. Set Actions access on your fork (Settings → Actions → General → Access → "Accessible from repositories owned by the user")
-4. If your fork and target repos are in the same org, you can use `secrets: inherit` instead of listing secrets explicitly
+3. Set Actions access on your fork (Settings → Actions → General → Access →
+   "Accessible from repositories owned by the user")
+4. If your fork and target repos are in the same org, you can use
+   `secrets: inherit` instead of listing secrets explicitly
 
-Now updates to your fork flow to your target repos, and you control the release cadence.
+Now updates to your fork flow to your target repos, and you control the release
+cadence.
 
-**Private forks:** If you keep your fork private, your target repos must be in the same org/user account (GitHub doesn't allow cross-owner calls to private repo workflows). Set the Actions access level as described in step 3.
+**Private forks:** If you keep your fork private, your target repos must be in
+the same org/user account (GitHub doesn't allow cross-owner calls to private
+repo workflows). Set the Actions access level as described in step 3.
 
 ## Quick Reference
 
-| I want to... | Where |
-|--------------|-------|
-| Set up a new repo to use the bot | Follow [runbook.md](runbook.md) |
-| Change the default model for my repo | `remote-dev-bot.yaml` in target repo |
+| I want to...                             | Where                                           |
+| ---------------------------------------- | ----------------------------------------------- |
+| Set up a new repo to use the bot         | Follow [runbook.md](runbook.md)                 |
+| Change the default model for my repo     | `remote-dev-bot.yaml` in target repo            |
 | Give the agent context about my codebase | `.openhands/microagents/repo.md` in target repo |
-| Override a setting for a single run | Inline args in the trigger comment (see above) |
-
+| Override a setting for a single run      | Inline args in the trigger comment (see above)  |

--- a/install.md
+++ b/install.md
@@ -2,36 +2,63 @@
 
 ## Quick Start
 
-This guide will walk you through setting up Remote Dev Bot on your GitHub repository. By the end, you'll have an AI-powered bot that can automatically resolve issues and create pull requests when triggered by a `/agent-resolve` comment.
+This guide will walk you through setting up Remote Dev Bot on your GitHub
+repository. By the end, you'll have an AI-powered bot that can automatically
+resolve issues and create pull requests when triggered by a `/agent-resolve`
+comment.
 
-The easiest way to install is to tell your favorite AI agent "Follow the runbook.md file to set up remote-dev-bot for my repo {owner}/{repo}."
+The easiest way to install is to tell your favorite AI agent "Follow the
+runbook.md file to set up remote-dev-bot for my repo {owner}/{repo}."
 
 ---
 
 ## Overview
 
-**How the bot works:** When you comment `/agent-resolve` on an issue, a GitHub Actions workflow starts. It spins up [OpenHands](https://github.com/All-Hands-AI/OpenHands) (an open-source AI coding agent) in a sandboxed container, points it at your issue, and lets it work. The agent reads the issue, explores your codebase, writes code, runs tests, and iterates until it has a solution. Then it pushes a branch and opens a draft PR for your review. You can also use `/agent-design` for AI design analysis posted as a comment (no code changes), or `/agent-review` on a pull request to get an AI code review.  Once you have human or machine generated comments and requested changes on the PR, you can comment '/agent-resolve' on the PR to make the requested changes.
+**How the bot works:** When you comment `/agent-resolve` on an issue, a GitHub
+Actions workflow starts. It spins up
+[OpenHands](https://github.com/All-Hands-AI/OpenHands) (an open-source AI coding
+agent) in a sandboxed container, points it at your issue, and lets it work. The
+agent reads the issue, explores your codebase, writes code, runs tests, and
+iterates until it has a solution. Then it pushes a branch and opens a draft PR
+for your review. You can also use `/agent-design` for AI design analysis posted
+as a comment (no code changes), or `/agent-review` on a pull request to get an
+AI code review. Once you have human or machine generated comments and requested
+changes on the PR, you can comment '/agent-resolve' on the PR to make the
+requested changes.
 
 **What you'll set up:**
 
-1. **Phase 1: Install and Configure GitHub CLI** — Install the `gh` command-line tool and authenticate with GitHub
-2. **Phase 2: GitHub Repository Settings** — Configure repository permissions, create API keys for your chosen LLM provider(s), and store them as GitHub secrets
-3. **Phase 3: Install the Workflow** — Add a small workflow file to your repository that connects to the Remote Dev Bot system
-4. **Phase 4: Test It** — Create a test issue and trigger the bot to verify everything works
-5. **Phase 5: Customize (Optional)** — See README.md for adding repo context, adjusting models, and tuning iteration limits
-6. **Phase 6: Report Install Feedback (Optional)** — If you encountered problems, report them to help improve the guide
+1. **Phase 1: Install and Configure GitHub CLI** — Install the `gh` command-line
+   tool and authenticate with GitHub
+2. **Phase 2: GitHub Repository Settings** — Configure repository permissions,
+   create API keys for your chosen LLM provider(s), and store them as GitHub
+   secrets
+3. **Phase 3: Install the Workflow** — Add a small workflow file to your
+   repository that connects to the Remote Dev Bot system
+4. **Phase 4: Test It** — Create a test issue and trigger the bot to verify
+   everything works
+5. **Phase 5: Customize (Optional)** — See README.md for adding repo context,
+   adjusting models, and tuning iteration limits
+6. **Phase 6: Report Install Feedback (Optional)** — If you encountered
+   problems, report them to help improve the guide
 
-**Time estimate:** 15-30 minutes for initial setup, depending on whether you already have the GitHub CLI installed and authenticated.
+**Time estimate:** 15-30 minutes for initial setup, depending on whether you
+already have the GitHub CLI installed and authenticated.
 
 ---
 
 ## How to Use This Guide
 
-This file is both documentation and executable instructions. It's designed to be followed by:
-- **A human** reading step-by-step
-- **An AI assistant** (like Claude Code) that can execute steps, ask for confirmation, and handle errors
+This file is both documentation and executable instructions. It's designed to be
+followed by:
 
-When following this guide with an AI assistant, the assistant should **default to the guided experience** unless the user asks to go faster:
+- **A human** reading step-by-step
+- **An AI assistant** (like Claude Code) that can execute steps, ask for
+  confirmation, and handle errors
+
+When following this guide with an AI assistant, the assistant should **default
+to the guided experience** unless the user asks to go faster:
+
 - Explain what each step does and why it's needed **before** executing it
 - Ask for confirmation before each action (not just secrets — all steps)
 - Ask whether the user already has API keys, PATs, etc. before creating new ones
@@ -39,7 +66,9 @@ When following this guide with an AI assistant, the assistant should **default t
 - If a step fails, diagnose the issue and suggest recovery options
 - Keep the user oriented: "We just finished X. Next is Y, which does Z."
 
-Experienced users can ask for a faster pace (see prompt examples below), in which case the assistant should skip explanations and only pause for secrets and confirmations that require user input.
+Experienced users can ask for a faster pace (see prompt examples below), in
+which case the assistant should skip explanations and only pause for secrets and
+confirmations that require user input.
 
 ---
 
@@ -49,60 +78,78 @@ Before starting, make sure you have:
 
 - [ ] A GitHub account
 - [ ] A GitHub repository where you want the bot to operate
-- [ ] **(For AI-assisted install)** An AI coding agent installed and configured. Supported options include:
+- [ ] **(For AI-assisted install)** An AI coding agent installed and configured.
+      Supported options include:
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude` CLI)
   - [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`gemini` CLI)
   - [OpenAI Codex CLI](https://github.com/openai/codex) (`codex` CLI)
   - Or any other AI coding assistant that can execute shell commands
 
-Throughout this guide, replace `{owner}/{repo}` with your actual GitHub owner and repo name (e.g., `myuser/myproject`).
+Throughout this guide, replace `{owner}/{repo}` with your actual GitHub owner
+and repo name (e.g., `myuser/myproject`).
 
 ---
 
 ## Using This Guide with an AI Coding Agent
 
-If you have an AI coding agent installed, you can have it guide you through the setup process.
+If you have an AI coding agent installed, you can have it guide you through the
+setup process.
 
 **First time? Use the guided setup** (recommended):
+
 ```bash
 claude "Follow the install.md file to set up remote-dev-bot for my repo {owner}/{repo}. This is my first time — walk me through each step, explain what's happening, and ask before doing anything."
 ```
 
 **Done this before? Use the fast setup:**
+
 ```bash
 claude "Follow the install.md file to set up remote-dev-bot for my repo {owner}/{repo}. I'm familiar with the process — go fast, just ask me for secrets and confirmations."
 ```
 
-These examples use Claude Code, but the same prompts work with any AI coding agent (Gemini CLI, Codex CLI, etc.) — just replace `claude` with your agent's command.
+These examples use Claude Code, but the same prompts work with any AI coding
+agent (Gemini CLI, Codex CLI, etc.) — just replace `claude` with your agent's
+command.
 
-The AI agent will read this guide, execute the necessary commands, and prompt you when it needs your input (like pasting API keys or confirming GitHub settings changes).
+The AI agent will read this guide, execute the necessary commands, and prompt
+you when it needs your input (like pasting API keys or confirming GitHub
+settings changes).
 
 ---
 
 ## Phase 1: Install and Configure GitHub CLI
 
-> **Note for humans:** This phase is optional if you prefer using the web interface. Throughout this guide, most steps provide both web interface and command line options. If you skip this phase, just use the "Via web interface" instructions in later steps. The CLI is useful for automation and scripting, but not required.
+> **Note for humans:** This phase is optional if you prefer using the web
+> interface. Throughout this guide, most steps provide both web interface and
+> command line options. If you skip this phase, just use the "Via web interface"
+> instructions in later steps. The CLI is useful for automation and scripting,
+> but not required.
 
 ### Step 1.1: Check if GitHub CLI is Already Installed
 
-**What this does:** Verifies if you already have the GitHub command-line tool installed. If it's already installed, you can skip the installation step.
+**What this does:** Verifies if you already have the GitHub command-line tool
+installed. If it's already installed, you can skip the installation step.
 
 ```bash
 gh --version
 ```
 
-If this command succeeds and shows a version number, you already have `gh` installed. Skip to Step 1.2.
+If this command succeeds and shows a version number, you already have `gh`
+installed. Skip to Step 1.2.
 
 If the command fails (command not found), proceed with the installation:
 
 **On macOS:**
+
 ```bash
 brew install gh
 ```
 
 **On Linux (Debian/Ubuntu):**
 
-`gh` isn't in the standard Debian/Ubuntu repositories, so this script adds GitHub's own apt repository first (downloading their signing key and registering the repo), then installs from it:
+`gh` isn't in the standard Debian/Ubuntu repositories, so this script adds
+GitHub's own apt repository first (downloading their signing key and registering
+the repo), then installs from it:
 
 ```bash
 type -p curl >/dev/null || sudo apt install curl -y
@@ -114,12 +161,13 @@ sudo apt install gh -y
 ```
 
 **On Linux (Fedora/RHEL/CentOS):**
+
 ```bash
 sudo dnf install gh
 ```
 
-**On Windows:**
-Download and install from https://cli.github.com/ or use:
+**On Windows:** Download and install from https://cli.github.com/ or use:
+
 ```bash
 winget install --id GitHub.cli
 ```
@@ -127,28 +175,33 @@ winget install --id GitHub.cli
 **Other platforms:** See https://cli.github.com/ for installation instructions.
 
 After installation, verify:
+
 ```bash
 gh --version
 ```
 
 ### Step 1.2: Authenticate with GitHub
 
-**What this does:** Logs you into GitHub through the command line so you can manage repositories, secrets, and workflows.
+**What this does:** Logs you into GitHub through the command line so you can
+manage repositories, secrets, and workflows.
 
 ```bash
 gh auth login
 ```
 
 Follow the prompts:
+
 - Choose **HTTPS** as your preferred protocol
 - Choose **Login with a web browser**
 - Copy the one-time code shown in your terminal
-- Press Enter to open the browser (or manually go to https://github.com/login/device)
+- Press Enter to open the browser (or manually go to
+  https://github.com/login/device)
 - Paste the code and authorize the GitHub CLI
 
 ### Step 1.3: Verify Authentication
 
-**What this does:** Confirms that authentication is working correctly and you have the necessary permissions.
+**What this does:** Confirms that authentication is working correctly and you
+have the necessary permissions.
 
 ```bash
 # Check authentication status
@@ -172,9 +225,11 @@ If all these commands succeed, your GitHub CLI is properly configured!
 
 ### Step 2.1: Enable Actions Permissions
 
-**What this does:** Allows GitHub Actions workflows to create branches and pull requests in your repository.
+**What this does:** Allows GitHub Actions workflows to create branches and pull
+requests in your repository.
 
 **Via web interface:**
+
 1. Go to `https://github.com/{owner}/{repo}/settings/actions`
 2. Scroll down to "Workflow permissions"
 3. Select "Read and write permissions"
@@ -182,6 +237,7 @@ If all these commands succeed, your GitHub CLI is properly configured!
 5. Click "Save"
 
 **Via command line:**
+
 ```bash
 gh api repos/{owner}/{repo}/actions/permissions/workflow \
   --method PUT \
@@ -191,9 +247,11 @@ gh api repos/{owner}/{repo}/actions/permissions/workflow \
 
 **Verify:**
 
-*Via web:* Go to `https://github.com/{owner}/{repo}/settings/actions` and check that the settings are as described above.
+_Via web:_ Go to `https://github.com/{owner}/{repo}/settings/actions` and check
+that the settings are as described above.
 
-*Via command line:*
+_Via command line:_
+
 ```bash
 gh api repos/{owner}/{repo}/actions/permissions/workflow
 # Should show: default_workflow_permissions: "write", can_approve_pull_request_reviews: true
@@ -201,13 +259,19 @@ gh api repos/{owner}/{repo}/actions/permissions/workflow
 
 ### Step 2.2: Create an LLM API Key
 
-**What this does:** The agent needs an API key to call the LLM. You need at least one key for whichever provider you want to use.
+**What this does:** The agent needs an API key to call the LLM. You need at
+least one key for whichever provider you want to use.
 
-> **Already have an API key?** One API key works across all your repos — just set the same key as a secret on each repo (Step 2.3). You don't need a separate key per repo. Skip ahead to Step 2.3.
+> **Already have an API key?** One API key works across all your repos — just
+> set the same key as a secret on each repo (Step 2.3). You don't need a
+> separate key per repo. Skip ahead to Step 2.3.
 >
-> **Per-repo keys (optional):** If you want to track API costs per repo, create a separate key for each one and name it after the repo (e.g., "remote-dev-bot-myrepo"). This is optional — most users share one key.
+> **Per-repo keys (optional):** If you want to track API costs per repo, create
+> a separate key for each one and name it after the repo (e.g.,
+> "remote-dev-bot-myrepo"). This is optional — most users share one key.
 
 **For Anthropic (Claude models):**
+
 1. Go to https://console.anthropic.com/settings/keys
 2. Click "+ Create Key"
 3. Name it "remote-dev-bot" (or "remote-dev-bot-myrepo" if using per-repo keys)
@@ -216,32 +280,48 @@ gh api repos/{owner}/{repo}/actions/permissions/workflow
 6. **Copy the key immediately** — you won't be able to see it again
 
 **For OpenAI (GPT models):**
-1. Go to https://platform.openai.com/api-keys (note: this is separate from your ChatGPT account)
+
+1. Go to https://platform.openai.com/api-keys (note: this is separate from your
+   ChatGPT account)
 2. Click "Create new secret key"
 3. Name it "remote-dev-bot", set permissions to "All"
 4. Click "Create secret key"
 5. **Copy the key immediately** — you won't be able to see it again
-6. **Billing:** You must add a payment method at https://platform.openai.com/settings/organization/billing/overview before the key will work. New accounts get a $100/month usage limit by default; you can adjust this in the limits page.
+6. **Billing:** You must add a payment method at
+   https://platform.openai.com/settings/organization/billing/overview before the
+   key will work. New accounts get a $100/month usage limit by default; you can
+   adjust this in the limits page.
 
 **For Google (Gemini models):**
-1. Go to https://aistudio.google.com/app/apikey (this is Google AI Studio — much simpler than the Google Cloud Console, but uses the same underlying API)
+
+1. Go to https://aistudio.google.com/app/apikey (this is Google AI Studio — much
+   simpler than the Google Cloud Console, but uses the same underlying API)
 2. Sign in with your Google account and accept the Terms of Service if prompted
-3. Click "Create API Key", name it "remote-dev-bot", then select or create a Google Cloud project
+3. Click "Create API Key", name it "remote-dev-bot", then select or create a
+   Google Cloud project
 4. **Copy the key immediately** (it starts with `AIza`)
-5. **Billing:** The free tier works for testing and light use (5-15 RPM depending on model). On the free tier, a compromised key can't cost you money — it's just rate-limited. For production use, enable billing on the underlying Google Cloud project. Paid tier (Tier 1) unlocks 150-300 RPM.
-6. **Note:** Google AI Studio is separate from a Google One AI Premium subscription ($20/mo). The subscription gives access to the Gemini chatbot; it does not provide API credits or affect API billing.
+5. **Billing:** The free tier works for testing and light use (5-15 RPM
+   depending on model). On the free tier, a compromised key can't cost you money
+   — it's just rate-limited. For production use, enable billing on the
+   underlying Google Cloud project. Paid tier (Tier 1) unlocks 150-300 RPM.
+6. **Note:** Google AI Studio is separate from a Google One AI Premium
+   subscription ($20/mo). The subscription gives access to the Gemini chatbot;
+   it does not provide API credits or affect API billing.
 
 **Tip:** Store your API key in a password manager.
 
 ### Step 2.2.1: Set Cost Limits (Recommended)
 
-**What this does:** Configures spending limits on your LLM provider accounts to prevent unexpected charges. Each provider handles this differently.
+**What this does:** Configures spending limits on your LLM provider accounts to
+prevent unexpected charges. Each provider handles this differently.
 
 **For OpenAI:**
 
 OpenAI provides two types of limits:
+
 - **Usage limits** — caps how much you can spend per month
-- **Charge limits** — caps how much can be charged to your payment method per month
+- **Charge limits** — caps how much can be charged to your payment method per
+  month
 
 1. Go to https://platform.openai.com/settings/organization/limits
 2. Under "Usage limits":
@@ -252,7 +332,8 @@ OpenAI provides two types of limits:
    - This caps the actual charges to your payment method
    - Useful as a secondary safeguard
 
-**Recommended starting point:** Set usage limit to $20-50 while testing. Increase as needed once you understand your usage patterns.
+**Recommended starting point:** Set usage limit to $20-50 while testing.
+Increase as needed once you understand your usage patterns.
 
 **For Anthropic:**
 
@@ -263,15 +344,20 @@ Anthropic provides usage limits that cap your monthly spending.
 3. You'll receive email notifications as you approach the limit
 4. API calls will be rejected once you hit the limit
 
-**Recommended starting point:** Set limit to $20-50 while testing. Increase as needed.
+**Recommended starting point:** Set limit to $20-50 while testing. Increase as
+needed.
 
 **For Google (Gemini):**
 
-⚠️ **Important:** Google's billing model makes it difficult to set hard spending limits. Unlike OpenAI and Anthropic, Google is post-paid and does not offer dollar-based caps that stop API calls.
+⚠️ **Important:** Google's billing model makes it difficult to set hard spending
+limits. Unlike OpenAI and Anthropic, Google is post-paid and does not offer
+dollar-based caps that stop API calls.
 
 **What you can do:**
 
-1. **Use the free tier** (recommended for testing): Stay on the free tier and your costs are capped at $0. The free tier has rate limits (5-15 RPM depending on model) but works fine for testing.
+1. **Use the free tier** (recommended for testing): Stay on the free tier and
+   your costs are capped at $0. The free tier has rate limits (5-15 RPM
+   depending on model) but works fine for testing.
 
 2. **Set up budget alerts** (advisory only — does NOT stop spending):
    - Go to https://console.cloud.google.com/billing/budgets
@@ -280,30 +366,43 @@ Anthropic provides usage limits that cap your monthly spending.
    - **Note:** This only sends emails — it does NOT stop API calls when exceeded
 
 3. **Set API quotas** (rate limits, not dollar limits):
-   - Go to https://console.cloud.google.com/apis/api/generativelanguage.googleapis.com/quotas
+   - Go to
+     https://console.cloud.google.com/apis/api/generativelanguage.googleapis.com/quotas
    - The most relevant quotas to limit are:
      - `GenerateContent requests per minute per region` — e.g., set to 30
      - `Request limit per model per day per project` — e.g., set to 1000
-     - `GenerateContent input token count per model per minute` — e.g., set to 500,000
-   - **Note:** These limit API calls, not dollars.  The limits suggested here are conservative in an attempt to limit the damage that can be caused by a leaked API key, but the resulting bill can still be large.
+     - `GenerateContent input token count per model per minute` — e.g., set to
+       500,000
+   - **Note:** These limit API calls, not dollars. The limits suggested here are
+     conservative in an attempt to limit the damage that can be caused by a
+     leaked API key, but the resulting bill can still be large.
 
-**Recommended approach for Google:** If you need hard cost limits, consider using OpenAI or Anthropic instead. If you must use Google with billing enabled, set conservative API quotas and monitor your budget alerts closely. The free tier is the only way to guarantee $0 spend.
+**Recommended approach for Google:** If you need hard cost limits, consider
+using OpenAI or Anthropic instead. If you must use Google with billing enabled,
+set conservative API quotas and monitor your budget alerts closely. The free
+tier is the only way to guarantee $0 spend.
 
 ### Step 2.3: Add Repository Secrets
 
-**What this does:** Stores your API keys securely as GitHub repository secrets so the workflow can use them. Secret values are encrypted and never exposed in logs.
+**What this does:** Stores your API keys securely as GitHub repository secrets
+so the workflow can use them. Secret values are encrypted and never exposed in
+logs.
 
 **Via web interface:**
+
 1. Go to `https://github.com/{owner}/{repo}/settings/secrets/actions`
 2. Click "New repository secret"
-3. For the Name, enter `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` or `GEMINI_API_KEY` depending on your provider)
+3. For the Name, enter `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` or
+   `GEMINI_API_KEY` depending on your provider)
 4. Paste your API key in the Secret field
 5. Click "Add secret"
 6. Repeat for any additional API keys you need
 
 **Via command line:**
 
-**Important:** The `gh secret set` command reads the secret value from your terminal interactively. You must run these commands yourself (not through an AI assistant's shell) so you can paste the key when prompted.
+**Important:** The `gh secret set` command reads the secret value from your
+terminal interactively. You must run these commands yourself (not through an AI
+assistant's shell) so you can paste the key when prompted.
 
 ```bash
 # Set the API key for whichever provider(s) you're using:
@@ -316,9 +415,11 @@ gh secret set GEMINI_API_KEY --repo {owner}/{repo}
 
 **Verify:**
 
-*Via web:* Go to `https://github.com/{owner}/{repo}/settings/secrets/actions` — you should see your secrets listed (values are hidden).
+_Via web:_ Go to `https://github.com/{owner}/{repo}/settings/secrets/actions` —
+you should see your secrets listed (values are hidden).
 
-*Via command line:*
+_Via command line:_
+
 ```bash
 gh secret list --repo {owner}/{repo}
 # Should list the secrets you just set (values are hidden)
@@ -328,28 +429,36 @@ gh secret list --repo {owner}/{repo}
 
 **Choose your path:**
 
-- **Just trying it out?** Skip this step entirely. The bot works out of the box using GitHub's built-in `GITHUB_TOKEN` — it pushes branches, creates PRs, and posts comments as `github-actions[bot]`. The only limitation is that bot-created PRs won't auto-trigger your CI workflows (you can trigger CI manually). Come back and set this up once you're sold.
+- **Just trying it out?** Skip this step entirely. The bot works out of the box
+  using GitHub's built-in `GITHUB_TOKEN` — it pushes branches, creates PRs, and
+  posts comments as `github-actions[bot]`. The only limitation is that
+  bot-created PRs won't auto-trigger your CI workflows (you can trigger CI
+  manually). Come back and set this up once you're sold.
 
-- **Ready to commit?** The typical setup uses a GitHub App (Option A below). It gives the bot a clear identity, auto-triggers CI on bot PRs, and doesn't involve rotating tokens. This is the recommended long-term setup.
+- **Ready to commit?** The typical setup uses a GitHub App (Option A below). It
+  gives the bot a clear identity, auto-triggers CI on bot PRs, and doesn't
+  involve rotating tokens. This is the recommended long-term setup.
 
 **Options A and B are alternatives — pick one, not both.**
 
-| Option | Skip for now | Bot identity | CI triggers | Setup effort |
-|--------|-------------|--------------|-------------|--------------|
-| **None** (default) | ✓ | `github-actions[bot]` | No | None |
-| **GitHub App** (recommended) | | `your-app-name[bot]` | Yes | Create app, set variable + secret |
-| **PAT** | | Posts as the PAT owner | Yes | Create PAT, set secret |
+| Option                       | Skip for now | Bot identity           | CI triggers | Setup effort                      |
+| ---------------------------- | ------------ | ---------------------- | ----------- | --------------------------------- |
+| **None** (default)           | ✓            | `github-actions[bot]`  | No          | None                              |
+| **GitHub App** (recommended) |              | `your-app-name[bot]`   | Yes         | Create app, set variable + secret |
+| **PAT**                      |              | Posts as the PAT owner | Yes         | Create PAT, set secret            |
 
 <details>
 <summary><strong>Option A: GitHub App (recommended for long-term use)</strong></summary>
 
-A GitHub App gives the bot a clear, distinct identity and triggers CI on bot PRs. Token management is automatic — no expiring PATs to rotate.
+A GitHub App gives the bot a clear, distinct identity and triggers CI on bot
+PRs. Token management is automatic — no expiring PATs to rotate.
 
 **First time setting up the app:**
 
 1. Go to https://github.com/settings/apps/new
 2. **Name:** Choose a name (this becomes the `name[bot]` identity)
-   - **Avatar:** The bot will use the app owner's avatar by default. To set a custom avatar, upload one on the app settings page after creation.
+   - **Avatar:** The bot will use the app owner's avatar by default. To set a
+     custom avatar, upload one on the app settings page after creation.
 3. **Homepage URL:** Your repo URL is fine
 4. **Uncheck** Webhook "Active" (not needed)
 5. **Repository permissions** — set to Read & write:
@@ -360,10 +469,18 @@ A GitHub App gives the bot a clear, distinct identity and triggers CI on bot PRs
 7. Click "Create GitHub App"
 8. Note the **App ID** shown on the app's settings page
 9. Scroll down and click **Generate a private key** (downloads a `.pem` file)
-   - **Store the key securely:** Copy the full contents of the `.pem` file into your password manager (name it "remote-dev-bot private key" or similar), then delete the downloaded file. You won't be able to download it again — if lost, you'll need to generate a new one.
+   - **Store the key securely:** Copy the full contents of the `.pem` file into
+     your password manager (name it "remote-dev-bot private key" or similar),
+     then delete the downloaded file. You won't be able to download it again —
+     if lost, you'll need to generate a new one.
 10. Click **Install App** in the left sidebar
-    - **Private app note:** If the app is not published to the GitHub Marketplace, it won't appear in your repo's Settings → Integrations list. You must install it from the app settings page.
-    - Choose **"Only select repositories"** and pick your target repo — or **"All repositories"** if you plan to use the bot on multiple repos. Installing on all repositories is safe: the bot only acts on repos where `RDB_APP_PRIVATE_KEY` is configured.
+    - **Private app note:** If the app is not published to the GitHub
+      Marketplace, it won't appear in your repo's Settings → Integrations list.
+      You must install it from the app settings page.
+    - Choose **"Only select repositories"** and pick your target repo — or
+      **"All repositories"** if you plan to use the bot on multiple repos.
+      Installing on all repositories is safe: the bot only acts on repos where
+      `RDB_APP_PRIVATE_KEY` is configured.
 
 Store the credentials on your repo:
 
@@ -378,8 +495,11 @@ gh secret set RDB_APP_PRIVATE_KEY --repo {owner}/{repo} < path/to/your-app.pem
 
 **Adding the bot to another repo (app already exists):**
 
-You don't need a new key — reuse the same App ID and private key. You just need to:
-1. Go to your app's settings page (https://github.com/settings/apps) and click **Install App**, then add the new repo
+You don't need a new key — reuse the same App ID and private key. You just need
+to:
+
+1. Go to your app's settings page (https://github.com/settings/apps) and click
+   **Install App**, then add the new repo
 2. Set the same credentials on the new repo:
 
 ```bash
@@ -394,10 +514,14 @@ gh secret set RDB_APP_PRIVATE_KEY --repo {owner}/{new-repo} < path/to/your-app.p
 <details>
 <summary><strong>Option B: Personal Access Token (PAT)</strong></summary>
 
-A PAT is an alternative to the GitHub App. Choose this if you prefer not to create a GitHub App, but note that the bot will post as your personal account, which can be confusing if you're also commenting on the same issues.
+A PAT is an alternative to the GitHub App. Choose this if you prefer not to
+create a GitHub App, but note that the bot will post as your personal account,
+which can be confusing if you're also commenting on the same issues.
 
 **Alternatives to posting as yourself:**
-- Organizations can create a dedicated GitHub user (e.g., `my-org-bot`) and use that user's PAT
+
+- Organizations can create a dedicated GitHub user (e.g., `my-org-bot`) and use
+  that user's PAT
 - This gives a distinct identity without the complexity of a GitHub App
 
 1. Go to https://github.com/settings/tokens?type=beta (Fine-grained tokens)
@@ -405,8 +529,10 @@ A PAT is an alternative to the GitHub App. Choose this if you prefer not to crea
 3. **Token name:** "remote-dev-bot"
 4. **Expiration:** No expiration is fine for a token scoped to one repo
 5. **Resource owner:** Your GitHub account (or the bot account)
-6. **Repository access:** Select "Only select repositories" and choose your target repo
-7. **Permissions** — under "Repository permissions", set these to **Read and write**:
+6. **Repository access:** Select "Only select repositories" and choose your
+   target repo
+7. **Permissions** — under "Repository permissions", set these to **Read and
+   write**:
    - Contents
    - Issues
    - Pull requests
@@ -428,7 +554,9 @@ gh secret set RDB_PAT_TOKEN --repo {owner}/{repo}
 
 ### Step 3.1: Download the Workflow File
 
-**What this does:** Adds a thin shim workflow to your repository. The shim calls the reusable workflow from `gnovak/remote-dev-bot`, so you automatically get updates when the bot is improved — no need to download new releases.
+**What this does:** Adds a thin shim workflow to your repository. The shim calls
+the reusable workflow from `gnovak/remote-dev-bot`, so you automatically get
+updates when the bot is improved — no need to download new releases.
 
 ```bash
 # From within the target repo:
@@ -437,11 +565,18 @@ curl -o .github/workflows/agent.yml \
   https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/.github/workflows/agent.yml
 ```
 
-The file is self-documenting — read the comments at the top for notes on optional secrets and auth.
+The file is self-documenting — read the comments at the top for notes on
+optional secrets and auth.
 
-**Using your own fork:** For full control, fork `gnovak/remote-dev-bot`, then edit the `uses:` line to point at your fork. If the fork is in the same owner/org as your target repos, `secrets: inherit` will work. You'll need to set Actions access to `user` level on the fork (see Troubleshooting).
+**Using your own fork:** For full control, fork `gnovak/remote-dev-bot`, then
+edit the `uses:` line to point at your fork. If the fork is in the same
+owner/org as your target repos, `secrets: inherit` will work. You'll need to set
+Actions access to `user` level on the fork (see Troubleshooting).
 
-**Note to `gnovak/remote-dev-bot` users:** GitHub does not notify repo owners when someone forks their repository. If you'd like the maintainer to know about your usage (and potentially get notified of relevant updates), consider starring the repo or opening a brief issue.
+**Note to `gnovak/remote-dev-bot` users:** GitHub does not notify repo owners
+when someone forks their repository. If you'd like the maintainer to know about
+your usage (and potentially get notified of relevant updates), consider starring
+the repo or opening a brief issue.
 
 ### Step 3.2: Commit and Push the Workflow File
 
@@ -450,22 +585,33 @@ git add .github/workflows/agent.yml
 git commit -m "Add remote dev bot workflow"
 ```
 
-> **AI agents:** Stop here. Pushing `.github/workflows/` files requires `workflow` scope, which your `gh` credential helper may not have. Ask the user to run `git push` (or `git push -u origin main` for a new repo) and confirm it succeeded before continuing.
+> **AI agents:** Stop here. Pushing `.github/workflows/` files requires
+> `workflow` scope, which your `gh` credential helper may not have. Ask the user
+> to run `git push` (or `git push -u origin main` for a new repo) and confirm it
+> succeeded before continuing.
 
-> **New empty repo?** If your repository has no commits yet, you'll need to set the branch name before pushing: `git branch -M main && git push -u origin main`.
+> **New empty repo?** If your repository has no commits yet, you'll need to set
+> the branch name before pushing:
+> `git branch -M main && git push -u origin main`.
 
 Push to your repo:
+
 ```bash
 git push
 ```
 
-> **If `git push` fails with a scope error:** Your `gh` credential helper needs `workflow` scope. Run `gh auth refresh --hostname github.com --scopes workflow` then retry. Alternatively, push using SSH if you have SSH keys configured.
+> **If `git push` fails with a scope error:** Your `gh` credential helper needs
+> `workflow` scope. Run
+> `gh auth refresh --hostname github.com --scopes workflow` then retry.
+> Alternatively, push using SSH if you have SSH keys configured.
 
 **Verify the workflow is recognized:**
 
-*Via web:* Go to `https://github.com/{owner}/{repo}/actions` — you should see "Remote Dev Bot" listed in the left sidebar under "All workflows".
+_Via web:_ Go to `https://github.com/{owner}/{repo}/actions` — you should see
+"Remote Dev Bot" listed in the left sidebar under "All workflows".
 
-*Via command line:*
+_Via command line:_
+
 ```bash
 gh workflow list --repo {owner}/{repo}
 # Should show "Remote Dev Bot"
@@ -474,7 +620,10 @@ gh workflow list --repo {owner}/{repo}
 <details>
 <summary><strong>Alternative: Compiled install (self-contained, pinned)</strong></summary>
 
-Instead of the shim, you can download self-contained workflow files that include all the logic inline. These don't auto-update — you control when to upgrade by downloading new releases. Useful if your organization restricts calling reusable workflows from external repos.
+Instead of the shim, you can download self-contained workflow files that include
+all the logic inline. These don't auto-update — you control when to upgrade by
+downloading new releases. Useful if your organization restricts calling reusable
+workflows from external repos.
 
 ```bash
 mkdir -p .github/workflows
@@ -487,6 +636,7 @@ curl -o .github/workflows/agent-review.yml \
 ```
 
 The files are configurable. Search for these markers to customize:
+
 - `MODEL_CONFIG` — change the default model or available aliases
 - `MAX_ITERATIONS` — adjust how many steps the agent can take
 - `PR_STYLE` — switch between draft and ready PRs
@@ -503,12 +653,14 @@ Commit and push all three files the same way as the shim install above.
 ### Step 4.1: Create a Test Issue
 
 **Via web interface:**
+
 1. Go to `https://github.com/{owner}/{repo}/issues/new`
 2. Title: `Test: Add a hello world script`
 3. Body: `Create a simple hello.py that prints 'Hello from Remote Dev Bot'`
 4. Click "Submit new issue"
 
 **Via command line:**
+
 ```bash
 gh issue create --repo {owner}/{repo} \
   --title "Test: Add a hello world script" \
@@ -520,12 +672,15 @@ gh issue create --repo {owner}/{repo} \
 Comment on the issue to trigger the agent.
 
 **Via web interface:**
-1. Go to `https://github.com/{owner}/{repo}/issues/{issue-number}` (or click on the issue you just created)
+
+1. Go to `https://github.com/{owner}/{repo}/issues/{issue-number}` (or click on
+   the issue you just created)
 2. Scroll to the comment box at the bottom
 3. Type `/agent-resolve`
 4. Click "Comment"
 
 **Via command line:**
+
 ```bash
 gh issue comment {issue-number} --repo {owner}/{repo} --body "/agent-resolve"
 ```
@@ -533,12 +688,14 @@ gh issue comment {issue-number} --repo {owner}/{repo} --body "/agent-resolve"
 ### Step 4.3: Monitor the Run
 
 **Via web interface:**
+
 1. Go to `https://github.com/{owner}/{repo}/actions`
 2. Click on "Remote Dev Bot" in the left sidebar to filter to just this workflow
 3. Click on the most recent run to see its status and logs
 4. Click on the "resolve" job to see detailed step-by-step logs
 
 **Via command line:**
+
 ```bash
 # Check the Actions tab for runs:
 gh run list --repo {owner}/{repo} --workflow=agent-resolve.yml
@@ -549,6 +706,7 @@ gh run view {run-id} --repo {owner}/{repo} --log
 ```
 
 A successful run typically takes 5-10 minutes. The agent will:
+
 1. Install OpenHands and dependencies (~1-2 min)
 2. Read the issue and work on the solution (~3-7 min)
 3. Create a draft PR (~30 sec)
@@ -556,61 +714,78 @@ A successful run typically takes 5-10 minutes. The agent will:
 ### Step 4.4: Check Results
 
 If successful, you should see:
+
 - A new branch created by the agent
 - A draft PR linked to the issue
 - A rocket emoji reaction on your `/agent-resolve` comment
-- You're auto-assigned to the issue (so your issues list shows what has active work)
+- You're auto-assigned to the issue (so your issues list shows what has active
+  work)
 
 **Via web interface:**
+
 - Go to `https://github.com/{owner}/{repo}/pulls` to see the new draft PR
 - Or check the issue page — it should have a link to the PR in the sidebar
 
 **Via command line:**
+
 ```bash
 gh pr list --repo {owner}/{repo}
 ```
 
 **If the run fails**, check the logs for the specific error. Some issues:
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `Missing Anthropic API Key` or `x-api-key header is required` | API key not reaching the workflow | Re-check the secret value via web (`https://github.com/{owner}/{repo}/settings/secrets/actions`) |
-| `Agent reached maximum iteration` | Agent may be looping instead of finishing | Try a more capable model |
-| Workflow file issue (instant failure, 0s) | Reusable workflow not accessible | If using a private fork of `gnovak/remote-dev-bot` set Actions access to `user` level |
+| Error                                                         | Cause                                     | Fix                                                                                              |
+| ------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `Missing Anthropic API Key` or `x-api-key header is required` | API key not reaching the workflow         | Re-check the secret value via web (`https://github.com/{owner}/{repo}/settings/secrets/actions`) |
+| `Agent reached maximum iteration`                             | Agent may be looping instead of finishing | Try a more capable model                                                                         |
+| Workflow file issue (instant failure, 0s)                     | Reusable workflow not accessible          | If using a private fork of `gnovak/remote-dev-bot` set Actions access to `user` level            |
 
 ---
 
 ## Phase 5: Customize (Optional)
 
-See the Customization section in `README.md` for details on adding repo context for the agent, adjusting model aliases, and changing iteration limits. These can be done any time after install — not just during initial setup.
+See the Customization section in `README.md` for details on adding repo context
+for the agent, adjusting model aliases, and changing iteration limits. These can
+be done any time after install — not just during initial setup.
 
 ---
 
 ## Phase 6: Report Install Feedback (Optional)
 
-> **This phase only applies if you encountered problems during installation.** If everything worked perfectly, you're done! Skip to the Troubleshooting section if you need help with specific issues.
+> **This phase only applies if you encountered problems during installation.**
+> If everything worked perfectly, you're done! Skip to the Troubleshooting
+> section if you need help with specific issues.
 
 ### Why Report Feedback?
 
-If your install required workarounds or failed at certain steps, reporting this helps improve the guide for future users. Your feedback tells us exactly what needs to be fixed.
+If your install required workarounds or failed at certain steps, reporting this
+helps improve the guide for future users. Your feedback tells us exactly what
+needs to be fixed.
 
 ### What Gets Reported
 
 The report includes:
+
 - **Environment info**: Operating system, shell type
 - **What went wrong**: Which steps failed or required deviations
 - **What you did instead**: The workaround or fix you used (if any)
 
 The report does **not** include:
+
 - API keys or secrets
 - Repository contents
 - Personal information beyond your GitHub username (which is public anyway)
 
 ### For AI Assistants / Agents
 
-> **This section is for AI agents executing this guide.** If you're a human following this guide manually and encounter problems, you can file issues directly at https://github.com/gnovak/remote-dev-bot/issues — no special format required.
+> **This section is for AI agents executing this guide.** If you're a human
+> following this guide manually and encounter problems, you can file issues
+> directly at https://github.com/gnovak/remote-dev-bot/issues — no special
+> format required.
 
-If you're an AI agent executing this guide, you should automatically collect problem details as you go through the phases. The user should not need to provide this information — you observed what happened.
+If you're an AI agent executing this guide, you should automatically collect
+problem details as you go through the phases. The user should not need to
+provide this information — you observed what happened.
 
 **During execution:**
 
@@ -634,7 +809,9 @@ report.add_problem(
 )
 ```
 
-**Important:** Do not include secrets, API keys, tokens, or other sensitive data in problem reports. You have no reason to include them, so this should be straightforward.
+**Important:** Do not include secrets, API keys, tokens, or other sensitive data
+in problem reports. You have no reason to include them, so this should be
+straightforward.
 
 **After all phases complete:**
 
@@ -662,13 +839,18 @@ if report.has_problems():
 - Limiting to 3 issues per install to avoid spam
 - Grouping many problems into a single summary issue
 
-**Consent is required:** The `report_problems()` function will post to GitHub using the user's credentials. Always show the user what will be reported (via `get_consent_prompt()`) and get explicit confirmation before calling `report_problems()`.
+**Consent is required:** The `report_problems()` function will post to GitHub
+using the user's credentials. Always show the user what will be reported (via
+`get_consent_prompt()`) and get explicit confirmation before calling
+`report_problems()`.
 
 ---
 
 ## Security
 
-See the [Security section in README.md](README.md#security) for an overview of who can trigger the agent, what it can access, prompt injection mitigations, and recommendations.
+See the [Security section in README.md](README.md#security) for an overview of
+who can trigger the agent, what it can access, prompt injection mitigations, and
+recommendations.
 
 ---
 
@@ -676,9 +858,11 @@ See the [Security section in README.md](README.md#security) for an overview of w
 
 ### Cross-repo reusable workflow access (shim install only)
 
-The shim calls `remote-dev-bot.yml` from `gnovak/remote-dev-bot`. Since that repo is public, this works automatically — no special access settings needed.
+The shim calls `remote-dev-bot.yml` from `gnovak/remote-dev-bot`. Since that
+repo is public, this works automatically — no special access settings needed.
 
-**If using a private fork:** You must enable Actions access sharing on your fork:
+**If using a private fork:** You must enable Actions access sharing on your
+fork:
 
 1. Go to your fork's Settings → Actions → General → Access
 2. Select "Accessible from repositories owned by the user" (or org)
@@ -688,31 +872,42 @@ Without this, the shim will fail instantly with "workflow file issue."
 
 ### Secrets not reaching the reusable workflow (shim install only)
 
-If the agent fails with `x-api-key header is required` or similar authentication errors, check that secrets are passed explicitly in the shim (not via `secrets: inherit`). GitHub Actions does not pass inherited secrets across different repo owners. See the shim template in `.github/workflows/agent.yml`.
+If the agent fails with `x-api-key header is required` or similar authentication
+errors, check that secrets are passed explicitly in the shim (not via
+`secrets: inherit`). GitHub Actions does not pass inherited secrets across
+different repo owners. See the shim template in `.github/workflows/agent.yml`.
 
 ### Agent doesn't trigger
-- Verify the shim workflow file is on the default branch (usually `main`) of the target repo
+
+- Verify the shim workflow file is on the default branch (usually `main`) of the
+  target repo
 - Check that the commenter has collaborator/member/owner access to the repo
-- Look at the Actions tab for failed runs (go to `https://github.com/{owner}/{repo}/actions`)
-- Make sure the comment starts with exactly `/agent-resolve`, `/agent-design`, or `/agent-review` (no leading spaces)
+- Look at the Actions tab for failed runs (go to
+  `https://github.com/{owner}/{repo}/actions`)
+- Make sure the comment starts with exactly `/agent-resolve`, `/agent-design`,
+  or `/agent-review` (no leading spaces)
 - Verify the shim points to the correct ref (e.g., `@main` or `@dev`)
 
 ### Agent fails during setup steps (first 2 minutes)
+
 - Check the run log — these are usually missing dependencies or config issues
 - See the error table in Step 4.4 above for common issues and fixes
 
 ### Agent runs but hits max iterations
+
 - The agent completed the work but couldn't gracefully stop
 - Try a more capable model: `/agent-resolve-claude-large`
 - Or increase `max_iterations` in `remote-dev-bot.yaml`
 
 ### Agent runs but skips PR creation
+
 - The log will say "Issue was not successfully resolved. Skipping PR creation."
-- This often means the agent hit max iterations — OpenHands marks this as "error" even if the code changes were correct
+- This often means the agent hit max iterations — OpenHands marks this as
+  "error" even if the code changes were correct
 - Try again with a more capable model
 
 ### Agent produces bad results
+
 - Add more context to the issue description
 - Add repo context in `.openhands/microagents/repo.md`
 - Comment `/agent-resolve` on the PR with specific feedback for another pass
-


### PR DESCRIPTION
Formatting-only change. Runs `prettier --prose-wrap always --print-width 80` on all .md files.

Reduces merge conflicts and makes diffs easier to read. Tables, code blocks, and URLs are left unwrapped automatically.

No content changes — safe to merge without review.

Generated with [Claude Code](https://claude.com/claude-code)