### PR TITLE
docs: add remote-dev-bot.yaml.template + update install step 2.3.1

### DIFF
--- a/install.md
+++ b/install.md
@@ -432,36 +432,25 @@ the API key you just added. Without this step, the bot defaults to a Claude
 model — which will fail on the first run if you added a Gemini or OpenAI key
 instead.
 
-Create a `remote-dev-bot.yaml` file in the root of your target repo:
-
-**If you added `ANTHROPIC_API_KEY`:**
-
-```yaml
-default_model: claude-small
-```
-
-**If you added `GEMINI_API_KEY`:**
-
-```yaml
-default_model: gemini-small
-```
-
-**If you added `OPENAI_API_KEY`:**
-
-```yaml
-default_model: gpt-small
-```
+Start from the provided template, which includes commented examples of the most
+useful options:
 
 ```bash
-# Example for Anthropic (adjust the value for your provider):
-cat > remote-dev-bot.yaml << 'EOF'
-default_model: claude-small
-EOF
+# From within the target repo:
+curl -o remote-dev-bot.yaml \
+  https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/remote-dev-bot.yaml.template
 ```
 
-You can customize this file further later — see the Customization section in
-`README.md` for model aliases, iteration limits, and other options. This minimal
-one-liner is all you need to get started.
+Then open the file and uncomment the `default_model` line that matches your API
+key:
+
+- `default_model: claude-small` — if you added `ANTHROPIC_API_KEY`
+- `default_model: gemini-small` — if you added `GEMINI_API_KEY`
+- `default_model: gpt-small` — if you added `OPENAI_API_KEY`
+
+The rest of the file shows available options with explanations — all commented
+out, so there are no active overrides until you choose to enable them. Browse
+it to see what's configurable; you can always come back and tweak later.
 
 ### Step 2.4: Bot Identity & CI Triggering
 

--- a/remote-dev-bot.yaml.template
+++ b/remote-dev-bot.yaml.template
@@ -1,0 +1,82 @@
+# remote-dev-bot.yaml — per-repo configuration
+#
+# Copy this file to your repo root as remote-dev-bot.yaml and uncomment
+# the options you want to change. Everything is optional except default_model.
+# Defaults live in remote-dev-bot's own remote-dev-bot.yaml.
+#
+# Usage: /agent-<mode>[-<model>]
+#   /agent-resolve              — resolve issue, open PR
+#   /agent-resolve-claude-large — resolve issue with a specific model
+#   /agent-design               — design analysis posted as a comment
+#   /agent-review               — code review posted as a comment
+
+# ---------------------------------------------------------------------------
+# REQUIRED: set this to match the API key secret you configured.
+# ---------------------------------------------------------------------------
+# default_model: claude-small   # Anthropic (ANTHROPIC_API_KEY)
+# default_model: gemini-small   # Google Gemini (GEMINI_API_KEY)
+# default_model: gpt-small      # OpenAI (OPENAI_API_KEY)
+
+# ---------------------------------------------------------------------------
+# Custom model aliases (optional)
+# Add entries here to make short names available in /agent-resolve-<alias>.
+# ---------------------------------------------------------------------------
+# models:
+#   my-model:
+#     id: anthropic/claude-opus-4-6
+#     description: "Claude Opus 4.6 — for the hardest tasks"
+
+# ---------------------------------------------------------------------------
+# Per-mode settings (optional)
+# All modes support: default_model, extra_instructions, extra_files
+# resolve also supports: max_iterations, timeout_minutes, target_branch, on_failure
+# design and review also support: max_iterations
+# ---------------------------------------------------------------------------
+# modes:
+#   resolve:
+#     # Use a more capable model by default for complex resolutions
+#     # default_model: claude-large
+#
+#     # Guidance appended to the agent's system prompt for every resolve run
+#     # extra_instructions: |
+#     #   Always add tests for new behavior.
+#     #   Prefer small, focused commits over large sweeping changes.
+#
+#   design:
+#     # Files always injected into the design agent's context window.
+#     # Useful for architecture docs, style guides, or any file that
+#     # should always inform design analysis.
+#     # extra_files:
+#     #   - docs/architecture.md
+#     #   - docs/api-conventions.md
+#
+#     # Guidance appended to the design agent's system prompt
+#     # extra_instructions: |
+#     #   Always consider backward compatibility with our public API.
+#     #   Flag any changes that would require a major version bump.
+#
+#   review:
+#     # Files always injected into the review agent's context window
+#     # extra_files:
+#     #   - docs/review-checklist.md
+#
+#     # Guidance appended to the review agent's system prompt
+#     # extra_instructions: |
+#     #   Flag any security concerns as high priority.
+#     #   Check that error messages don't leak internal details.
+
+# ---------------------------------------------------------------------------
+# OpenHands settings (resolve mode) — all optional
+# ---------------------------------------------------------------------------
+# openhands:
+#   # Create draft PRs even for partial results, instead of just posting a comment
+#   # on_failure: draft
+#
+#   # Override the default target branch for PRs
+#   # target_branch: main
+#
+#   # Max agent iterations per run (controls cost ceiling; default: 50)
+#   # max_iterations: 30
+#
+#   # Watchdog timeout in minutes (default: 60; GitHub Actions hard cap: 360)
+#   # timeout_minutes: 90


### PR DESCRIPTION
## Summary

- Adds `remote-dev-bot.yaml.template` — a fully-commented config that users copy into their repos during setup. Everything is commented out (no active overrides); it serves as an in-repo reference for what is configurable.
- Updates `install.md` step 2.3.1 to `curl` the template instead of writing a one-liner, then uncomment the matching `default_model` line.

This addresses discoverability: users will now encounter `extra_instructions`, `extra_files`, `on_failure`, etc. naturally during setup rather than having to read docs separately.

Note: the template uses `extra_files` / `extra_instructions` naming (not `context_files` / `additional_instructions`) — intended to land after the rename PR.

## Test plan
- [ ] Read `remote-dev-bot.yaml.template` — all options make sense, nothing misleading
- [ ] Follow install.md step 2.3.1 — curl works, correct file is downloaded, instructions are clear
- [ ] Verify no options in the template reference keys that don't exist yet (coordinate with rename PR merge order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)