### PR TITLE
Add model alias suffix to agent branch names

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -69,7 +69,8 @@ def _find_available_branch(issue_number):
     Checks remote via git ls-remote so we don't miss branches that were
     created by a previous run or by a parallel agent.
     """
-    base = f"rdb-fix-issue-{issue_number}"
+    alias_suffix = f"-{ALIAS}" if ALIAS else ""
+    base = f"rdb-fix-issue-{issue_number}{alias_suffix}"
     candidate = base
     suffix = 1
     while True:


### PR DESCRIPTION
Branches are now `rdb-fix-issue-{N}-{alias}` (e.g. `rdb-fix-issue-16-claude-small`). This allows simultaneous multi-model triggers on the same issue without branch name collisions. Retry detection still works: a second claude-small run sees the first branch exists and creates `rdb-fix-issue-16-claude-small-2`.