### PR TITLE
Fix rf-feedback polling: remove displayTitle filter

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -616,19 +616,17 @@ if [[ "$RF_REVIEW_RESULT" == "success" && -n "$RF_PR_NUM" ]]; then
             [[ "$conclusion" == "skipped" ]] && continue
             echo "$RF_FEEDBACK_BASELINE" | grep -qx "$run_id" && continue
 
-            if [[ "$display_title" == *"e2e-rv-$RF_TS"* ]]; then
-                RF_FEEDBACK_RUN_ID="$run_id"
-                if [[ "$status" == "completed" ]]; then
-                    RF_FEEDBACK_RESULT="$conclusion"
-                    log "  rf-feedback: $conclusion (run $run_id)"
-                    # Check whether the branch has a new commit
-                    RF_FEEDBACK_NEW_SHA=$(gh api "repos/$TEST_REPO/git/ref/heads/$RF_PR_BRANCH" \
-                        --jq '.object.sha' 2>/dev/null || echo "")
-                else
-                    log "  rf-feedback: $status (run $run_id)"
-                fi
-                break
+            RF_FEEDBACK_RUN_ID="$run_id"
+            if [[ "$status" == "completed" ]]; then
+                RF_FEEDBACK_RESULT="$conclusion"
+                log "  rf-feedback: $conclusion (run $run_id)"
+                # Check whether the branch has a new commit
+                RF_FEEDBACK_NEW_SHA=$(gh api "repos/$TEST_REPO/git/ref/heads/$RF_PR_BRANCH" \
+                    --jq '.object.sha' 2>/dev/null || echo "")
+            else
+                log "  rf-feedback: $status (run $run_id)"
             fi
+            break
         done <<< "$(echo "$rf_feedback_json" | jq -c '.[]')"
 
         if [[ -z "$RF_FEEDBACK_RESULT" ]]; then


### PR DESCRIPTION
Remove the `displayTitle` filter from the rf-feedback polling loop so that any new non-skipped run (not already in the baseline) is claimed as the rf-feedback run, since `/agent-resolve` is triggered from a PR comment and the resulting workflow run carries the PR title rather than the issue title.