### PR TITLE
fix: auto-detect PR base branch for PR-comment triggers

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -59,6 +59,7 @@ jobs:
       pr_type: ${{ steps.parse.outputs.pr_type }}
       on_failure: ${{ steps.parse.outputs.on_failure }}
       target_branch: ${{ steps.parse.outputs.target_branch }}
+      target_branch_explicit: ${{ steps.parse.outputs.target_branch_explicit }}
       extra_files: ${{ steps.parse.outputs.extra_files }}
       commit_trailer: ${{ steps.parse.outputs.commit_trailer }}
       assign_issue: ${{ steps.parse.outputs.assign_issue }}
@@ -341,7 +342,15 @@ jobs:
           GIT_USERNAME: ${{ github.repository_owner }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
-          TARGET_BRANCH=${{ github.event.pull_request.base.ref || needs.parse.outputs.target_branch || 'main' }}
+          ISSUE_TYPE=${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
+          TARGET_BRANCH_EXPLICIT="${{ needs.parse.outputs.target_branch_explicit }}"
+          if [[ "$TARGET_BRANCH_EXPLICIT" == "true" ]]; then
+            TARGET_BRANCH="${{ needs.parse.outputs.target_branch }}"
+          elif [[ "$ISSUE_TYPE" == "pr" ]]; then
+            TARGET_BRANCH=$(gh pr view "$ISSUE_NUMBER" --json baseRefName --jq '.baseRefName')
+          else
+            TARGET_BRANCH="${{ needs.parse.outputs.target_branch || 'main' }}"
+          fi
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -377,12 +377,14 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     action = mode_config.get("action", "pr")
 
     # Apply command-line arg overrides
+    target_branch_explicit = False  # True only when set via inline arg
     if "max_iterations" in args:
         max_iter = args["max_iterations"]
     if "timeout_minutes" in args:
         resolved_timeout = args["timeout_minutes"]
     if "target_branch" in args:
         target_branch = args["target_branch"]
+        target_branch_explicit = True
 
     # Calculate the iteration warning threshold (iteration number at which to warn)
     wrapup_iteration = int(max_iter * wrapup_threshold) if wrapup_enabled else 0
@@ -397,6 +399,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         "pr_type": pr_type,
         "on_failure": on_failure,
         "target_branch": target_branch,
+        "target_branch_explicit": target_branch_explicit,
         "assign_issue": assign_issue,
         "assign_pr": assign_pr,
         "has_override": bool(override_config),
@@ -536,6 +539,7 @@ def main():
             f.write(f"pr_type={result['pr_type']}\n")
             f.write(f"on_failure={result['on_failure']}\n")
             f.write(f"target_branch={result['target_branch']}\n")
+            f.write(f"target_branch_explicit={str(result['target_branch_explicit']).lower()}\n")
             f.write(f"assign_issue={str(result['assign_issue']).lower()}\n")
             f.write(f"assign_pr={str(result['assign_pr']).lower()}\n")
             if "extra_instructions" in result:


### PR DESCRIPTION
## Summary

- When `/agent-resolve` is triggered from a PR comment, `TARGET_BRANCH` now auto-detects the PR's base branch via `gh pr view` instead of falling back to `main`
- An explicit `target_branch = <branch>` inline arg still takes precedence
- Adds `target_branch_explicit` to parse job outputs to distinguish user overrides from config/default values

## Motivation

When commenting `/agent-resolve` on a PR whose base is not `main` (e.g. blargish's `claude` branch, the resolver would check out , generate a patch, and then  would fail with a  because the file context didn't match.

## Behaviour after this fix

- **PR comment, no inline arg**: auto-fetches PR base branch — no need to specify 
- **PR comment + **: explicit override, uses 
- **Issue comment**: unchanged — uses config/default target branch (still need  inline or in )

## Test plan

- [ ] Trigger  on a PR whose base is not  — should resolve against the correct base branch
- [ ] Trigger  with  on such a PR — should use  (explicit override)
- [ ] Trigger  on a regular issue — should behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)