### PR TITLE
fix: update tests after OpenHands removal

### DIFF
--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,149 +1,18 @@
 """Tests for cost parsing functions.
 
-- parse_litellm_logs: embedded in remote-dev-bot.yml's cost step
-- parse_cost_from_comment: embedded in tests/e2e.sh for cost aggregation
+- parse_cost_from_comment: bash function in tests/e2e.sh for cost aggregation
 
-Both functions are extracted from their source files at test time, so tests
+The function is extracted from its source file at test time, so tests
 always exercise the actual code that runs in CI.
 """
 
-import json
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 WORKSPACE = Path(__file__).parent.parent
-
-
-@pytest.fixture(scope="module")
-def parse_litellm_logs():
-    """Extract and return parse_litellm_logs from remote-dev-bot.yml's cost step."""
-    with open(WORKSPACE / ".github/workflows/remote-dev-bot.yml") as f:
-        workflow = yaml.safe_load(f)
-
-    resolve_steps = workflow["jobs"]["resolve"]["steps"]
-    cost_step = next(
-        s for s in resolve_steps if s.get("name") == "Calculate and post cost"
-    )
-
-    run_text = cost_step["run"]
-    match = re.search(r"python3 << 'PYEOF'\n(.*?)PYEOF", run_text, re.DOTALL)
-    assert match, "Could not find PYEOF block in 'Calculate and post cost' step"
-
-    python_code = match.group(1)
-    # Keep only the function definition; stop before the file-I/O main body
-    func_code = python_code.split("# Try OpenHands output")[0]
-
-    ns = {}
-    exec(func_code, ns)  # noqa: S102 — intentional, test-only
-    return ns["parse_litellm_logs"]
-
-
-# --- parse_litellm_logs ---
-
-
-def test_empty_log(parse_litellm_logs):
-    result = parse_litellm_logs("")
-    assert result == {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_cost": None,
-        "call_count": 0,
-    }
-
-
-def test_single_call_tokens_in_root(parse_litellm_logs):
-    entry = {"response_cost": 0.01, "prompt_tokens": 100, "completion_tokens": 50}
-    result = parse_litellm_logs(json.dumps(entry))
-    assert result["call_count"] == 1
-    assert result["input_tokens"] == 100
-    assert result["output_tokens"] == 50
-    assert result["total_cost"] == pytest.approx(0.01)
-
-
-def test_single_call_tokens_in_metadata(parse_litellm_logs):
-    """Tokens nested in metadata.usage_object are preferred over root fields."""
-    entry = {
-        "response_cost": 0.02,
-        "metadata": {"usage_object": {"prompt_tokens": 200, "completion_tokens": 80}},
-    }
-    result = parse_litellm_logs(json.dumps(entry))
-    assert result["call_count"] == 1
-    assert result["input_tokens"] == 200
-    assert result["output_tokens"] == 80
-    assert result["total_cost"] == pytest.approx(0.02)
-
-
-def test_multiple_calls_accumulate(parse_litellm_logs):
-    entries = [
-        {"response_cost": 0.01, "prompt_tokens": 100, "completion_tokens": 50},
-        {"response_cost": 0.02, "prompt_tokens": 200, "completion_tokens": 100},
-    ]
-    log = " ".join(json.dumps(e) for e in entries)
-    result = parse_litellm_logs(log)
-    assert result["call_count"] == 2
-    assert result["input_tokens"] == 300
-    assert result["output_tokens"] == 150
-    assert result["total_cost"] == pytest.approx(0.03)
-
-
-def test_none_cost_treated_as_zero(parse_litellm_logs):
-    """None response_cost is treated as 0, but the call is still counted."""
-    entry = {"response_cost": None, "prompt_tokens": 100, "completion_tokens": 50}
-    result = parse_litellm_logs(json.dumps(entry))
-    assert result["call_count"] == 1
-    assert result["total_cost"] == pytest.approx(0.0)
-
-
-def test_none_tokens_treated_as_zero(parse_litellm_logs):
-    """None token values are treated as 0."""
-    entry = {"response_cost": 0.01, "prompt_tokens": None, "completion_tokens": None}
-    result = parse_litellm_logs(json.dumps(entry))
-    assert result["input_tokens"] == 0
-    assert result["output_tokens"] == 0
-
-
-def test_malformed_json_skipped(parse_litellm_logs):
-    """Malformed JSON fragments are skipped; valid entries are still counted."""
-    valid = {"response_cost": 0.01, "prompt_tokens": 100, "completion_tokens": 50}
-    log = f"not json at all {json.dumps(valid)} more garbage {{broken"
-    result = parse_litellm_logs(log)
-    assert result["call_count"] == 1
-    assert result["input_tokens"] == 100
-
-
-def test_non_matching_json_skipped(parse_litellm_logs):
-    """JSON objects without response_cost are ignored."""
-    noise = {"some_other": "data", "no_cost_here": True}
-    valid = {"response_cost": 0.01, "prompt_tokens": 50, "completion_tokens": 25}
-    log = json.dumps(noise) + " " + json.dumps(valid)
-    result = parse_litellm_logs(log)
-    assert result["call_count"] == 1
-    assert result["input_tokens"] == 50
-
-
-def test_total_cost_none_when_no_calls(parse_litellm_logs):
-    """total_cost is None (not 0.0) when no matching calls are found."""
-    log = json.dumps({"no_response_cost": True})
-    result = parse_litellm_logs(log)
-    assert result["total_cost"] is None
-    assert result["call_count"] == 0
-
-
-def test_log_with_surrounding_noise(parse_litellm_logs):
-    """Realistic log: JSON objects embedded in non-JSON log lines."""
-    valid = {"response_cost": 0.005, "prompt_tokens": 75, "completion_tokens": 30}
-    log = (
-        "2026-01-01 INFO LiteLLM cost tracking enabled\n"
-        f"2026-01-01 INFO payload: {json.dumps(valid)}\n"
-        "2026-01-01 INFO done\n"
-    )
-    result = parse_litellm_logs(log)
-    assert result["call_count"] == 1
-    assert result["total_cost"] == pytest.approx(0.005)
 
 
 # --- parse_cost_from_comment (bash function in e2e.sh) ---

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -47,7 +47,7 @@ def test_config_has_required_keys(bot_config):
     assert "default_model" in bot_config
     assert "models" in bot_config
     assert "modes" in bot_config
-    assert "openhands" in bot_config
+    assert "agent" in bot_config
 
 
 def test_default_model_exists_in_models(bot_config):
@@ -88,13 +88,9 @@ def test_every_model_id_has_known_provider(bot_config):
         )
 
 
-def test_openhands_has_version(bot_config):
-    assert "version" in bot_config["openhands"]
-
-
-def test_openhands_has_max_iterations(bot_config):
-    assert "max_iterations" in bot_config["openhands"]
-    assert isinstance(bot_config["openhands"]["max_iterations"], int)
+def test_agent_has_max_iterations(bot_config):
+    assert "max_iterations" in bot_config["agent"]
+    assert isinstance(bot_config["agent"]["max_iterations"], int)
 
 
 # --- Security checks ---
@@ -105,23 +101,19 @@ def resolve_yml():
     return (REPO_ROOT / ".github/workflows/remote-dev-bot.yml").read_text()
 
 
-def test_resolve_yml_injects_security_guardrails(resolve_yml):
-    """Verify the security microagent step exists in remote-dev-bot.yml."""
-    assert "Inject security guardrails" in resolve_yml
-    assert "remote-dev-bot-security.md" in resolve_yml
-    assert "NEVER output, print, log, echo" in resolve_yml
+def test_resolve_py_has_security_rules():
+    """Verify lib/resolve.py embeds security rules in the agent's system prompt."""
+    resolve_py = (REPO_ROOT / "lib/resolve.py").read_text()
+    assert "NEVER output, print, log, echo" in resolve_py
+    assert "SECURITY_RULES" in resolve_py
+    assert "E2E_TEST_TOKEN" in resolve_py
 
 
-def test_resolve_yml_has_max_iterations_override(resolve_yml):
-    """Verify the workflow overrides success=false when agent hits max iterations.
-
-    This is a workaround for the completion function false-positive issue where
-    the LLM-based completion check can return success=true even when the agent
-    hit max iterations mid-task.
-    """
-    assert "Agent reached maximum iteration" in resolve_yml
-    # Verify the logic checks the error field
-    assert "error = data.get('error')" in resolve_yml or "data.get('error')" in resolve_yml
+def test_resolve_py_has_max_iterations_loop():
+    """Verify lib/resolve.py enforces MAX_ITERATIONS and reports failure on exhaustion."""
+    resolve_py = (REPO_ROOT / "lib/resolve.py").read_text()
+    assert "MAX_ITERATIONS" in resolve_py
+    assert "exhausted all iterations" in resolve_py
 
 
 class TestMaxIterationsSuccessOverride:


### PR DESCRIPTION
Fixes 5 failing tests in test_yaml.py and 10 erroring tests in test_cost.py left behind by the OpenHands removal PRs.

**test_yaml.py**: openhands key references updated to agent, version test deleted, security guardrails test rewritten to check lib/resolve.py, max iterations test rewritten to check resolve.py loop.

**test_cost.py**: parse_litellm_logs fixture and 10 tests removed — the PYEOF Python block in the cost step is gone; resolve.py now writes /tmp/llm_usage.json directly. parse_cost_from_comment tests unchanged.

Generated with Claude Code