### PR TITLE
Fix e2e.sh branch naming and make no-PR a hard failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ Project conventions for AI coding agents working on this repository.
 
 ## Project
 
-Remote Dev Bot — a GitHub Action that triggers an AI agent (OpenHands) to
-resolve issues and create PRs, controlled via `/agent-resolve`, `/agent-design`,
-and `/agent-review` comments on GitHub issues and PRs.
+Remote Dev Bot — a GitHub Action that triggers an AI agent to resolve issues
+and create PRs, controlled via `/agent-resolve`, `/agent-design`, and
+`/agent-review` comments on GitHub issues and PRs.
 
 ### How It Works
 
@@ -14,9 +14,9 @@ and `/agent-review` comments on GitHub issues and PRs.
    `/agent-review[-<model>]` on a GitHub issue or PR
 2. Target repo's shim workflow calls `remote-dev-bot.yml` from this repo
 3. Reusable workflow parses the mode and model, dispatches to the right job
-4. Resolve mode: OpenHands runs, edits code, opens a PR. Design mode: LLM
-   analyzes the issue, posts a comment. Review mode: LLM reviews a PR, posts a
-   code review comment.
+4. Resolve mode: agent loop runs (`lib/resolve.py`), edits code, opens a PR.
+   Design mode: LLM analyzes the issue, posts a comment. Review mode: LLM
+   reviews a PR, posts a code review comment.
 5. Iterative: comment `/agent-resolve` again on the PR with feedback for another
    pass
 
@@ -52,8 +52,8 @@ and `/agent-review` comments on GitHub issues and PRs.
 - `test_compile.py` — tests that compiled outputs contain expected steps
 - `test_yaml.py` — structural/validity tests for YAML files (workflow and
   config)
-- `test_cost.py` — tests for the `parse_litellm_logs` Python function embedded
-  in the workflow's cost step; extracts it from the YAML at test time
+- `test_cost.py` — tests for cost parsing helpers (`parse_cost_from_comment`
+  bash function in `e2e.sh`)
 - `test_feedback.py` — unit tests for `lib/feedback.py`
 - `e2e.sh` — full E2E test runner; creates issues in `remote-dev-bot-test`,
   triggers runs, checks results
@@ -61,8 +61,8 @@ and `/agent-review` comments on GitHub issues and PRs.
 
 **Config**:
 
-- `remote-dev-bot.yaml` — model aliases and OpenHands settings (canonical
-  config; also serves as template for user repos)
+- `remote-dev-bot.yaml` — model aliases and agent settings (canonical config;
+  also serves as template for user repos)
 - `remote-dev-bot.local.yaml` — local overrides (gitignored); use for dev
   without affecting CI
 - `install.md` — setup instructions designed to be followed by humans or AI
@@ -96,7 +96,7 @@ pytest --doctest-modules lib/config.py
 
 1. Add to `ALLOWED_ARGS` in `lib/config.py` (name → type)
 2. Add handling in `resolve_config()` where other args are applied (search for
-   `if "target_branch" in args` as an example)
+   `if "branch" in args` as an example)
 3. If it produces a workflow output, add it to the `GITHUB_OUTPUT` writes in
    `main()`
 4. Add tests in `tests/test_config.py`
@@ -134,10 +134,10 @@ pytest --doctest-modules lib/config.py
 
 ### Changing the cost/metrics step
 
-The `parse_litellm_logs` Python function lives inside a bash heredoc in the
-"Calculate and post cost" step of `remote-dev-bot.yml`. `test_cost.py` extracts
-it directly from the YAML at test time, so tests always exercise the live code.
-After changing the step, run `pytest tests/test_cost.py -v`.
+The cost step in `remote-dev-bot.yml` reads `/tmp/llm_usage.json` (written by
+`lib/resolve.py` and the design/review loops) and formats a cost summary comment.
+`test_cost.py` tests the `parse_cost_from_comment` bash function in `e2e.sh`.
+After changing the cost step, run `pytest tests/test_cost.py -v`.
 
 ## Inline Args System
 
@@ -266,6 +266,19 @@ gh run view RUN_ID --repo gnovak/remote-dev-bot-test --log | tail -40
   PR and let the user merge it.
 - For small changes, a single-commit PR self-merged immediately is fine — the
   point is the artifact, not the review ceremony.
+
+## Commit Attribution
+
+Sign every commit with a `Co-Authored-By` trailer that identifies you (the
+model) by name and version:
+
+```
+Co-Authored-By: <Your Model Name and Version> <noreply@your-provider.com>
+```
+
+Fill in your actual model name, version, and your provider's noreply address.
+For example, a Gemini model might use `noreply@google.com`; an OpenAI model
+`noreply@openai.com`. Use whatever is accurate for your model.
 
 ## Code Style
 

--- a/install.md
+++ b/install.md
@@ -816,7 +816,39 @@ straightforward.
 
 **After all phases complete:**
 
-If problems were recorded, ask the user for consent before filing:
+If problems were recorded, first produce a conversation summary, then ask the
+user for consent before filing.
+
+**Conversation summary:** Write a narrative of the install session in this
+format:
+
+```
+## TL;DR
+
+One short paragraph summarizing what went wrong and what was needed to work
+around it.
+
+## Conversation Summary
+
+For each user message and your response, write:
+
+### User: <verbatim user message>
+<50 words or fewer summarizing your response and actions>
+
+## Feedback for the remote-dev-bot author
+
+What was confusing, what failed, what would have made this smoother. Be
+specific — e.g. "Step 3.2 should mention X before Y" rather than "the
+instructions were unclear."
+```
+
+Attach this summary to the report before filing:
+
+```python
+report.set_conversation_summary(summary_text)
+```
+
+Then ask the user for consent:
 
 ```python
 from lib.feedback import get_consent_prompt, report_problems

--- a/install.md
+++ b/install.md
@@ -749,6 +749,26 @@ See the Customization section in `README.md` for details on adding repo context
 for the agent, adjusting model aliases, and changing iteration limits. These can
 be done any time after install — not just during initial setup.
 
+### Agent Instructions (AGENTS.md)
+
+You can add an `AGENTS.md` file to your repository to give the agent
+project-specific instructions. This is read automatically as part of the agent's
+context. Useful things to put there:
+
+- **Commit attribution**: Ask the agent to sign its commits so you can identify
+  which model made which change:
+
+  ```
+  ## Commit Attribution
+  Sign every commit with a Co-Authored-By trailer that identifies you (the
+  model) by name and version:
+
+      Co-Authored-By: <Your Model Name and Version> <noreply@your-provider.com>
+  ```
+
+- Project conventions, preferred patterns, areas to focus on
+- Instructions for how to run tests or build the project
+
 ---
 
 ## Phase 6: Report Install Feedback (Optional)

--- a/lib/feedback.py
+++ b/lib/feedback.py
@@ -102,6 +102,7 @@ class InstallReport:
     shell: str = field(default_factory=_get_default_shell)
     python_version: str = field(default_factory=_get_default_python_version)
     problems: list[InstallProblem] = field(default_factory=list)
+    conversation_summary: Optional[str] = field(default=None)
 
     def add_problem(
         self,
@@ -125,6 +126,10 @@ class InstallReport:
                 suggested_fix=suggested_fix,
             )
         )
+
+    def set_conversation_summary(self, summary: str) -> None:
+        """Attach a narrative summary of the install conversation."""
+        self.conversation_summary = summary
 
     def has_problems(self) -> bool:
         """Return True if any problems were recorded."""
@@ -223,6 +228,13 @@ def format_metoo_comment(problem: InstallProblem, env_info: dict) -> str:
     return comment
 
 
+def _append_conversation_summary(body: str, report: InstallReport) -> str:
+    """Append conversation summary to an issue body if one was recorded."""
+    if report.conversation_summary:
+        body += f"\n## Install session summary\n\n{report.conversation_summary}\n"
+    return body
+
+
 def format_summary_issue_body(report: InstallReport) -> str:
     """Format a summary issue body when too many problems occurred."""
     env_info = get_environment_info()
@@ -249,7 +261,7 @@ This install encountered {len(report.problems)} problems, suggesting a fundament
         if problem.suggested_fix:
             body += f"- **Suggested fix:** {problem.suggested_fix}\n"
 
-    return body
+    return _append_conversation_summary(body, report)
 
 
 def search_existing_issues(
@@ -426,7 +438,9 @@ def report_problems(
         else:
             # File a new issue
             title = format_issue_title(problem)
-            body = format_issue_body(problem, env_info)
+            body = _append_conversation_summary(
+                format_issue_body(problem, env_info), report
+            )
 
             if dry_run:
                 result["filed"].append({"title": title, "body": body, "dry_run": True})

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -700,7 +700,7 @@ def main():
             {
                 "role": "assistant",
                 "content": message.content,
-                "tool_calls": [tc.dict() for tc in tool_calls],
+                "tool_calls": [tc.model_dump() for tc in tool_calls],
             }
         )
 
@@ -753,9 +753,14 @@ def main():
         if ISSUE_TYPE == "issue":
             print(f"Creating PR from {branch} -> {TARGET_BRANCH}...")
             draft = PR_TYPE == "draft"
-            pr_url = create_pr(branch, pr_title, pr_body, draft=draft)
-            print(f"PR created: {pr_url}")
-            write_pr_url(pr_url)
+            try:
+                pr_url = create_pr(branch, pr_title, pr_body, draft=draft)
+                print(f"PR created: {pr_url}")
+                write_pr_url(pr_url)
+            except Exception as e:
+                print(f"PR creation failed: {e}", file=sys.stderr)
+                write_status(False, f"Agent completed work but PR creation failed: {e}")
+                return
         else:
             # PR trigger: record the existing PR URL
             pr_url = f"https://github.com/{GITHUB_REPO}/pull/{ISSUE_NUMBER}"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -422,7 +422,7 @@ while [[ $elapsed -lt $TIMEOUT ]]; do
                     RF_RESOLVE_RESULT="$conclusion"
                     log "  rf-resolve: $conclusion (run $run_id)"
                     # Locate the PR and capture its initial commit SHA
-                    RF_PR_BRANCH="openhands-fix-issue-$RF_ISSUE_NUM"
+                    RF_PR_BRANCH="rdb-fix-issue-$RF_ISSUE_NUM"
                     RF_PR_NUM=$(gh pr list --repo "$TEST_REPO" \
                         --search "head:$RF_PR_BRANCH" \
                         --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
@@ -643,16 +643,16 @@ for pos in "${!issue_nums[@]}"; do
         else
             # Resolve mode: check if a PR was created
             pr_count=$(gh pr list --repo "$TEST_REPO" \
-                --search "head:openhands-fix-issue-$issue_num" \
+                --search "head:rdb-fix-issue-$issue_num" \
                 --json number --jq 'length' 2>/dev/null || echo "0")
 
             if [[ "$pr_count" -gt 0 ]]; then
                 status="PASS"
                 ((pass++)) || true
-                cleanup_branches+=("openhands-fix-issue-$issue_num")
+                cleanup_branches+=("rdb-fix-issue-$issue_num")
             else
-                status="PASS (no PR)"
-                ((pass++)) || true
+                status="FAIL (no PR created)"
+                ((fail++)) || true
             fi
         fi
     elif [[ "$conclusion" == "timeout" ]]; then
@@ -689,10 +689,11 @@ if [[ -z "$RF_RESOLVE_RESULT" ]]; then
 elif [[ "$RF_RESOLVE_RESULT" == "success" ]]; then
     if [[ -n "$RF_PR_NUM" ]]; then
         rf_resolve_status="PASS (PR #$RF_PR_NUM)"
+        ((RF_PASS++)) || true
     else
-        rf_resolve_status="PASS (no PR found)"
+        rf_resolve_status="FAIL (no PR found)"
+        ((RF_FAIL++)) || true
     fi
-    ((RF_PASS++)) || true
 else
     rf_resolve_status="FAIL ($RF_RESOLVE_RESULT)"
     ((RF_FAIL++)) || true
@@ -703,7 +704,8 @@ printf "  %-25s %-30s issue #%-5s %s\n" "rf-resolve" "$rf_resolve_status" "${RF_
 rf_review_url=""
 [[ -n "$RF_REVIEW_RUN_ID" ]] && rf_review_url="https://github.com/$TEST_REPO/actions/runs/$RF_REVIEW_RUN_ID"
 if [[ "$RF_RESOLVE_RESULT" != "success" || -z "$RF_PR_NUM" ]]; then
-    rf_review_status="SKIPPED (resolve didn't create PR)"
+    rf_review_status="FAIL (resolve didn't create PR)"
+    ((RF_FAIL++)) || true
 elif [[ -z "$RF_REVIEW_RESULT" ]]; then
     rf_review_status="TIMEOUT"
     ((RF_FAIL++)) || true
@@ -727,7 +729,8 @@ printf "  %-25s %-30s PR #%-5s  %s\n" "rf-review" "$rf_review_status" "$rf_pr_re
 rf_feedback_url=""
 [[ -n "$RF_FEEDBACK_RUN_ID" ]] && rf_feedback_url="https://github.com/$TEST_REPO/actions/runs/$RF_FEEDBACK_RUN_ID"
 if [[ "$RF_REVIEW_RESULT" != "success" || -z "$RF_PR_NUM" ]]; then
-    rf_feedback_status="SKIPPED (review didn't complete)"
+    rf_feedback_status="FAIL (review didn't complete)"
+    ((RF_FAIL++)) || true
 elif [[ -z "$RF_FEEDBACK_RESULT" ]]; then
     rf_feedback_status="TIMEOUT"
     ((RF_FAIL++)) || true
@@ -794,14 +797,14 @@ if [[ -z "$WRAPUP_RESULT" ]]; then
 elif [[ "$WRAPUP_RESULT" == "success" ]]; then
     # Check for either a PR (agent finished) or a failure comment (wrapup triggered)
     pr_count=$(gh pr list --repo "$TEST_REPO" \
-        --search "head:openhands-fix-issue-$wrapup_issue_num" \
+        --search "head:rdb-fix-issue-$wrapup_issue_num" \
         --json number --jq 'length' 2>/dev/null || echo "0")
     comment_count=$(gh api "repos/$TEST_REPO/issues/$wrapup_issue_num/comments" \
         --jq '[.[] | select(.body | contains("could not fully resolve"))] | length' \
         2>/dev/null || echo "0")
     if [[ "$pr_count" -gt 0 ]]; then
         wrapup_status="PASS (agent finished — PR created)"
-        cleanup_branches+=("openhands-fix-issue-$wrapup_issue_num")
+        cleanup_branches+=("rdb-fix-issue-$wrapup_issue_num")
         ((WRAPUP_PHASE_PASS++)) || true
     elif [[ "$comment_count" -gt 0 ]]; then
         wrapup_status="PASS (wrapup triggered — failure comment posted)"


### PR DESCRIPTION
## Summary

- **e2e.sh was searching for wrong branch prefix**: all `openhands-fix-issue-*` searches updated to `rdb-fix-issue-*` (resolve, rf-resolve, wrapup tests)
- **"PASS (no PR)" to "FAIL (no PR created)"**: agents that don't produce a PR now fail the e2e suite
- **rf-review/rf-feedback SKIPPED to FAIL**: when rf-resolve doesn't create a PR, dependent tests count as failures
- **rf-resolve: workflow success without PR is now FAIL**
- **resolve.py**: wrap `create_pr()` in try/except so a failed `gh pr create` exits cleanly via `write_status(False, ...)` instead of crashing
- **resolve.py**: `tc.dict()` to `tc.model_dump()` (Pydantic v2 deprecation)

## Root cause of run 22760804687

All 6 model runs created PRs (`rdb-fix-issue-*`) but e2e.sh couldn't find them because it searched for `openhands-fix-issue-*`. gpt-small legitimately crashed: it called `finish(success=True)` without committing anything, so `gh pr create` returned "No commits between main and rdb-fix-issue-377" and the unhandled exception killed the process.

## Test plan
- [ ] Run full e2e suite and verify model tests show PASS/FAIL (not "PASS (no PR)")
- [ ] Verify rf-review/rf-feedback show FAIL when rf-resolve doesn't create PR
