### PR TITLE
fix: raise max_tokens from 4096 to 16384 for review and design loops

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1142,7 +1142,7 @@ jobs:
                   model=model,
                   messages=messages,
                   tools=tools,
-                  max_tokens=4096,
+                  max_tokens=16384,
               )
 
               # Track token usage
@@ -1654,7 +1654,7 @@ jobs:
                   model=model,
                   messages=messages,
                   tools=tools,
-                  max_tokens=4096,
+                  max_tokens=16384,
               )
 
               # Track token usage


### PR DESCRIPTION
The 4096 token cap caused review/design responses to be truncated mid-sentence. Observed concretely in gnovak/blargish PR #8 (gemini-large review ended mid-sentence; cost summary showed exactly 4092 output tokens).

16384 gives sufficient headroom for complete responses while still bounding runaway cost. The companion prompt fix (PR #297 → main) tells the agent to write a complete, self-contained response and be selective rather than trail off.