### PR TITLE
Fix compiled mode: install agent-review.yml and honor timeout_minutes

### DIFF
--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -89,6 +89,7 @@ def inline_config_parsing(config_yaml, mode):
     target_branch = oh.get("target_branch", "main")
     assign_issue = oh.get("assign_issue", True)
     assign_pr = oh.get("assign_pr", True)
+    timeout_minutes = oh.get("timeout_minutes", 120)
 
     # Commit trailer template (resolve mode only) — lives under openhands:
     commit_trailer_template = config_yaml.get("openhands", {}).get("commit_trailer", "")
@@ -145,6 +146,9 @@ ASSIGN_PR = "{assign_pr_str}"
 # Supported variables: {{model_alias}}, {{model_id}}, {{oh_version}}
 COMMIT_TRAILER_TEMPLATE = "{commit_trailer_escaped}"
 
+# --- TIMEOUT_MINUTES: watchdog timeout for the agent process ---
+TIMEOUT_MINUTES = {timeout_minutes}
+
 # Parse alias from comment — mode is known at compile time
 comment = os.environ.get("COMMENT", "")
 # Strip the known prefix: "/agent-{mode}-claude-large do X" -> "claude-large"
@@ -159,6 +163,27 @@ if alias not in MODELS:
     sys.exit(1)
 
 model = MODELS[alias]
+
+# Parse inline args from subsequent comment lines (e.g. "timeout_minutes = 5")
+for line in comment.split("\\n")[1:]:
+    line = line.strip()
+    if not line or "=" not in line:
+        continue
+    key, _, val = line.partition("=")
+    key = re.sub(r'[\\s-]+', '_', key.strip().lower())
+    val = val.strip()
+    if key == "timeout_minutes" and val:
+        try:
+            TIMEOUT_MINUTES = int(val)
+        except ValueError:
+            pass
+    elif key == "max_iterations" and val:
+        try:
+            MAX_ITERATIONS = int(val)
+        except ValueError:
+            pass
+    elif key == "target_branch" and val:
+        TARGET_BRANCH = val
 
 # Resolve commit trailer template
 commit_trailer = ""
@@ -183,12 +208,14 @@ if output_file:
         f.write(f"assign_issue={{ASSIGN_ISSUE}}\\n")
         f.write(f"assign_pr={{ASSIGN_PR}}\\n")
         f.write(f"commit_trailer={{commit_trailer}}\\n")
+        f.write(f"timeout_minutes={{TIMEOUT_MINUTES}}\\n")
 
 # Log for visibility
 print(f"Mode: {mode}")
 print(f"Model alias: {{alias}}")
 print(f"Model ID: {{model}}")
 print(f"PR type: {{PR_TYPE}}")
+print(f"Timeout: {{TIMEOUT_MINUTES}} minutes")
 PYTHON_EOF
 '''
     return code

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -188,6 +188,7 @@ cleanup_branches=()
 ORIGINAL_SHIM_CONTENT=""  # base64-encoded original shim
 ORIGINAL_SHIM_SHA=""      # SHA for restoring
 DESIGN_WORKFLOW_SHA=""     # SHA for removing agent-design.yml on cleanup
+REVIEW_WORKFLOW_SHA=""     # SHA for removing agent-review.yml on cleanup
 
 install_compiled_workflow() {
     log "Compiling workflows..."
@@ -232,6 +233,29 @@ install_compiled_workflow() {
     }
     DESIGN_WORKFLOW_SHA=$(echo "$design_response" | jq -r '.content.sha' 2>/dev/null || echo "")
 
+    log "Adding compiled review workflow..."
+    local review_content
+    review_content=$(base64 < /tmp/compiled-workflows/agent-review.yml | tr -d '\n')
+
+    local review_response
+    review_response=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent-review.yml" \
+        --method PUT \
+        -f message="E2E: add compiled review workflow (pre-release test)" \
+        -f content="$review_content" 2>&1) || {
+        # File may already exist; get its SHA and update
+        local existing_sha
+        existing_sha=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent-review.yml" \
+            --jq '.sha' 2>/dev/null || echo "")
+        if [[ -n "$existing_sha" ]]; then
+            review_response=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent-review.yml" \
+                --method PUT \
+                -f message="E2E: update compiled review workflow (pre-release test)" \
+                -f content="$review_content" \
+                -f sha="$existing_sha")
+        fi
+    }
+    REVIEW_WORKFLOW_SHA=$(echo "$review_response" | jq -r '.content.sha' 2>/dev/null || echo "")
+
     log "Compiled workflows installed. Waiting 10s for GitHub to register..."
     sleep 10
 }
@@ -271,6 +295,18 @@ restore_shim() {
             -f message="E2E: remove compiled design workflow after pre-release test" \
             -f sha="$design_sha" >/dev/null 2>&1 || true
         log "  Compiled design workflow removed."
+    fi
+
+    # Remove agent-review.yml if we added it
+    local review_sha
+    review_sha=$(gh api "repos/$TEST_REPO/contents/.github/workflows/agent-review.yml" \
+        --jq '.sha' 2>/dev/null || echo "")
+    if [[ -n "$review_sha" ]]; then
+        gh api "repos/$TEST_REPO/contents/.github/workflows/agent-review.yml" \
+            -X DELETE \
+            -f message="E2E: remove compiled review workflow after pre-release test" \
+            -f sha="$review_sha" >/dev/null 2>&1 || true
+        log "  Compiled review workflow removed."
     fi
 }
 


### PR DESCRIPTION
## Summary

Two bugs in the compiled e2e test path, identified from run 22502266416:

**1. agent-review.yml not installed in compiled mode**

install_compiled_workflow() installed agent-resolve.yml and agent-design.yml but not agent-review.yml. When the review+feedback test posts /agent-review in compiled mode, no workflow exists — the run never starts and the test times out. Fix: also install/clean up agent-review.yml.

**2. timeout_minutes inline arg ignored in compiled mode**

inline_config_parsing() hardcoded all config values from YAML and never read inline args from the comment body. The timeout test posts timeout_minutes = 5, but TIMEOUT_MINUTES was empty so TIMEOUT_SECONDS=0 and timeout 0 disables the watchdog entirely — agent ran for 120 min at $1.68 instead of ~$0.10. Fix: parse timeout_minutes, max_iterations, and target_branch from subsequent comment lines and output timeout_minutes.

## Test plan

- All 279 unit tests pass
- Run e2e compiled with review+feedback: rf-review should no longer TIMEOUT
- Run e2e compiled with timeout test: should cost ~$0.10, job concludes failure not success