### PR TITLE
chore: upgrade Claude models to 4.6

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -39,11 +39,11 @@ modes:
 
 models:
   claude-small:
-    id: anthropic/claude-sonnet-4-5
+    id: anthropic/claude-sonnet-4-6
     description: "Balanced cost/capability — good default for most tasks"
 
   claude-large:
-    id: anthropic/claude-opus-4-5
+    id: anthropic/claude-opus-4-6
     description: "Most capable — for complex multi-file features"
 
   gpt-small:


### PR DESCRIPTION
Bumps claude-small and claude-large to 4.6.

The temperature+top_p conflict that blocked 4.6 under OpenHands is gone — our LiteLLM completion() calls don't pass either parameter, so there is nothing to fix beyond the version bump.

Generated with Claude Code