### PR TITLE
Push after every commit to preserve agent work on remote

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -460,11 +460,11 @@ Use the bash tool to edit files. Good approaches:
    git add <files>
    git commit -m "Clear description of what and why"
    ```
-3. Push to remote regularly:
+3. **Push immediately after every `git commit`:**
    ```
    git push origin HEAD
    ```
-   Push after each logical chunk of work — if you run out of iterations with uncommitted work, it is lost.
+   After every `git commit`, immediately run `git push origin HEAD` to preserve your work on the remote. This ensures progress is saved even if the run is interrupted before completion.
 
 ### Finishing
 - Before calling finish(), run `git status` to confirm all changes are committed and the working tree is clean.

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -917,6 +917,25 @@ def main():
     if finish_args is None:
         write_status(False, "Agent exhausted all iterations without calling finish()")
         print("Agent did not call finish() — treating as failure")
+        remote_branch_exists = bool(run(
+            f"git ls-remote --heads origin {branch}",
+            check=False, timeout=30
+        ).strip())
+        if ISSUE_TYPE == "issue" and remote_branch_exists:
+            try:
+                draft_body = (
+                    f"\U0001f916 **Model:** `{ALIAS}` (`{LLM_MODEL}`)\n\n"
+                    f"\u26a0\ufe0f **Partial work** \u2014 agent exhausted all {MAX_ITERATIONS} iterations "
+                    f"without completing the task.\n\n"
+                    f"This draft PR contains whatever was committed and pushed during the run. "
+                    f"To continue, trigger `/agent-resolve` as a comment on this PR and the "
+                    f"agent will pick up from this branch.\n\n"
+                    f"**Agent's last status:** No status recorded."
+                )
+                pr_url = create_pr(branch, f"WIP: partial work on #{ISSUE_NUMBER}", draft_body, draft=True)
+                print(f"Created draft PR for partial work: {pr_url}")
+            except Exception as e:
+                print(f"Could not create draft PR: {e}")
         return
 
     success = finish_args.get("success", False)

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -492,17 +492,27 @@ def build_system_prompt(repo_context, issue_context_str):
     """Build the system prompt for the resolve agent."""
     wrapup_hint = ""
     if WRAPUP_ENABLED and WRAPUP_ITERATION > 0:
+        remaining = MAX_ITERATIONS - WRAPUP_ITERATION
         wrapup_hint = f"""
-## Iteration Budget
+## ⚠️ Iteration Budget — WRAP-UP REQUIRED
 
 This task has a budget of **{MAX_ITERATIONS} iterations**.
 
-When you reach iteration **{WRAPUP_ITERATION}**, begin wrapping up:
-1. Commit all changes you have made so far with a clear commit message
-2. If the task is not fully complete, add a brief TODO comment describing what remains
-3. Call `finish()` with your honest assessment of what was accomplished
+**When you reach iteration {WRAPUP_ITERATION}, you MUST begin wrapping up immediately.**
+At that point only {remaining} iteration(s) remain. Do NOT continue working toward a
+complete solution — partial work committed and pushed is far better than complete work
+that never ships.
 
-Do not start new work after iteration {WRAPUP_ITERATION}.
+You MUST take these steps at iteration {WRAPUP_ITERATION}:
+1. **Commit** whatever work exists, even if incomplete:
+   `git add -A && git commit -m "WIP: partial implementation"`
+2. **Push** immediately:
+   `git push origin HEAD`
+3. **Call `finish()`** with `success=False` if the task is incomplete, explaining
+   what was done and what still remains.
+
+Do NOT start new work after iteration {WRAPUP_ITERATION}. Do NOT wait until the work
+is complete before committing — call `finish()` now.
 """
 
     prompt = (

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -46,6 +46,10 @@ GIT_USERNAME = (
 )
 
 
+# Sentinels for top-level cleanup handler
+_branch_created: str | None = None  # set as soon as branch is known
+_pr_created: bool = False            # set when any PR (draft or real) is successfully created
+
 # --- Utilities ---
 
 def run(cmd, *, check=True, timeout=60):
@@ -719,9 +723,11 @@ def write_usage(input_tokens, output_tokens, cost, iterations):
 # --- Main agent loop ---
 
 def main():
+    global _branch_created, _pr_created
     # Set up branch
     print(f"Setting up branch for {ISSUE_TYPE} #{ISSUE_NUMBER}...")
     branch = setup_branch()
+    _branch_created = branch
     print(f"Working on branch: {branch}")
 
     # Gather repository context
@@ -934,6 +940,7 @@ def main():
                 )
                 pr_url = create_pr(branch, f"WIP: partial work on #{ISSUE_NUMBER}", draft_body, draft=True)
                 print(f"Created draft PR for partial work: {pr_url}")
+                _pr_created = True
             except Exception as e:
                 print(f"Could not create draft PR: {e}")
         return
@@ -953,6 +960,7 @@ def main():
                 pr_url = create_pr(branch, pr_title, pr_body, draft=draft)
                 print(f"PR created: {pr_url}")
                 write_pr_url(pr_url)
+                _pr_created = True
             except Exception as e:
                 print(f"PR creation failed: {e}", file=sys.stderr)
                 write_status(False, f"Agent completed work but PR creation failed: {e}")
@@ -975,9 +983,44 @@ def main():
                 )
                 write_pr_url(pr_url)
                 print(f"Draft PR created: {pr_url}")
+                _pr_created = True
             except Exception as e:
                 print(f"Failed to create draft PR: {e}", file=sys.stderr)
 
 
+def _cleanup():
+    """Best-effort: create draft PR if the agent terminated without creating one."""
+    if not _pr_created and _branch_created and ISSUE_TYPE == "issue":
+        try:
+            remote_exists = bool(run(
+                f"git ls-remote --heads origin {_branch_created}",
+                check=False, timeout=30
+            ).strip())
+            if remote_exists:
+                draft_body = (
+                    f"\U0001f916 **Model:** `{ALIAS}` (`{LLM_MODEL}`)\n\n"
+                    f"\u26a0\ufe0f **Partial work** \u2014 agent terminated unexpectedly before completing the task.\n\n"
+                    f"This draft PR contains whatever was committed and pushed during the run. "
+                    f"To continue, trigger `/agent-resolve` as a comment on this PR and the "
+                    f"agent will pick up from this branch."
+                )
+                pr_url = create_pr(
+                    _branch_created,
+                    f"WIP: partial work on #{ISSUE_NUMBER}",
+                    draft_body,
+                    draft=True
+                )
+                print(f"Cleanup handler: created draft PR {pr_url}")
+        except Exception as e:
+            print(f"Cleanup handler: could not create draft PR: {e}")
+
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        import traceback
+        print(f"Unhandled exception in resolve.py: {e}")
+        traceback.print_exc()
+        write_status(False, f"Agent crashed: {e}")
+    finally:
+        _cleanup()


### PR DESCRIPTION
Adds instruction to git workflow: after every git commit, immediately push to origin. This ensures work is preserved on the remote branch even if the runner is interrupted, times out, or hits max iterations before calling finish().