### PR TITLE
fix: skip send_pull_request when agent self-pushes on PR triggers

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -305,6 +305,17 @@ jobs:
           # doesn't exist at all.
           ISSUE_TYPE=${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
 
+          # For PR triggers: record the head branch SHA before the resolver runs.
+          # Used by the "Create pull request" step to detect whether the agent
+          # pushed its own commits (and skip send_pull_request if it did).
+          if [[ "$ISSUE_TYPE" == "pr" ]]; then
+            PR_HEAD_BRANCH=$(gh pr view "$ISSUE_NUMBER" --json headRefName --jq '.headRefName')
+            SHA_BEFORE=$(gh api "repos/${{ github.repository }}/git/ref/heads/$PR_HEAD_BRANCH" \
+              --jq '.object.sha' 2>/dev/null || echo "none")
+            echo "$PR_HEAD_BRANCH" > /tmp/pr_head_branch
+            echo "$SHA_BEFORE" > /tmp/sha_before
+          fi
+
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
           TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
@@ -353,6 +364,25 @@ jobs:
           fi
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # For PR triggers: detect whether the agent pushed its own commits.
+          # If it did, send_pull_request would fail (non-fast-forward) since the
+          # fresh clone it uses won't have those commits. Instead, write the PR URL
+          # to /tmp/spr_output.log so downstream steps (amend, model info, assign)
+          # work normally, then skip send_pull_request.
+          AGENT_PUSHED=false
+          if [[ "$ISSUE_TYPE" == "pr" ]] && [[ -f /tmp/sha_before ]]; then
+            PR_HEAD_BRANCH=$(cat /tmp/pr_head_branch)
+            SHA_BEFORE=$(cat /tmp/sha_before)
+            SHA_AFTER=$(gh api "repos/${{ github.repository }}/git/ref/heads/$PR_HEAD_BRANCH" \
+              --jq '.object.sha' 2>/dev/null || echo "none")
+            if [[ "$SHA_AFTER" != "$SHA_BEFORE" && "$SHA_BEFORE" != "none" ]]; then
+              AGENT_PUSHED=true
+              echo "https://github.com/${{ github.repository }}/pull/$ISSUE_NUMBER" \
+                > /tmp/spr_output.log
+              echo "Agent pushed to $PR_HEAD_BRANCH ($SHA_BEFORE -> $SHA_AFTER) — skipping send_pull_request"
+            fi
+          fi
 
           # Check whether the agent considered itself successful.
           # Override success=false if the agent hit max iterations (error field
@@ -431,8 +461,9 @@ jobs:
               --repo "${{ github.repository }}" \
               --body-file /tmp/failure_comment.md
 
-            # If configured, also create a draft PR with whatever the agent did
-            if [[ "$ON_FAILURE" == "draft" ]]; then
+            # If configured, also create a draft PR with whatever the agent did.
+            # Skip if the agent already pushed to the branch (work is there).
+            if [[ "$ON_FAILURE" == "draft" && "$AGENT_PUSHED" != "true" ]]; then
               python -m openhands.resolver.send_pull_request \
                 --issue-number "$ISSUE_NUMBER" \
                 --pr-type draft \
@@ -453,23 +484,27 @@ jobs:
               fi
             fi
           else
-            # Normal success path
-            python -m openhands.resolver.send_pull_request \
-              --issue-number "$ISSUE_NUMBER" \
-              --pr-type ${{ needs.parse.outputs.pr_type }} \
-              --target-branch "$TARGET_BRANCH" \
-              2>&1 | tee /tmp/spr_output.log
-            SPR_EXIT_CODE=${PIPESTATUS[0]}
-            if [[ $SPR_EXIT_CODE -ne 0 ]]; then
-              {
-                echo "### ⚠️ Agent completed but PR creation failed"
-                echo ""
-                echo "The agent finished successfully, but \`send_pull_request\` crashed (exit code ${SPR_EXIT_CODE}) before creating the pull request."
-                echo ""
-                echo "See the [workflow run logs]($RUN_URL) for the full error output."
-              } | gh issue comment "$ISSUE_NUMBER" \
-                  --repo "${{ github.repository }}" \
-                  --body-file -
+            # Normal success path — skip if the agent already pushed to the branch.
+            if [[ "$AGENT_PUSHED" == "true" ]]; then
+              echo "Agent self-pushed to PR branch — send_pull_request skipped"
+            else
+              python -m openhands.resolver.send_pull_request \
+                --issue-number "$ISSUE_NUMBER" \
+                --pr-type ${{ needs.parse.outputs.pr_type }} \
+                --target-branch "$TARGET_BRANCH" \
+                2>&1 | tee /tmp/spr_output.log
+              SPR_EXIT_CODE=${PIPESTATUS[0]}
+              if [[ $SPR_EXIT_CODE -ne 0 ]]; then
+                {
+                  echo "### ⚠️ Agent completed but PR creation failed"
+                  echo ""
+                  echo "The agent finished successfully, but \`send_pull_request\` crashed (exit code ${SPR_EXIT_CODE}) before creating the pull request."
+                  echo ""
+                  echo "See the [workflow run logs]($RUN_URL) for the full error output."
+                } | gh issue comment "$ISSUE_NUMBER" \
+                    --repo "${{ github.repository }}" \
+                    --body-file -
+              fi
             fi
           fi
 


### PR DESCRIPTION
## Summary

- Before the resolver runs, records the PR head branch SHA
- After resolver finishes, checks if SHA changed (agent pushed its own commits)
- If yes: writes the PR URL to `/tmp/spr_output.log` (so amend/model-info/assign steps work unchanged) and skips `send_pull_request`
- If no: normal `send_pull_request` path unchanged

## Motivation

Claude Opus 4.5 tends to push its own commits to the PR branch during resolution. This causes `send_pull_request` to fail with a non-fast-forward rejection (its fresh clone doesn't have those commits). The work is saved but the run posts a confusing error comment.

This fix detects the agent-pushed case and routes around `send_pull_request` cleanly. The downstream amend/model-info/assign steps work normally via the planted PR URL.

Only applies to PR-comment triggers — issue triggers are unchanged.

## Test plan

- [ ] Trigger `/agent-resolve` on a PR where agent self-pushes — should complete cleanly with no error comment
- [ ] Trigger `/agent-resolve` on a PR where agent does not self-push — `send_pull_request` should run as normal
- [ ] Commit trailer and model info should appear on PR in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
