### PR TITLE
fix: prompt review/design agents to write complete responses within length limits

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -986,6 +986,9 @@ jobs:
               "\n\nCRITICAL: Do NOT modify any files. Do NOT make git commits. "
               "Do NOT begin your response with a slash command like /agent. "
               "Your only output is the review submitted via submit_review."
+              "\n\nLength: your review will be posted as a GitHub comment. "
+              "Write a complete, self-contained review — do not truncate or trail off mid-sentence. "
+              "If you need to be selective, prioritize the most important points over exhaustive coverage."
           )
 
           if extra_instructions:
@@ -1493,6 +1496,9 @@ jobs:
               "Use these tools to gather the information you need before providing your analysis. "
               "When you have enough information, call submit_analysis with your final analysis. "
               "Never begin your response with a slash command like /agent."
+              "\n\nLength: your analysis will be posted as a GitHub comment. "
+              "Write a complete, self-contained analysis — do not truncate or trail off mid-sentence. "
+              "If you need to be selective, prioritize the most important points over exhaustive coverage."
           )
 
           if extra_instructions:


### PR DESCRIPTION
Review and design agents currently hit the 4096 max_tokens ceiling and stop mid-sentence (observed in gnovak/blargish PR #8 with gemini-large). This adds a length hint to both prompts telling the agent to write a complete, self-contained response and prioritize important points over exhaustive coverage if it needs to be selective.

The hard max_tokens cap increase is tracked separately (to dev — code change).