### PR TITLE
Bump gpt-large to gpt-5.3-codex

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -51,8 +51,8 @@ models:
     description: "OpenAI GPT-5.1 Codex Mini — good default"
 
   gpt-large:
-    id: openai/gpt-5.2-codex
-    description: "OpenAI GPT-5.2 Codex — best coding model"
+    id: openai/gpt-5.3-codex
+    description: "OpenAI GPT-5.3 Codex — best coding model"
 
   gemini-small:
     id: gemini/gemini-2.5-flash


### PR DESCRIPTION
gpt-5.3-codex is the latest codex model, same pricing as 5.2-codex ($1.75/1M in, $14/1M out).