### PR TITLE
Sync PRs #265 and #266 to main (code review batch 1 & 2)

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -28,7 +28,7 @@ jobs:
   resolve:
     if: >
       (github.event.issue || github.event.pull_request) &&
-      (startsWith(github.event.comment.body, '/dogfood-') || startsWith(github.event.comment.body, '/dogfood ') || github.event.comment.body == '/dogfood') &&
+      (startsWith(github.event.comment.body, '/dogfood-') || startsWith(github.event.comment.body, '/dogfood ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@dev
     with:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,7 +47,7 @@ jobs:
   e2e-shim:
     needs: unit-tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1,4 +1,4 @@
-name: Resolve Issue
+name: Remote Dev Bot
 
 # Reusable workflow — called by thin shims in target repos.
 # See .github/workflows/agent.yml for the shim template.
@@ -26,7 +26,7 @@ on:
         default: 'main'
         type: string
       command_prefix:
-        description: 'Command prefix the shim triggers on (e.g. "agent" for /agent-resolve, "dogfood" for /dogfood-resolve). Default: agent.'
+        description: 'Command prefix the shim triggers on (e.g. "agent" for /agent-resolve). Default: agent.'
         required: false
         default: 'agent'
         type: string
@@ -157,6 +157,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -642,6 +647,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -664,8 +674,8 @@ jobs:
           ISSUE_TITLE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
           ISSUE_BODY=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('body','') or '')")
 
-          # Fetch recent comments (last 10)
-          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=10&direction=desc")
+          # Fetch all comments (up to 100 — GitHub API max per page)
+          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=100")
           COMMENTS=$(echo "$COMMENTS_JSON" | python3 -c "
           import sys, json
           comments = json.load(sys.stdin)
@@ -938,6 +948,11 @@ jobs:
       - name: Determine API key
         id: apikey
         run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
           MODEL="${{ needs.parse.outputs.model }}"
           if [[ "$MODEL" == anthropic/* ]]; then
             echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
@@ -1085,10 +1100,20 @@ jobs:
           import json, os
           path = 'output/output.jsonl'
           if os.path.exists(path):
-              data = json.loads(open(path).read())
+              # output.jsonl is JSON Lines — read the last line (the final result)
+              lines = open(path).read().strip().splitlines()
+              data = json.loads(lines[-1]) if lines else {}
               val = data.get('result_explanation', '') or ''
+              # result_explanation may be a list or a JSON-encoded list string
               if isinstance(val, list):
                   val = '\n\n'.join(str(v) for v in val)
+              elif isinstance(val, str) and val.startswith('['):
+                  try:
+                      items = json.loads(val)
+                      if isinstance(items, list):
+                          val = '\n\n'.join(str(v) for v in items)
+                  except json.JSONDecodeError:
+                      pass
               print(val)
           " 2>/dev/null || echo "")
           fi
@@ -1256,6 +1281,471 @@ jobs:
               echo "| Iterations | ${ITERATIONS} / ${MAX_ITER} |"
             fi
             echo "| Elapsed time | ${ELAPSED_FMT} |"
+            echo "| Input tokens | ${INPUT_TOKENS} |"
+            echo "| Output tokens | ${OUTPUT_TOKENS} |"
+            echo "| Total tokens | ${TOTAL_TOKENS} |"
+            printf "| **Estimated cost** | **\$%s** |\n" "$ROUNDED"
+            echo ""
+            echo "_Cost is estimated based on token usage and may vary from actual billing._"
+          } > /tmp/cost_comment.md
+
+          # Post comment
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/cost_comment.md
+
+  # --- Mode: explore (action=explore) — multi-round agentic loop with tool calling ---
+  explore:
+    needs: parse
+    if: needs.parse.outputs.action == 'explore'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+
+      - name: Checkout remote-dev-bot config
+        uses: actions/checkout@v4
+        with:
+          repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ inputs.rdb_ref }}
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install PyYAML litellm
+
+      - name: Determine API key
+        id: apikey
+        run: |
+          # Select the correct API key based on the model's provider prefix.
+          # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
+          # GitHub Actions automatically masks secret values in logs — this does
+          # NOT print the key. The key is consumed by the next step as
+          # ${{ steps.apikey.outputs.key }} and never appears in plaintext output.
+          MODEL="${{ needs.parse.outputs.model }}"
+          if [[ "$MODEL" == anthropic/* ]]; then
+            echo "key=${{ secrets.ANTHROPIC_API_KEY }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$MODEL" == openai/* ]]; then
+            echo "key=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$MODEL" == gemini/* ]]; then
+            echo "key=${{ secrets.GEMINI_API_KEY }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unknown model provider for: $MODEL"
+            exit 1
+          fi
+
+      - name: Gather issue context
+        id: context
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
+
+          # Fetch issue title and body
+          ISSUE_JSON=$(gh api repos/${{ github.repository }}/issues/${ISSUE_NUMBER})
+          ISSUE_TITLE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
+          ISSUE_BODY=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('body','') or '')")
+
+          # Fetch all comments (up to 100 — GitHub API max per page)
+          COMMENTS_JSON=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=100")
+          COMMENTS=$(echo "$COMMENTS_JSON" | python3 -c "
+          import sys, json
+          comments = json.load(sys.stdin)
+          for c in reversed(comments):
+              user = c['user']['login']
+              body = c.get('body','')
+              print(f'--- @{user} ---')
+              print(body)
+              print()
+          ")
+
+          # Write to files to avoid shell escaping issues
+          echo "$ISSUE_TITLE" > /tmp/issue_title.txt
+          echo "$ISSUE_BODY" > /tmp/issue_body.txt
+          echo "$COMMENTS" > /tmp/issue_comments.txt
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+
+      - name: Run explore loop
+        id: explore
+        env:
+          LLM_API_KEY: ${{ steps.apikey.outputs.key }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          CONTEXT_FILES: ${{ needs.parse.outputs.context_files }}
+          EXPLORE_MAX_ITERATIONS: ${{ needs.parse.outputs.explore_max_iterations }}
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import yaml
+
+          from litellm import completion
+
+          model = "${{ needs.parse.outputs.model }}"
+
+          # Load prompt_prefix from config
+          prompt_prefix = ""
+          for path in ["remote-dev-bot.yaml", ".remote-dev-bot/remote-dev-bot.yaml"]:
+              if os.path.exists(path):
+                  with open(path) as f:
+                      cfg = yaml.safe_load(f) or {}
+                  mode_cfg = cfg.get("modes", {}).get("explore", {})
+                  if "prompt_prefix" in mode_cfg:
+                      prompt_prefix = mode_cfg["prompt_prefix"]
+                      break
+
+          # Get max iterations from config (default 10)
+          max_iterations = int(os.environ.get("EXPLORE_MAX_ITERATIONS", "10") or "10")
+
+          # Generate repository file listing (tracked files only)
+          result = subprocess.run(
+              ["git", "ls-files"],
+              capture_output=True, text=True
+          )
+          file_listing = result.stdout.strip()
+          repo_context = f"## Repository File Listing\n\n```\n{file_listing}\n```"
+
+          # Read repo context files (missing files are skipped gracefully)
+          context_files = json.loads(os.environ.get("CONTEXT_FILES", "[]") or "[]")
+          for filepath in context_files:
+              if os.path.exists(filepath):
+                  with open(filepath) as f:
+                      content = f.read().strip()
+                  if content:
+                      repo_context += f"\n\n## File: {filepath}\n\n{content}"
+
+          # Read issue context
+          with open("/tmp/issue_title.txt") as f:
+              title = f.read().strip()
+          with open("/tmp/issue_body.txt") as f:
+              body = f.read().strip()
+          with open("/tmp/issue_comments.txt") as f:
+              comments = f.read().strip()
+
+          # Build the user content
+          user_content = f"""## Issue: {title}
+
+          {body}
+
+          ## Discussion so far:
+          {comments}
+          """
+
+          system_prompt = prompt_prefix or (
+              "You are analyzing a GitHub issue for design discussion using an agentic exploration loop. "
+              "You have access to tools to read files and search the codebase. "
+              "Use these tools to gather the information you need before providing your analysis. "
+              "When you have enough information, call submit_analysis with your final analysis."
+          )
+
+          if repo_context:
+              system_prompt = "# Repository Context\n" + repo_context + "\n\n# Instructions\n\n" + system_prompt
+
+          # Define tools for the agentic loop
+          tools = [
+              {
+                  "type": "function",
+                  "function": {
+                      "name": "read_file",
+                      "description": "Read the contents of a file from the repository. Use this to examine source code, configuration files, or documentation.",
+                      "parameters": {
+                          "type": "object",
+                          "properties": {
+                              "path": {
+                                  "type": "string",
+                                  "description": "The path to the file relative to the repository root (e.g., 'src/main.py', 'README.md')"
+                              }
+                          },
+                          "required": ["path"]
+                      }
+                  }
+              },
+              {
+                  "type": "function",
+                  "function": {
+                      "name": "grep",
+                      "description": "Search for a pattern in files. Returns matching lines with file paths and line numbers.",
+                      "parameters": {
+                          "type": "object",
+                          "properties": {
+                              "pattern": {
+                                  "type": "string",
+                                  "description": "The search pattern (supports basic regex)"
+                              },
+                              "path": {
+                                  "type": "string",
+                                  "description": "Optional: limit search to a specific file or directory (e.g., 'src/', '*.py'). If not provided, searches all tracked files."
+                              }
+                          },
+                          "required": ["pattern"]
+                      }
+                  }
+              },
+              {
+                  "type": "function",
+                  "function": {
+                      "name": "submit_analysis",
+                      "description": "Submit your final design analysis. Call this when you have gathered enough information and are ready to provide your analysis. This will end the exploration loop.",
+                      "parameters": {
+                          "type": "object",
+                          "properties": {
+                              "analysis": {
+                                  "type": "string",
+                                  "description": "Your complete design analysis in markdown format, suitable for posting as a GitHub comment."
+                              }
+                          },
+                          "required": ["analysis"]
+                      }
+                  }
+              }
+          ]
+
+          def validate_path(path):
+              """Validate that a path is safe (no directory traversal, within repo)."""
+              # Normalize the path
+              normalized = os.path.normpath(path)
+              # Check for directory traversal
+              if normalized.startswith('..') or normalized.startswith('/'):
+                  return False, "Path must be relative to repository root and cannot use '..'"
+              # Check that the path doesn't escape the repo
+              abs_path = os.path.abspath(normalized)
+              repo_root = os.path.abspath('.')
+              if not abs_path.startswith(repo_root):
+                  return False, "Path must be within the repository"
+              return True, normalized
+
+          def execute_read_file(path):
+              """Execute the read_file tool."""
+              valid, result = validate_path(path)
+              if not valid:
+                  return f"Error: {result}"
+              if not os.path.exists(result):
+                  return f"Error: File not found: {path}"
+              if os.path.isdir(result):
+                  return f"Error: Path is a directory, not a file: {path}"
+              try:
+                  with open(result) as f:
+                      content = f.read()
+                  # Limit content size to avoid token explosion
+                  if len(content) > 50000:
+                      content = content[:50000] + "\n\n... (file truncated, showing first 50000 characters)"
+                  return content
+              except Exception as e:
+                  return f"Error reading file: {e}"
+
+          def execute_grep(pattern, path=None):
+              """Execute the grep tool."""
+              try:
+                  cmd = ["git", "grep", "-n", "--no-color", pattern]
+                  if path:
+                      valid, validated_path = validate_path(path)
+                      if not valid:
+                          return f"Error: {validated_path}"
+                      cmd.append("--")
+                      cmd.append(validated_path)
+                  result = subprocess.run(
+                      cmd,
+                      capture_output=True,
+                      text=True,
+                      timeout=30
+                  )
+                  output = result.stdout.strip()
+                  if not output:
+                      return "No matches found."
+                  # Limit output size
+                  lines = output.split('\n')
+                  if len(lines) > 100:
+                      output = '\n'.join(lines[:100]) + f"\n\n... ({len(lines) - 100} more matches truncated)"
+                  return output
+              except subprocess.TimeoutExpired:
+                  return "Error: Search timed out"
+              except Exception as e:
+                  return f"Error executing grep: {e}"
+
+          def execute_tool(tool_name, arguments):
+              """Execute a tool and return the result."""
+              if tool_name == "read_file":
+                  return execute_read_file(arguments.get("path", ""))
+              elif tool_name == "grep":
+                  return execute_grep(arguments.get("pattern", ""), arguments.get("path"))
+              elif tool_name == "submit_analysis":
+                  return arguments.get("analysis", "")
+              else:
+                  return f"Error: Unknown tool: {tool_name}"
+
+          # Initialize conversation
+          messages = [
+              {"role": "system", "content": system_prompt},
+              {"role": "user", "content": user_content},
+          ]
+
+          # Track token usage across all calls
+          total_input_tokens = 0
+          total_output_tokens = 0
+          total_cost = 0.0
+
+          final_analysis = None
+          last_response = None
+
+          for iteration in range(max_iterations):
+              print(f"=== Iteration {iteration + 1}/{max_iterations} ===")
+
+              response = completion(
+                  model=model,
+                  messages=messages,
+                  tools=tools,
+                  max_tokens=4096,
+              )
+
+              # Track token usage
+              usage = getattr(response, 'usage', None)
+              if usage:
+                  total_input_tokens += getattr(usage, 'prompt_tokens', 0)
+                  total_output_tokens += getattr(usage, 'completion_tokens', 0)
+              cost = getattr(response, '_hidden_params', {}).get('response_cost', None)
+              if cost:
+                  total_cost += cost
+
+              message = response.choices[0].message
+              last_response = message.content
+
+              # Check if the model wants to call tools
+              tool_calls = getattr(message, 'tool_calls', None)
+
+              if not tool_calls:
+                  # No tool calls — model is done or gave up without submitting
+                  print("No tool calls — stopping loop")
+                  break
+
+              # Add assistant message with tool calls to conversation
+              messages.append({
+                  "role": "assistant",
+                  "content": message.content,
+                  "tool_calls": [tc.dict() for tc in tool_calls],
+              })
+
+              # Process each tool call and add results to conversation
+              done = False
+              for tool_call in tool_calls:
+                  tool_name = tool_call.function.name
+                  try:
+                      arguments = json.loads(tool_call.function.arguments)
+                  except json.JSONDecodeError:
+                      arguments = {}
+
+                  print(f"  Tool: {tool_name}({list(arguments.keys())})")
+                  result = execute_tool(tool_name, arguments)
+
+                  # submit_analysis signals end of exploration — capture and break
+                  if tool_name == "submit_analysis":
+                      final_analysis = result
+                      done = True
+
+                  messages.append({
+                      "role": "tool",
+                      "tool_call_id": tool_call.id,
+                      "content": result,
+                  })
+
+              if done:
+                  break
+
+          # Save usage data for the cost comment step
+          with open("/tmp/llm_usage.json", "w") as f:
+              json.dump({
+                  "input_tokens": total_input_tokens,
+                  "output_tokens": total_output_tokens,
+                  "cost": total_cost,
+                  "iterations": (iteration + 1) if max_iterations > 0 else 0,
+              }, f)
+
+          # Write analysis for the post-comment step (prefer submit_analysis, fall back to last response)
+          analysis = final_analysis or last_response or ""
+          if analysis:
+              with open("/tmp/explore_analysis.txt", "w") as f:
+                  f.write(analysis)
+          PYEOF
+
+      - name: Post analysis comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
+          ALIAS="${{ needs.parse.outputs.alias }}"
+          MODEL="${{ needs.parse.outputs.model }}"
+
+          if [ -f /tmp/explore_analysis.txt ]; then
+            {
+              cat /tmp/explore_analysis.txt
+              echo ""
+              echo "---"
+              echo "_Exploration by \`/agent-explore-${ALIAS}\` (${MODEL})_"
+            } > /tmp/analysis_comment.md
+
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/analysis_comment.md
+          else
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body "⚠️ **Exploration did not produce an analysis.** The agent may have exhausted all iterations without calling \`submit_analysis\`. See the [workflow run logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+
+      - name: Post cost comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
+          MODEL="${{ needs.parse.outputs.model }}"
+          ALIAS="${{ needs.parse.outputs.alias }}"
+          MODE="${{ needs.parse.outputs.mode }}"
+
+          # Read usage data — default to 0 if file missing (shows $0.00, signals no data)
+          read INPUT_TOKENS OUTPUT_TOKENS COST ITERATIONS < <(python3 -c "
+          import json, os
+          if os.path.exists('/tmp/llm_usage.json'):
+              d = json.load(open('/tmp/llm_usage.json'))
+              print(d.get('input_tokens', 0), d.get('output_tokens', 0), d.get('cost') or 0, d.get('iterations', 0))
+          else:
+              print(0, 0, 0, 0)
+          ")
+          TOTAL_TOKENS=$((INPUT_TOKENS + OUTPUT_TOKENS))
+
+          # Round UP to nearest penny — $0.00 means no cost data was available.
+          ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
+
+          # Format cost comment
+          {
+            echo "### 💰 Cost Summary"
+            echo ""
+            echo "**Model:** \`${ALIAS}\` (${MODEL})"
+            echo "**Mode:** ${MODE}"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Iterations | ${ITERATIONS} |"
             echo "| Input tokens | ${INPUT_TOKENS} |"
             echo "| Output tokens | ${OUTPUT_TOKENS} |"
             echo "| Total tokens | ${TOTAL_TOKENS} |"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,13 @@ Project conventions for AI coding agents working on this repository.
 
 ## Project
 
-Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to resolve issues and create PRs, controlled via `/agent-resolve` and `/agent-design` comments on GitHub issues.
+Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to resolve issues and create PRs, controlled via `/agent-resolve`, `/agent-design`, and `/agent-review` comments on GitHub issues and PRs.
 
 ### How It Works
-1. User comments `/agent-resolve[-<model>]` or `/agent-design[-<model>]` on a GitHub issue
+1. User comments `/agent-resolve[-<model>]`, `/agent-design[-<model>]`, or `/agent-review[-<model>]` on a GitHub issue or PR
 2. Target repo's shim workflow calls `remote-dev-bot.yml` from this repo
 3. Reusable workflow parses the mode and model, dispatches to the right job
-4. Resolve mode: OpenHands runs, edits code, opens a draft PR. Design mode: LLM analyzes the issue, posts a comment.
+4. Resolve mode: OpenHands runs, edits code, opens a PR. Design mode: LLM analyzes the issue, posts a comment. Review mode: LLM reviews a PR, posts a code review comment.
 5. Iterative: comment `/agent-resolve` again on the PR with feedback for another pass
 
 ### Key Files
@@ -27,7 +27,7 @@ Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to reso
 **Python**:
 - `lib/config.py` — config parsing: `parse_invocation`, `parse_args`, `resolve_config`, `ALLOWED_ARGS`; called by the workflow and unit tests
 - `lib/feedback.py` — install feedback collection: `InstallReport`, `InstallProblem`, `report_problems`; used during runbook execution
-- `scripts/compile.py` — compiles `remote-dev-bot.yml` → `dist/agent-resolve.yml`, `dist/agent-design.yml`; finds steps by **name** not index
+- `scripts/compile.py` — compiles `remote-dev-bot.yml` → `dist/agent-resolve.yml`, `dist/agent-design.yml`, `dist/agent-review.yml`; finds steps by **name** not index
 
 **Tests** (`tests/`):
 - `test_config.py` — unit tests for all `lib/config.py` functions
@@ -79,6 +79,13 @@ pytest --doctest-modules lib/config.py
 2. Add a job to `.github/workflows/remote-dev-bot.yml`
 3. `resolve_config()` in `lib/config.py` reads the mode's config from the YAML — no code change needed unless the mode has a novel output field
 
+### Adding a new model provider (e.g., a new LLM vendor)
+1. Add the provider prefix to `KNOWN_PROVIDERS` in `lib/config.py` (e.g., `"newvendor/"`)
+2. Add an API key check in the "Determine API key" step of `.github/workflows/remote-dev-bot.yml` — there are four copies (resolve, design, review, explore); update all of them
+3. Add model aliases under `models:` in `remote-dev-bot.yaml` with IDs using the new prefix
+4. Add the API key secret (`NEWVENDOR_API_KEY`) to the secrets passed through in `agent.yml` and `dogfood.yml`
+5. Update the runbook.md to mention the new provider as an option
+
 ### Changing the cost/metrics step
 The `parse_litellm_logs` Python function lives inside a bash heredoc in the "Calculate and post cost" step of `remote-dev-bot.yml`. `test_cost.py` extracts it directly from the YAML at test time, so tests always exercise the live code. After changing the step, run `pytest tests/test_cost.py -v`.
 
@@ -88,7 +95,7 @@ Users can pass per-invocation arguments on lines after the command:
 ```
 /agent resolve
 max iterations = 75
-context = extra-file.md
+context_files = extra-file.md
 target branch = design/gemini
 ```
 
@@ -98,11 +105,11 @@ target branch = design/gemini
 - `parse_args(lines)` parses `name = value` lines; `normalize_arg_name` maps spaces/dashes/underscores to underscores
 - `ALLOWED_ARGS` in `lib/config.py` defines accepted names and types; unknown names are rejected with an error
 - `resolve_config(..., args=...)` applies parsed args on top of YAML config
-- `context` is an alias for `context_files`; it **appends** to the mode's existing list (does not replace)
+- `context_files` **appends** to the mode's existing list (does not replace)
 
-## compile.py: Two-File Output
+## compile.py: Three-File Output
 
-`scripts/compile.py` inlines config parsing and selected steps from `remote-dev-bot.yml` into two standalone files: `dist/agent-resolve.yml` and `dist/agent-design.yml`. It finds steps by **name** (not index), so reordering steps is safe as long as step names don't change.
+`scripts/compile.py` inlines config parsing and selected steps from `remote-dev-bot.yml` into three standalone files: `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. It finds steps by **name** (not index), so reordering steps is safe as long as step names don't change.
 
 **Rule: if you add, remove, or rename a step in remote-dev-bot.yml, update compile.py to match**, then run `pytest tests/test_compile.py -v`. The step-count tripwire tests will catch mismatches.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,7 @@ Secrets stored on `gnovak/remote-dev-bot`:
 | `ANTHROPIC_API_KEY` | Anthropic API key (for Claude models) |
 | `OPENAI_API_KEY` | OpenAI API key (for GPT models) |
 | `GEMINI_API_KEY` | Google AI API key (for Gemini models) |
-| `RDB_PAT_TOKEN` | Fine-grained PAT (gnovak). Scoped to all repos, with Contents/Issues/PRs/Workflows read-write. |
-| `RDB_APP_PRIVATE_KEY` | (Optional) GitHub App private key, for bot identity on comments/PRs. |
+| `RDB_APP_PRIVATE_KEY` | GitHub App private key, for bot identity on comments/PRs. |
 | `RDB_TESTER_PAT_TOKEN` | PAT for `remote-dev-bot` account (collaborator on rdb-test). Used by e2e tests to post authorized trigger comments. |
 | `RDB_TESTER_UNAUTHORIZED_PAT_TOKEN` | PAT for `remote-dev-bot-tester` (not a collaborator). Used by security e2e tests to verify unauthorized users are blocked. |
 
@@ -79,7 +78,6 @@ Secrets stored on `gnovak/remote-dev-bot-test`:
 | `ANTHROPIC_API_KEY` | Same key as above (shared) |
 | `OPENAI_API_KEY` | Same key as above (shared) |
 | `GEMINI_API_KEY` | Same key as above (shared) |
-| `RDB_PAT_TOKEN` | Same PAT as above (shared) |
 | `E2E_TEST_TOKEN` | Canary secret used by security e2e tests. The test prompts the agent to exfiltrate env vars and checks the output doesn't contain this value. Current canary: `Uh_Oh_c7f3a9b2e1d8k4m6p0q5r2w8`. Must match `CANARY_VALUE` in `tests/e2e-security.sh`. If you rotate it, update both. |
 
 ## Config Layering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Three separate GitHub identities are used so each role is cleanly separated:
 - Created at https://github.com/settings/apps/remote-dev-bot (owned by `gnovak`)
 - When used, the bot posts as `remote-dev-bot[bot]` — a clearly distinct identity from the repo owner
 - App ID: `2895037`
-- Installed on all `gnovak` repos (blanket install). Only repos with `RDB_APP_PRIVATE_KEY` secret actually use it. Currently configured on: `gnovak/remote-dev-bot`, `gnovak/remote-dev-bot-test`, `gnovak/bridge-analysis`
+- Installed on all `gnovak` repos (blanket install). Only repos with `RDB_APP_PRIVATE_KEY` secret actually use it. Currently configured on: `gnovak/remote-dev-bot`, `gnovak/remote-dev-bot-test`
 - Permissions (all Read & write): Contents, Issues, Pull Requests, Workflows, Actions, Checks
   - **Workflows** is included because this app devs rdb itself, so the agent may need to modify `.github/workflows/` files. Regular rdb users should *not* grant this — the runbook intentionally omits it.
   - **Actions + Checks** are included so the agent can inspect CI logs and check run results when debugging ("PR XYZ is failing, dig into the logs"). The OpenHands sandbox has `gh` CLI and GitHub API access, so these work. Regular rdb users don't need these unless they specifically want the agent to debug CI.
@@ -70,7 +70,7 @@ Variables stored on `gnovak/remote-dev-bot`:
 
 | Variable | Value | What it is |
 |----------|-------|-----------|
-| `RDB_APP_ID` | `2895037` | GitHub App ID for the "remote-dev-bot" app. Used with `RDB_APP_PRIVATE_KEY` to generate a short-lived token so the bot posts as `remote-dev-bot[bot]`. This is a variable (not a secret) because app IDs are public. Set on `remote-dev-bot`, `remote-dev-bot-test`, and `bridge-analysis`. |
+| `RDB_APP_ID` | `2895037` | GitHub App ID for the "remote-dev-bot" app. Used with `RDB_APP_PRIVATE_KEY` to generate a short-lived token so the bot posts as `remote-dev-bot[bot]`. This is a variable (not a secret) because app IDs are public. Set on `remote-dev-bot` and `remote-dev-bot-test`. |
 
 Secrets stored on `gnovak/remote-dev-bot-test`:
 
@@ -84,13 +84,14 @@ Secrets stored on `gnovak/remote-dev-bot-test`:
 
 ## Config Layering
 
-rdb uses a three-layer config merge (each layer is optional, deeper layers win):
+rdb uses a three-layer config merge plus optional per-invocation runtime args (each layer is optional, deeper layers win):
 
-| Layer | Path | Source |
-|-------|------|--------|
+| Layer | Path / Source | Notes |
+|-------|---------------|-------|
 | Base | `.remote-dev-bot/remote-dev-bot.yaml` | rdb repo, via sparse-checkout |
 | Override | `remote-dev-bot.yaml` | Target repo (user's settings) |
-| Local | `remote-dev-bot.local.yaml` | Target repo (deepest override) |
+| Local | `remote-dev-bot.local.yaml` | Target repo (deepest override; gitignored) |
+| Runtime args | Inline `name = value` lines in the trigger comment | Override for a single run; see `ALLOWED_ARGS` in `lib/config.py` |
 
 All merges are deep (leaf-level), so overriding `modes.design.max_iterations`
 does not clobber `modes.design.context_files`.  Lists replace entirely (no
@@ -198,7 +199,7 @@ E2E tests cost real money (they invoke LLM APIs), so the full test suite is not 
    ```bash
    python scripts/compile.py
    ```
-   This writes `dist/agent-resolve.yml` and `dist/agent-design.yml`. Commit the updated dist files if they changed.
+   This writes `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. Commit the updated dist files if they changed.
 
 4. **Tag the release**:
    ```bash
@@ -208,13 +209,13 @@ E2E tests cost real money (they invoke LLM APIs), so the full test suite is not 
 
 5. **Create the GitHub release** with both compiled workflows:
    ```bash
-   gh release create vX.Y.Z dist/agent-resolve.yml dist/agent-design.yml \
+   gh release create vX.Y.Z dist/agent-resolve.yml dist/agent-design.yml dist/agent-review.yml \
      --title "vX.Y.Z" \
      --notes "Release notes here"
    ```
 
 ### What goes in a release
 
-- Two compiled workflow files: `agent-resolve.yml` (issue resolution) and `agent-design.yml` (design analysis). Both are self-contained with inlined config, model aliases, and security guardrails.
+- Three compiled workflow files: `agent-resolve.yml` (issue resolution), `agent-design.yml` (design analysis), and `agent-review.yml` (code review). All are self-contained with inlined config, model aliases, and security guardrails.
 - Users who installed via compiled workflows get updates by downloading the new release.
 - Users who installed via the shim get updates automatically (the shim calls `remote-dev-bot.yml@main`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,32 +180,37 @@ All e2e tests (functional, compiled, security) use `remote-dev-bot-test` as thei
 
 ## Release Procedure
 
-Releases distribute two compiled workflows (`agent-resolve.yml` and `agent-design.yml`) that users download into their repos.
+Releases distribute three compiled workflows (`agent-resolve.yml`, `agent-design.yml`, `agent-review.yml`) that users download into their repos.
 
-E2E tests cost real money (they invoke LLM APIs), so the full test suite is not automated. Run it manually before each release.
+E2E tests cost real money (they invoke LLM APIs), so the full test suite is not automated. Run it manually before each release. The key rule: **test on `dev` before merging to `main`** — once something is on `main` it's live for users.
 
 ### Steps
 
-1. **Ensure main is clean**: all PRs merged, unit CI green.
+1. **Ensure `dev` is ready**: all intended PRs merged to `dev`, unit CI green.
 
-2. **Run the full test suite** via GitHub Actions → Full Test Suite → Run workflow (branch: main).
+2. **Run the full test suite on `dev`** via GitHub Actions → Full Test Suite → Run workflow (branch: **dev**).
    - This runs unit tests → e2e shim (all models) → e2e compiled (all models) → e2e security, sequentially.
    - Do not trigger other e2e workflows while this is running — they share the test repo and will interfere.
-   - If it fails, debug using targeted e2e triggers (one at a time), fix on a branch, merge to main, and re-run.
+   - If it fails, debug using targeted e2e triggers (one at a time), fix on a branch, merge to `dev`, and re-run.
 
-3. **Compile the release artifacts**:
+3. **Merge `dev` → `main`** once the full test suite passes:
+   ```bash
+   git checkout main && git merge --ff-only dev && git push
+   ```
+
+4. **Compile the release artifacts** (on `main`):
    ```bash
    python scripts/compile.py
    ```
    This writes `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. Commit the updated dist files if they changed.
 
-4. **Tag the release**:
+5. **Tag the release**:
    ```bash
    git tag -a vX.Y.Z -m "Release vX.Y.Z: summary of changes"
    git push origin vX.Y.Z
    ```
 
-5. **Create the GitHub release** with both compiled workflows:
+6. **Create the GitHub release** with compiled workflows:
    ```bash
    gh release create vX.Y.Z dist/agent-resolve.yml dist/agent-design.yml dist/agent-review.yml \
      --title "vX.Y.Z" \
@@ -214,6 +219,6 @@ E2E tests cost real money (they invoke LLM APIs), so the full test suite is not 
 
 ### What goes in a release
 
-- Three compiled workflow files: `agent-resolve.yml` (issue resolution), `agent-design.yml` (design analysis), and `agent-review.yml` (code review). All are self-contained with inlined config, model aliases, and security guardrails.
+- Three compiled workflow files: `agent-resolve.yml` (issue resolution), `agent-design.yml` (design analysis), `agent-review.yml` (code review). All are self-contained with inlined config, model aliases, and security guardrails.
 - Users who installed via compiled workflows get updates by downloading the new release.
-- Users who installed via the shim get updates automatically (the shim calls `remote-dev-bot.yml@main`).
+- Users who installed via the shim get updates automatically when `main` is updated (the shim calls `remote-dev-bot.yml@main`).

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -52,10 +52,8 @@ This is the "engine" — the shared infrastructure that all target repos use.
 |------|---------|
 | `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
 | `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
-| `lib/config.py` | Config parsing logic. Loads base config, merges with target repo overrides, resolves aliases. Used by remote-dev-bot.yml at runtime. |
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
 | `install.md` | Step-by-step setup instructions for humans or AI assistants. |
-| `AGENTS.md` | Development guidance for AI assistants working on this repo. |
 
 **Who maintains this:** You (if you forked it) or the upstream maintainer (gnovak). Updates here automatically flow to all target repos that reference it.
 
@@ -67,7 +65,7 @@ This is where you want the AI agent to help with development.
 |------|---------|
 | `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, and `/agent-review` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
 | `remote-dev-bot.yaml` | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config. |
-| `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. |
+| `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. You can also use `AGENTS.md` or `CLAUDE.md` and add them to `context_files` in your `remote-dev-bot.yaml`. |
 
 **Repository Secrets (required):**
 - At least one LLM API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`
@@ -155,7 +153,7 @@ Users can override config values for a single run by adding argument lines after
 /agent-resolve
 max iterations = 75
 target branch = my-feature
-context = docs/architecture.md extra-context.md
+context_files = docs/architecture.md extra-context.md
 ```
 
 **How it works:**
@@ -169,7 +167,8 @@ context = docs/architecture.md extra-context.md
 |----------|-----------|-------------|
 | `max_iterations` | `openhands.max_iterations` | Override iteration limit for this run |
 | `target_branch` | `openhands.target_branch` | Override target branch for this run |
-| `context` | mode's `context_files` | Append extra files (space-separated) — does not replace existing list |
+| `timeout_minutes` | `openhands.timeout_minutes` | Override watchdog timeout for this run |
+| `context_files` | the mode's `context_files` | Append extra files (space-separated) — does not replace existing list |
 
 Unknown argument names are rejected with an error comment. The inline arg system is implemented in `lib/config.py` (`parse_invocation`, `parse_args`, `ALLOWED_ARGS`).
 
@@ -205,14 +204,7 @@ If you fork remote-dev-bot into your own org and your target repos are in the sa
 
 ### Advanced: GitHub App setup
 
-A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and triggers CI on bot PRs. To set one up:
-
-1. Create a GitHub App at https://github.com/settings/apps/new
-2. Grant repository permissions: Contents, Issues, Pull Requests (all Read & write)
-3. Uncheck Webhook "Active" (not needed)
-4. Install the app on your repo(s)
-5. Store the App ID as a repository **variable** `RDB_APP_ID`
-6. Generate a private key and store it as a repository **secret** `RDB_APP_PRIVATE_KEY`
+A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and triggers CI on bot PRs. See [install.md](install.md) for step-by-step setup instructions.
 
 ### Advanced: PAT setup
 
@@ -254,7 +246,7 @@ The recommended dev cycle uses two repos:
 - `remote-dev-bot` — the main repo with the reusable workflow
 - `remote-dev-bot-test` — a test repo whose shim points at `remote-dev-bot.yml@e2e-test`
 
-See `AGENTS.md` for the full dev cycle, including how the `e2e-test` branch works as a test pointer.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev cycle, including how the `e2e-test` branch works as a test pointer.
 
 ## Quick Reference: What Goes Where
 
@@ -263,7 +255,7 @@ See `AGENTS.md` for the full dev cycle, including how the `e2e-test` branch work
 | Add a new model alias | `remote-dev-bot.yaml` | remote-dev-bot (or your fork) |
 | Change the default model for one repo | `remote-dev-bot.yaml` | target repo |
 | Modify how the agent runs | `.github/workflows/remote-dev-bot.yml` | remote-dev-bot |
-| Give the agent context about my codebase | `.openhands/microagents/repo.md` | target repo |
+| Give the agent context about my codebase | `.openhands/microagents/repo.md` (or any file via `context_files`) | target repo |
 | Set up a new repo to use the bot | `.github/workflows/agent.yml` + secrets | target repo |
 | Change config parsing logic | `lib/config.py` | remote-dev-bot |
 
@@ -284,7 +276,7 @@ Config: base=remote-dev-bot, override=none
 
 - If you changed `remote-dev-bot.yaml` in the target repo: changes should work immediately
 - If you changed `remote-dev-bot.yaml` in remote-dev-bot: the target repo's shim must reference the branch with your changes (e.g., `@dev` instead of `@main`)
-- If you changed `lib/config.py`: this is checked out from `main` at runtime, so changes must be merged to main first (see AGENTS.md for details)
+- If you changed `lib/config.py`: this is checked out from `main` at runtime, so changes must be merged to main first (see [CONTRIBUTING.md](CONTRIBUTING.md) for details)
 
 **"I'm confused about which repo I'm in"**
 

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -143,6 +143,11 @@ This lets you:
 - Set lower iteration limits for repos with simpler tasks
 - Override only the settings that matter to your repo — everything else is inherited from the base
 
+The workflow logs show which configs were loaded, so you can verify what's in effect:
+```
+Config: base=remote-dev-bot, override=target repo
+```
+
 ## Per-Invocation Arguments (Inline Args)
 
 Users can override config values for a single run by adding argument lines after the command in their GitHub comment:
@@ -238,27 +243,3 @@ Now updates to your fork flow to your target repos, and you control the release 
 | Give the agent context about my codebase | `.openhands/microagents/repo.md` in target repo |
 | Override a setting for a single run | Inline args in the trigger comment (see above) |
 
-## Troubleshooting
-
-**"Which config file is being used?"**
-
-The workflow logs show which configs were loaded:
-```
-Config: base=remote-dev-bot, override=target repo
-```
-or
-```
-Config: base=remote-dev-bot, override=none
-```
-
-**"My config changes aren't taking effect"**
-
-- If you changed `remote-dev-bot.yaml` in the target repo: changes should work immediately on the next run.
-
-**"I'm confused about which repo I'm in"**
-
-Check the `uses:` line in your shim:
-```yaml
-uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
-```
-This tells you which remote-dev-bot repo (and branch) you're using.

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -1,6 +1,6 @@
 # How Remote Dev Bot Works
 
-This document explains the architecture of Remote Dev Bot: what files live where, how the pieces connect, and how to think about the system when setting it up or developing it.
+This document explains the architecture of Remote Dev Bot: what files live where, how the pieces connect, and how to think about the system when setting it up.
 
 ## The Two-Repo Model
 
@@ -34,8 +34,6 @@ Remote Dev Bot uses a **shim + reusable workflow** pattern that involves two rep
 │                                                                             │
 │   remote-dev-bot.yaml            ←── Base config: model aliases, settings   │
 │                                                                             │
-│   lib/config.py                  ←── Config parsing logic                   │
-│                                                                             │
 │   .github/workflows/agent.yml    ←── Shim (also the template for target repos)│
 │                                                                             │
 │   install.md                     ←── Setup instructions                     │
@@ -55,7 +53,7 @@ This is the "engine" — the shared infrastructure that all target repos use.
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
 | `install.md` | Step-by-step setup instructions for humans or AI assistants. |
 
-**Who maintains this:** You (if you forked it) or the upstream maintainer (gnovak). Updates here automatically flow to all target repos that reference it.
+**Who maintains this:** The upstream maintainer (gnovak), or you if you forked it. Updates here automatically flow to all target repos that reference it.
 
 ### In Each Target Repo
 
@@ -82,7 +80,7 @@ When someone comments `/agent-resolve-claude-large` on an issue:
 1. **Shim triggers** — The target repo's `agent.yml` fires on the comment
 2. **Calls reusable workflow** — The shim calls `remote-dev-bot.yml@main` from remote-dev-bot
 3. **Config checkout** — remote-dev-bot.yml sparse-checks out `remote-dev-bot.yaml` and `lib/` from remote-dev-bot
-4. **Config merge** — config.py loads base config from remote-dev-bot, merges with any override config in the target repo
+4. **Config merge** — base config from remote-dev-bot is merged with any override config in the target repo
 5. **Model resolution** — The alias `claude-large` is resolved to a model ID like `anthropic/claude-opus-4-5`
 6. **Feedback** — A rocket emoji is added to your comment and you're assigned to the issue, so you can see at a glance which issues have active work
 7. **Agent runs** — OpenHands reads the issue, explores the codebase, makes changes
@@ -143,7 +141,7 @@ Merges are deep (leaf-level): overriding `openhands.max_iterations` does not clo
 This lets you:
 - Use different default models per repo
 - Set lower iteration limits for repos with simpler tasks
-- Test config changes without modifying remote-dev-bot
+- Override only the settings that matter to your repo — everything else is inherited from the base
 
 ## Per-Invocation Arguments (Inline Args)
 
@@ -157,7 +155,6 @@ context_files = docs/architecture.md extra-context.md
 ```
 
 **How it works:**
-- `COMMENT_BODY` carries the full comment text into `lib/config.py`
 - The first line is the command; subsequent `name = value` lines are parsed as arguments
 - Argument names are normalized: spaces, dashes, and underscores are equivalent (`max iterations`, `max-iterations`, and `max_iterations` all resolve to the same thing)
 
@@ -170,7 +167,7 @@ context_files = docs/architecture.md extra-context.md
 | `timeout_minutes` | `openhands.timeout_minutes` | Override watchdog timeout for this run |
 | `context_files` | the mode's `context_files` | Append extra files (space-separated) — does not replace existing list |
 
-Unknown argument names are rejected with an error comment. The inline arg system is implemented in `lib/config.py` (`parse_invocation`, `parse_args`, `ALLOWED_ARGS`).
+Unknown argument names are rejected with an error comment.
 
 ## Authentication and Bot Identity
 
@@ -232,32 +229,14 @@ Now updates to your fork flow to your target repos, and you control the release 
 
 **Private forks:** If you keep your fork private, your target repos must be in the same org/user account (GitHub doesn't allow cross-owner calls to private repo workflows). Set the Actions access level as described in step 3.
 
-## The Special Case: Developing Remote-Dev-Bot Itself
+## Quick Reference
 
-When using remote-dev-bot to develop remote-dev-bot, the two repos are the same. This creates a bootstrapping situation:
-
-- The shim (`agent.yml`) lives in remote-dev-bot
-- The reusable workflow (`remote-dev-bot.yml`) also lives in remote-dev-bot
-- The shim calls `remote-dev-bot.yml@main`, so changes on feature branches don't take effect
-
-**Solution: Use a separate test repo.**
-
-The recommended dev cycle uses two repos:
-- `remote-dev-bot` — the main repo with the reusable workflow
-- `remote-dev-bot-test` — a test repo whose shim points at `remote-dev-bot.yml@e2e-test`
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev cycle, including how the `e2e-test` branch works as a test pointer.
-
-## Quick Reference: What Goes Where
-
-| I want to... | File to edit | Which repo |
-|--------------|--------------|------------|
-| Add a new model alias | `remote-dev-bot.yaml` | remote-dev-bot (or your fork) |
-| Change the default model for one repo | `remote-dev-bot.yaml` | target repo |
-| Modify how the agent runs | `.github/workflows/remote-dev-bot.yml` | remote-dev-bot |
-| Give the agent context about my codebase | `.openhands/microagents/repo.md` (or any file via `context_files`) | target repo |
-| Set up a new repo to use the bot | `.github/workflows/agent.yml` + secrets | target repo |
-| Change config parsing logic | `lib/config.py` | remote-dev-bot |
+| I want to... | Where |
+|--------------|-------|
+| Set up a new repo to use the bot | Follow [runbook.md](runbook.md) |
+| Change the default model for my repo | `remote-dev-bot.yaml` in target repo |
+| Give the agent context about my codebase | `.openhands/microagents/repo.md` in target repo |
+| Override a setting for a single run | Inline args in the trigger comment (see above) |
 
 ## Troubleshooting
 
@@ -274,9 +253,7 @@ Config: base=remote-dev-bot, override=none
 
 **"My config changes aren't taking effect"**
 
-- If you changed `remote-dev-bot.yaml` in the target repo: changes should work immediately
-- If you changed `remote-dev-bot.yaml` in remote-dev-bot: the target repo's shim must reference the branch with your changes (e.g., `@dev` instead of `@main`)
-- If you changed `lib/config.py`: this is checked out from `main` at runtime, so changes must be merged to main first (see [CONTRIBUTING.md](CONTRIBUTING.md) for details)
+- If you changed `remote-dev-bot.yaml` in the target repo: changes should work immediately on the next run.
 
 **"I'm confused about which repo I'm in"**
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -308,6 +308,11 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         print("Local extension (remote-dev-bot.local.yaml):")
         print(yaml.dump(local_config, default_flow_style=False, sort_keys=False).rstrip())
         print()
+    if args:
+        print("Runtime args (from comment body):")
+        for k, v in args.items():
+            print(f"  {k} = {v}")
+        print()
     print("Merged:")
     print(yaml.dump(config, default_flow_style=False, sort_keys=False).rstrip())
     print("===================")

--- a/lib/config.py
+++ b/lib/config.py
@@ -4,16 +4,16 @@ Loads base config from remote-dev-bot repo, merges with optional
 per-repo override config, resolves model aliases and modes, and writes
 GitHub Actions outputs.
 
-Commands follow the pattern: /agent-<verb>[-<model>] [--timeout N]
-  /agent-resolve           — resolve mode, default model
+Commands follow the pattern: /agent-<verb>[-<model>]
+  /agent-resolve              — resolve mode, default model
   /agent-resolve-claude-large — resolve mode, specific model
-  /agent-design            — design mode, default model
-  /agent-resolve --timeout 120 — resolve mode, override timeout to 120 minutes
+  /agent-design               — design mode, default model
 
 Arguments can be passed on subsequent lines:
   /agent resolve
-  max iterations = 75
-  context = file1.txt file2.txt
+  max_iterations = 75
+  context_files = file1.txt file2.txt
+  timeout_minutes = 60
 
 Argument names are normalized (spaces/dashes/underscores are equivalent).
 Values after = can be single values or space-separated lists.
@@ -43,11 +43,12 @@ def deep_merge(base, override):
 
 KNOWN_PROVIDERS = ("anthropic/", "openai/", "gemini/")
 
-# Arguments that can be overridden via command-line args
+DEFAULT_TIMEOUT_MINUTES = 120
+
+# Arguments that can be overridden via inline args (lines after the command)
 ALLOWED_ARGS = {
     "max_iterations": int,  # openhands.max_iterations
     "timeout_minutes": int,  # openhands.timeout_minutes
-    "context": list,  # mode's context_files (alias)
     "context_files": list,  # mode's context_files
     "target_branch": str,  # openhands.target_branch
 }
@@ -79,7 +80,7 @@ def parse_args(lines):
     {'max_iterations': 75}
     >>> parse_args(["max-iterations = 100"])
     {'max_iterations': 100}
-    >>> parse_args(["context = file1.txt file2.txt"])
+    >>> parse_args(["context_files = file1.txt file2.txt"])
     {'context_files': ['file1.txt', 'file2.txt']}
     >>> parse_args(["context files = README.md"])
     {'context_files': ['README.md']}
@@ -102,10 +103,6 @@ def parse_args(lines):
 
         if not name or not value:
             continue
-
-        # Map 'context' alias to 'context_files'
-        if name == "context":
-            name = "context_files"
 
         if name not in ALLOWED_ARGS:
             raise ValueError(
@@ -142,7 +139,7 @@ def parse_invocation(comment_body, known_modes, command_prefix="agent"):
     ('resolve', 'claude-large', {})
     >>> parse_invocation("/agent resolve\\nmax iterations = 75", {"resolve", "design"})
     ('resolve', '', {'max_iterations': 75})
-    >>> parse_invocation("/agent-design-claude-small\\ncontext = a.txt b.txt", {"resolve", "design"})
+    >>> parse_invocation("/agent-design-claude-small\\ncontext_files = a.txt b.txt", {"resolve", "design"})
     ('design', 'claude-small', {'context_files': ['a.txt', 'b.txt']})
     >>> parse_invocation("/dogfood resolve", {"resolve", "design"}, command_prefix="dogfood")
     ('resolve', '', {})
@@ -256,9 +253,6 @@ def resolve_commit_trailer(template, alias, model_id, oh_version):
         model_id=model_id,
         oh_version=oh_version,
     )
-
-
-DEFAULT_TIMEOUT_MINUTES = 120
 
 
 def resolve_config(base_path, override_path, command_string, local_path=None, timeout_minutes=None, args=None):
@@ -409,8 +403,12 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
             print(f"  {key}: {value}")
         print()
 
-    # Resolve commit_trailer template (for resolve mode)
-    commit_trailer_template = config.get("commit_trailer", "")
+    # Include explore_max_iterations if the mode defines it (for explore mode)
+    if "max_iterations" in mode_config:
+        result["explore_max_iterations"] = mode_config["max_iterations"]
+
+    # Resolve commit_trailer template (for resolve mode) — lives under openhands:
+    commit_trailer_template = config.get("openhands", {}).get("commit_trailer", "")
     result["commit_trailer"] = resolve_commit_trailer(
         commit_trailer_template, alias, model_id, oh_version
     )

--- a/lib/feedback.py
+++ b/lib/feedback.py
@@ -19,6 +19,14 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Optional
 
+# Repository where installation feedback issues are filed.
+# If you fork remote-dev-bot, update this to your fork's repo path.
+# All report_problems() callers accept a repo= parameter to override.
+DEFAULT_REPO = "gnovak/remote-dev-bot"
+
+# Maximum individual issues to file per install; beyond this, file a summary issue.
+MAX_ISSUES_PER_INSTALL = 3
+
 
 @dataclass
 class InstallProblem:
@@ -145,11 +153,6 @@ class InstallReport:
     def to_json(self) -> str:
         """Convert to JSON string."""
         return json.dumps(self.to_dict(), indent=2)
-
-
-# Default repository for filing issues
-DEFAULT_REPO = "gnovak/remote-dev-bot"
-MAX_ISSUES_PER_INSTALL = 3
 
 
 def get_environment_info() -> dict:

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -1,25 +1,20 @@
 # Remote Dev Bot Configuration
 # Usage: /agent-<mode>[-<model>]
-#   /agent-resolve             — resolve issue, open PR (default model)
+#   /agent-resolve              — resolve issue, open PR (default model)
 #   /agent-resolve-claude-large — resolve issue with specific model
-#   /agent-design              — design discussion, post comment
+#   /agent-design               — design discussion, post comment
 #   /agent-design-claude-large  — design discussion with specific model
+#   /agent-review               — code review on a PR, post comment
+#   /agent-review-claude-large  — code review with specific model
 
 default_model: claude-small
-
-# Commit trailer appended to OpenHands commits (resolve mode only).
-# Supported variables: {model_alias}, {model_id}, {oh_version}
-# Set to empty string to disable.
-commit_trailer: "Model: {model_alias} ({model_id}), openhands-ai v{oh_version}"
 
 # Modes define what the agent does. Each mode has an action and optional defaults.
 modes:
   resolve:
     action: pr               # Run OpenHands, open a draft PR
-    default_model: claude-small
   design:
     action: comment           # Post analysis as an issue comment (no code changes)
-    default_model: claude-small
     context_files:
       - README.md
       - CONTRIBUTING.md
@@ -36,7 +31,32 @@ modes:
 
   review:
     action: review            # Run OpenHands on the PR, post review as a PR comment (no code changes)
+
+  explore:
+    action: explore           # Multi-round agentic loop with tool calling for design analysis
     default_model: claude-small
+    max_iterations: 10        # Iteration limit for the agentic loop (not OpenHands iterations)
+    context_files:
+      - README.md
+      - CONTRIBUTING.md
+      - AGENTS.md
+      - CLAUDE.md
+      - .gemini/GEMINI.md
+      - .openhands/microagents/repo.md
+      - how-it-works.md
+    additional_instructions: >
+      You are analyzing this issue for design discussion using an agentic exploration loop.
+      You have access to tools to read files and search the codebase.
+      Use these tools to gather the information you need before providing your analysis.
+      When you have enough information, call submit_analysis with your final analysis.
+      Do NOT write code or open a PR. Instead, provide thoughtful
+      analysis, surface trade-offs, suggest approaches, and ask
+      clarifying questions.
+      IMPORTANT: Never begin your response with a slash command like /agent
+      or any text that could trigger another bot action.
+      Do NOT end your response with conversational invitations like
+      "Want me to elaborate?" or "Let me know if you have questions."
+      Your response is a design document, not a chat message.
 
 models:
   claude-small:
@@ -83,7 +103,21 @@ openhands:
   assign_pr: true
   # Watchdog timeout in minutes. The runner kills the OpenHands process after this
   # many minutes, then cleanup steps (cost report, artifact upload) still run.
-  # Override per-invocation with /agent-resolve --timeout N.
+  # Override per-invocation with: timeout_minutes = 60 (inline arg in comment body)
   # Note: GitHub Actions has a hard 6-hour cap. If you need longer runs, set
   # timeout-minutes in your calling workflow's job definition.
-  timeout_minutes: 120
+  timeout_minutes: 60
+  # Graceful wrap-up: inject instructions when approaching max iterations
+  # This helps the agent commit partial work before hitting the limit
+  graceful_wrapup:
+    # Enable/disable graceful wrap-up instructions
+    enabled: true
+    # Threshold as fraction of max_iterations (0.8 = 80%)
+    # At this point, the agent receives instructions to wrap up
+    threshold: 0.8
+  # Commit trailer appended to OpenHands commits (resolve mode only).
+  # Supported variables: {model_alias}, {model_id}, {oh_version}
+  # Set to empty string to disable.
+  # Note: the amend step does `git commit --amend` after OpenHands pushes,
+  # which requires a force-push to update the branch.
+  commit_trailer: "Model: {model_alias} ({model_id}), openhands-ai v{oh_version}"

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -90,8 +90,8 @@ def inline_config_parsing(config_yaml, mode):
     assign_issue = oh.get("assign_issue", True)
     assign_pr = oh.get("assign_pr", True)
 
-    # Commit trailer template (resolve mode only)
-    commit_trailer_template = config_yaml.get("commit_trailer", "")
+    # Commit trailer template (resolve mode only) — lives under openhands:
+    commit_trailer_template = config_yaml.get("openhands", {}).get("commit_trailer", "")
     # Escape for Python string literal
     commit_trailer_escaped = commit_trailer_template.replace('\\', '\\\\').replace('"', '\\"')
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -200,8 +200,12 @@ def test_design_comment_footer_includes_model(compiled_dir):
     assert "(${MODEL})_" in content or "(${{ steps.parse.outputs.model }})_" in content
     # Also check the blocked case footer
     assert "_Blocked by " in content
-    # Verify MODEL variable is assigned in the Post comment step
-    assert 'MODEL="${{ steps.parse.outputs.model }}"' in content
+    # Verify MODEL variable is assigned in the Post comment step.
+    # May appear as a block scalar (unescaped) or quoted YAML string (escaped).
+    assert (
+        'MODEL="${{ steps.parse.outputs.model }}"' in content
+        or r'MODEL=\"${{ steps.parse.outputs.model }}\"' in content
+    )
 
 
 # --- Both: model aliases ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,22 +205,17 @@ def test_parse_args_target_branch():
 
 
 def test_parse_args_context_files():
-    """context_files should be parsed as list."""
-    assert parse_args(["context = file1.txt file2.txt"]) == {"context_files": ["file1.txt", "file2.txt"]}
+    """context_files should be parsed as list (various normalized name forms)."""
+    assert parse_args(["context_files = file1.txt file2.txt"]) == {"context_files": ["file1.txt", "file2.txt"]}
     assert parse_args(["context files = README.md"]) == {"context_files": ["README.md"]}
     assert parse_args(["context-files = a.txt b.txt c.txt"]) == {"context_files": ["a.txt", "b.txt", "c.txt"]}
-
-
-def test_parse_args_context_alias():
-    """'context' should be an alias for 'context_files'."""
-    assert parse_args(["context = file.txt"]) == {"context_files": ["file.txt"]}
 
 
 def test_parse_args_multiple():
     """Multiple args should all be parsed."""
     result = parse_args([
         "max iterations = 75",
-        "context = file1.txt file2.txt",
+        "context_files = file1.txt file2.txt",
     ])
     assert result == {
         "max_iterations": 75,
@@ -234,7 +229,7 @@ def test_parse_args_skip_empty_lines():
         "",
         "max iterations = 75",
         "",
-        "context = file.txt",
+        "context_files = file.txt",
         "",
     ])
     assert result == {
@@ -258,7 +253,7 @@ def test_parse_args_skip_lines_without_equals():
     result = parse_args([
         "max iterations = 75",
         "some random text",
-        "context = file.txt",
+        "context_files = file.txt",
     ])
     assert result == {
         "max_iterations": 75,
@@ -286,7 +281,7 @@ def test_parse_args_empty_name():
 
 def test_parse_args_empty_value():
     """Lines with empty value after = should be skipped."""
-    result = parse_args(["max iterations =", "context = file.txt"])
+    result = parse_args(["max iterations =", "context_files = file.txt"])
     assert result == {"context_files": ["file.txt"]}
 
 
@@ -298,7 +293,7 @@ def test_parse_args_whitespace_only_name():
 
 def test_parse_args_whitespace_only_value():
     """Lines with whitespace-only value should be skipped."""
-    result = parse_args(["max iterations =   ", "context = file.txt"])
+    result = parse_args(["max iterations =   ", "context_files = file.txt"])
     assert result == {"context_files": ["file.txt"]}
 
 
@@ -335,7 +330,7 @@ def test_parse_invocation_with_args():
 
 def test_parse_invocation_with_model_and_args():
     """Command with model and args."""
-    comment = "/agent resolve claude-large\nmax iterations = 100\ncontext = file.txt"
+    comment = "/agent resolve claude-large\nmax iterations = 100\ncontext_files = file.txt"
     mode, alias, args = parse_invocation(comment, KNOWN_MODES)
     assert mode == "resolve"
     assert alias == "claude-large"
@@ -344,7 +339,7 @@ def test_parse_invocation_with_model_and_args():
 
 def test_parse_invocation_dash_syntax():
     """Dash syntax should work with args."""
-    comment = "/agent-design-claude-small\ncontext = a.txt b.txt"
+    comment = "/agent-design-claude-small\ncontext_files = a.txt b.txt"
     mode, alias, args = parse_invocation(comment, KNOWN_MODES)
     assert mode == "design"
     assert alias == "claude-small"
@@ -434,6 +429,13 @@ def config_dir(tmp_path):
                 "action": "review",
                 "default_model": "claude-small",
             },
+            "explore": {
+                "action": "explore",
+                "default_model": "claude-small",
+                "max_iterations": 10,
+                "additional_instructions": "You are exploring this issue.",
+                "context_files": ["README.md", "AGENTS.md"],
+            },
         },
         "openhands": {
             "version": "1.4.0",
@@ -494,6 +496,29 @@ def test_resolve_config_review_with_model(config_dir):
     result = resolve_config(base_path, "nonexistent.yaml", "review-claude-large")
     assert result["mode"] == "review"
     assert result["alias"] == "claude-large"
+
+
+def test_resolve_config_explore_mode(config_dir):
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "explore")
+    assert result["mode"] == "explore"
+    assert result["action"] == "explore"
+    assert result["alias"] == "claude-small"
+    assert result["model"] == "anthropic/claude-sonnet-4-5"
+    assert "additional_instructions" in result
+    assert "exploring" in result["additional_instructions"]
+    assert "context_files" in result
+    assert result["context_files"] == ["README.md", "AGENTS.md"]
+    assert "explore_max_iterations" in result
+    assert result["explore_max_iterations"] == 10
+
+
+def test_resolve_config_explore_with_model(config_dir):
+    tmp_path, base_path = config_dir
+    result = resolve_config(base_path, "nonexistent.yaml", "explore-claude-large")
+    assert result["mode"] == "explore"
+    assert result["alias"] == "claude-large"
+    assert result["model"] == "anthropic/claude-opus-4-5"
 
 
 def test_resolve_config_unknown_model(config_dir):
@@ -812,8 +837,7 @@ def test_resolve_config_commit_trailer_with_template():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "openhands": {"version": "1.3.0"},
-                "commit_trailer": "Model: {model_alias} ({model_id}), v{oh_version}",
+                "openhands": {"version": "1.3.0", "commit_trailer": "Model: {model_alias} ({model_id}), v{oh_version}"},
             },
             f,
         )
@@ -833,8 +857,7 @@ def test_resolve_config_commit_trailer_override():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "openhands": {"version": "1.3.0"},
-                "commit_trailer": "Base trailer: {model_alias}",
+                "openhands": {"version": "1.3.0", "commit_trailer": "Base trailer: {model_alias}"},
             },
             base_f,
         )
@@ -843,7 +866,7 @@ def test_resolve_config_commit_trailer_override():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as override_f:
         yaml.dump(
             {
-                "commit_trailer": "Override trailer: {model_id}",
+                "openhands": {"commit_trailer": "Override trailer: {model_id}"},
             },
             override_f,
         )
@@ -865,7 +888,7 @@ def test_resolve_config_commit_trailer_disable_via_override():
                 "default_model": "m1",
                 "models": {"m1": {"id": "anthropic/test-model"}},
                 "modes": {"resolve": {"action": "pr"}},
-                "commit_trailer": "Base trailer: {model_alias}",
+                "openhands": {"commit_trailer": "Base trailer: {model_alias}"},
             },
             base_f,
         )
@@ -874,7 +897,7 @@ def test_resolve_config_commit_trailer_disable_via_override():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as override_f:
         yaml.dump(
             {
-                "commit_trailer": "",
+                "openhands": {"commit_trailer": ""},
             },
             override_f,
         )
@@ -1152,9 +1175,9 @@ class TestConfigMain:
         assert "alias=claude-large\n" in content
 
     def test_timeout_minutes_default_when_not_specified(self, tmp_path):
-        """timeout_minutes is the hardcoded default (120) when not specified."""
+        """timeout_minutes comes from the config file (60) when not overridden."""
         content = self._call_main("resolve", tmp_path)
-        assert "timeout_minutes=120\n" in content
+        assert "timeout_minutes=60\n" in content
 
     def test_timeout_minutes_value_when_specified(self, tmp_path):
         """timeout_minutes contains the per-invocation value when specified."""
@@ -1204,7 +1227,7 @@ class TestConfigMain:
 
     def test_comment_body_design_with_context_append(self, tmp_path):
         """COMMENT_BODY appends context_files to mode's existing list."""
-        comment = "/agent design\ncontext = custom.txt"
+        comment = "/agent design\ncontext_files = custom.txt"
         content = self._call_main_with_comment(comment, tmp_path)
         assert "mode=design\n" in content
         assert "custom.txt" in content

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -60,7 +60,7 @@ def test_default_model_exists_in_models(bot_config):
 def test_modes_have_action(bot_config):
     for name, mode in bot_config["modes"].items():
         assert "action" in mode, f"Mode '{name}' missing 'action' field"
-        assert mode["action"] in ("pr", "comment", "review"), (
+        assert mode["action"] in ("pr", "comment", "review", "explore"), (
             f"Mode '{name}' has unknown action '{mode['action']}'"
         )
 


### PR DESCRIPTION
PRs #265 and #266 were accidentally merged to `dev` instead of `main`. This brings those changes forward via cherry-pick.

## Changes included

**Code review batch 1 (#265):**
- dogfood.yml: remove dead == /dogfood check
- full-test-suite.yml: bump timeouts
- remote-dev-bot.yml: rename, fix comment fetch per_page, fix review body parsing
- config.py: remove context alias, fix commit_trailer lookup, move constants
- feedback.py: move constants to top
- remote-dev-bot.yaml: add review examples, move commit_trailer, fix timeout 120->60
- compile.py: fix commit_trailer lookup
- tests: fix context alias removal, timeout, commit_trailer, explore mode fixtures

**Code review batch 2 (#266):**
- AGENTS.md: add review mode, three compiled outputs, add model provider task
- CONTRIBUTING.md: remove bridge-analysis refs, add runtime args layer, fix release procedure
- how-it-works.md: rewrite as user-facing doc, remove developer content, drop troubleshooting

**Follow-on commits:**
- config.py: log runtime args in config merge output
- CONTRIBUTING.md: remove RDB_PAT_TOKEN from secrets map
- CONTRIBUTING.md: fix release procedure (test on dev before merging to main)
- how-it-works.md: rewrite as user-facing doc
- how-it-works.md: drop troubleshooting section

All 215 unit tests pass.

Generated with [Claude Code](https://claude.com/claude-code)