### PR TITLE
refactor: drop redundant branch input from full-test-suite, use github.ref_name

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -1,13 +1,8 @@
 name: Full Test Suite
-run-name: "Full Test Suite: ${{ inputs.branch || 'main' }}"
+run-name: "Full Test Suite: ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to test (e2e-test pointer in remote-dev-bot will be reset to this branch)"
-        required: false
-        default: "main"
 
 # Sequential execution: all jobs use the same test repo, so they
 # cannot run in parallel (shared e2e-test pointer, workflow files, issues).
@@ -28,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-python@v5
         with:
@@ -57,7 +52,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
@@ -67,7 +62,7 @@ jobs:
       - name: Run E2E tests (shim, all models)
         env:
           GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
-        run: ./tests/e2e.sh --branch ${{ inputs.branch }} --all-models
+        run: ./tests/e2e.sh --branch ${{ github.ref_name }} --all-models
 
   e2e-security:
     needs: [unit-tests, e2e-shim]
@@ -85,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
@@ -93,4 +88,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RDB_TESTER_PAT_TOKEN || github.token }}
           UNAUTHORIZED_PAT: ${{ secrets.RDB_TESTER_UNAUTHORIZED_PAT_TOKEN }}
-        run: ./tests/e2e-security.sh --branch ${{ inputs.branch }}
+        run: ./tests/e2e-security.sh --branch ${{ github.ref_name }}


### PR DESCRIPTION
The workflow dispatch UI already has a 'Use workflow from' branch selector (github.ref_name). The separate branch text input was asking for the same thing twice. Drop the input; run name, checkout refs, and --branch args all now derive from github.ref_name automatically.