### PR TITLE
feat: add conversation summary to install feedback reports

### DIFF
--- a/install.md
+++ b/install.md
@@ -816,7 +816,39 @@ straightforward.
 
 **After all phases complete:**
 
-If problems were recorded, ask the user for consent before filing:
+If problems were recorded, first produce a conversation summary, then ask the
+user for consent before filing.
+
+**Conversation summary:** Write a narrative of the install session in this
+format:
+
+```
+## TL;DR
+
+One short paragraph summarizing what went wrong and what was needed to work
+around it.
+
+## Conversation Summary
+
+For each user message and your response, write:
+
+### User: <verbatim user message>
+<50 words or fewer summarizing your response and actions>
+
+## Feedback for the remote-dev-bot author
+
+What was confusing, what failed, what would have made this smoother. Be
+specific — e.g. "Step 3.2 should mention X before Y" rather than "the
+instructions were unclear."
+```
+
+Attach this summary to the report before filing:
+
+```python
+report.set_conversation_summary(summary_text)
+```
+
+Then ask the user for consent:
 
 ```python
 from lib.feedback import get_consent_prompt, report_problems

--- a/lib/feedback.py
+++ b/lib/feedback.py
@@ -102,6 +102,7 @@ class InstallReport:
     shell: str = field(default_factory=_get_default_shell)
     python_version: str = field(default_factory=_get_default_python_version)
     problems: list[InstallProblem] = field(default_factory=list)
+    conversation_summary: Optional[str] = field(default=None)
 
     def add_problem(
         self,
@@ -125,6 +126,10 @@ class InstallReport:
                 suggested_fix=suggested_fix,
             )
         )
+
+    def set_conversation_summary(self, summary: str) -> None:
+        """Attach a narrative summary of the install conversation."""
+        self.conversation_summary = summary
 
     def has_problems(self) -> bool:
         """Return True if any problems were recorded."""
@@ -223,6 +228,13 @@ def format_metoo_comment(problem: InstallProblem, env_info: dict) -> str:
     return comment
 
 
+def _append_conversation_summary(body: str, report: InstallReport) -> str:
+    """Append conversation summary to an issue body if one was recorded."""
+    if report.conversation_summary:
+        body += f"\n## Install session summary\n\n{report.conversation_summary}\n"
+    return body
+
+
 def format_summary_issue_body(report: InstallReport) -> str:
     """Format a summary issue body when too many problems occurred."""
     env_info = get_environment_info()
@@ -249,7 +261,7 @@ This install encountered {len(report.problems)} problems, suggesting a fundament
         if problem.suggested_fix:
             body += f"- **Suggested fix:** {problem.suggested_fix}\n"
 
-    return body
+    return _append_conversation_summary(body, report)
 
 
 def search_existing_issues(
@@ -426,7 +438,9 @@ def report_problems(
         else:
             # File a new issue
             title = format_issue_title(problem)
-            body = format_issue_body(problem, env_info)
+            body = _append_conversation_summary(
+                format_issue_body(problem, env_info), report
+            )
 
             if dry_run:
                 result["filed"].append({"title": title, "body": body, "dry_run": True})


### PR DESCRIPTION
When an AI agent hits problems during install and files feedback, it now produces a narrative of the session (user prompts + short agent response summaries + author feedback) and attaches it to the filed issue.

Based on feedback in issue #286 — a friend's Gemini install session produced exactly this kind of summary and it was very useful context for understanding what went wrong.

Changes:
- install.md Phase 6: instructions telling the agent to generate a conversation summary and call report.set_conversation_summary() before filing
- lib/feedback.py: add set_conversation_summary() to InstallReport, _append_conversation_summary() helper used by both single-problem and summary issue bodies

Generated with Claude Code