### PR TITLE
Context/cost reduction: bash truncation + drop old tool results

### DIFF
--- a/debug.md
+++ b/debug.md
@@ -1,0 +1,43 @@
+# Debug / Tuning Parameters
+
+These inline arguments are available for debugging and tuning agent behavior.
+They are not part of the stable public interface and may change without notice.
+Pass them in the comment body when triggering the agent:
+
+    /agent-resolve bash_output_limit = 4000
+
+---
+
+## Context and Cost Tuning
+
+### `bash_output_limit`
+
+Maximum characters of bash tool output to include in the agent's context.
+Output exceeding this limit is truncated with a note. Set to `0` to disable truncation.
+
+- **Default:** `8000`
+- **Lower values:** Reduce context size and cost; risk hiding relevant output
+- **Higher values / 0:** Full output; can cause context bloat on verbose commands
+
+### `context_keep_tool_results`
+
+Number of recent tool call/result pairs to keep in the conversation context.
+Older pairs are replaced with a placeholder. This prevents O(N²) context growth
+over long runs. Set to `0` to keep all tool results (default behavior).
+
+- **Default:** `0` (keep all)
+- **Suggested starting point:** `20` (keeps the last 20 tool interactions)
+- **Lower values:** Smaller context, lower cost, but agent may "forget" earlier work
+- **Higher values / 0:** Full history; safe but expensive on long runs
+
+---
+
+## Iteration and Behavior
+
+### `status_log_interval`
+
+*(Coming soon)* Every N iterations, the agent writes a one-sentence status update
+to a running log. The log is posted as a comment at the end of the run.
+Set to `0` to disable.
+
+- **Default:** `0` (disabled)

--- a/lib/config.py
+++ b/lib/config.py
@@ -59,6 +59,8 @@ ALLOWED_ARGS = {
     "branch": str,           # agent.branch (target branch for PRs)
     # BACKCOMPAT(v0→v1, 2026-03-05): target_branch accepted as alias for branch
     "target_branch": str,
+    "bash_output_limit": int,          # agent bash output truncation
+    "context_keep_tool_results": int,  # how many tool result pairs to keep
 }
 
 
@@ -384,6 +386,9 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         target_branch = args["target_branch"]
         target_branch_explicit = True
 
+    bash_output_limit = args.get("bash_output_limit", None)
+    context_keep_tool_results = args.get("context_keep_tool_results", None)
+
     # Calculate the iteration warning threshold (iteration number at which to warn)
     wrapup_iteration = int(max_iter * wrapup_threshold) if wrapup_enabled else 0
 
@@ -405,6 +410,11 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         "graceful_wrapup_iteration": wrapup_iteration,
         "timeout_minutes": resolved_timeout,
     }
+
+    if bash_output_limit is not None:
+        result["bash_output_limit"] = bash_output_limit
+    if context_keep_tool_results is not None:
+        result["context_keep_tool_results"] = context_keep_tool_results
 
     # Include extra_instructions if the mode defines one (appended to canonical prompt)
     if "extra_instructions" in mode_config:
@@ -544,6 +554,10 @@ def main():
             f.write(f"graceful_wrapup_enabled={str(result['graceful_wrapup_enabled']).lower()}\n")
             f.write(f"graceful_wrapup_iteration={result['graceful_wrapup_iteration']}\n")
             f.write(f"timeout_minutes={result['timeout_minutes']}\n")
+            if "bash_output_limit" in result:
+                f.write(f"bash_output_limit={result['bash_output_limit']}\n")
+            if "context_keep_tool_results" in result:
+                f.write(f"context_keep_tool_results={result['context_keep_tool_results']}\n")
 
     # Log for visibility
     override_label = "target repo" if result["has_override"] else "none"

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -36,6 +36,8 @@ COMMIT_TRAILER = os.environ.get("COMMIT_TRAILER", "")
 ALIAS = os.environ.get("ALIAS", "")
 LLM_MODEL = os.environ.get("LLM_MODEL", "")
 EXTRA_FILES = json.loads(os.environ.get("EXTRA_FILES", "[]") or "[]")
+BASH_OUTPUT_LIMIT = int(os.environ.get("BASH_OUTPUT_LIMIT", "8000") or "8000")
+CONTEXT_KEEP_TOOL_RESULTS = int(os.environ.get("CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
 
 GH_TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
 GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "")
@@ -156,7 +158,10 @@ def execute_bash(command):
         output = (result.stdout or "") + (result.stderr or "")
         if result.returncode != 0:
             output = f"(exit code {result.returncode})\n" + output
-        return output or "(no output)"
+        output = output or "(no output)"
+        if BASH_OUTPUT_LIMIT > 0 and len(output) > BASH_OUTPUT_LIMIT:
+            output = output[:BASH_OUTPUT_LIMIT] + f"\n... [truncated: output was {len(output)} chars, limit is {BASH_OUTPUT_LIMIT}]"
+        return output
     except subprocess.TimeoutExpired:
         return "Error: Command timed out after 30 seconds"
     except Exception as e:
@@ -640,6 +645,84 @@ TOOLS = [
 ]
 
 
+
+def trim_tool_results(messages, keep_n):
+    """Remove oldest tool call/result pairs, keeping the last keep_n pairs.
+
+    Preserves all assistant text content and the system prompt.
+    Operates on OpenAI-format messages where tool calls are in assistant messages
+    (role="assistant", tool_calls=[...]) and results are role="tool" messages.
+    """
+    if keep_n <= 0:
+        return messages
+
+    # Collect indices of all "tool" role messages (each is one tool result)
+    tool_result_indices = [i for i, m in enumerate(messages) if m.get("role") == "tool"]
+
+    if len(tool_result_indices) <= keep_n:
+        return messages
+
+    # Number of pairs to drop
+    n_drop = len(tool_result_indices) - keep_n
+    indices_to_drop = set(tool_result_indices[:n_drop])
+
+    # Also find the assistant messages that contain tool_calls for the pairs we're dropping.
+    # Each assistant message with tool_calls is immediately followed by one or more tool messages.
+    # We scan backwards from each tool_result index to find its owning assistant message.
+    dropped_tool_call_ids = set()
+    for idx in indices_to_drop:
+        dropped_tool_call_ids.add(messages[idx].get("tool_call_id"))
+
+    new_messages = []
+    for i, msg in enumerate(messages):
+        role = msg.get("role")
+        if i in indices_to_drop:
+            # Drop this tool result message entirely
+            continue
+        if role == "assistant" and msg.get("tool_calls"):
+            # Filter out tool_calls whose IDs are being dropped
+            remaining_calls = [
+                tc for tc in msg["tool_calls"]
+                if tc.get("id") not in dropped_tool_call_ids
+            ]
+            dropped_calls = [
+                tc for tc in msg["tool_calls"]
+                if tc.get("id") in dropped_tool_call_ids
+            ]
+            if dropped_calls:
+                # Build a new assistant message: preserve content, replace dropped calls
+                # with a placeholder text note. Keep remaining tool calls if any.
+                n_omitted = len(dropped_calls)
+                placeholder_text = f"[{n_omitted} tool call(s) omitted for context]"
+                new_msg = dict(msg)
+                if remaining_calls:
+                    new_msg["tool_calls"] = remaining_calls
+                    # Prepend placeholder to content (content may be str or list or None)
+                    if new_msg.get("content") is None:
+                        new_msg["content"] = placeholder_text
+                    elif isinstance(new_msg["content"], str):
+                        new_msg["content"] = placeholder_text + "\n" + new_msg["content"]
+                    else:
+                        # list of content blocks — prepend text block
+                        new_msg["content"] = [{"type": "text", "text": placeholder_text}] + list(new_msg["content"])
+                else:
+                    # No remaining calls — strip tool_calls entirely, keep only content
+                    new_msg = {"role": "assistant"}
+                    if msg.get("content") is None or msg.get("content") == []:
+                        new_msg["content"] = placeholder_text
+                    elif isinstance(msg["content"], str):
+                        new_msg["content"] = (msg["content"] + "\n" + placeholder_text).strip()
+                    else:
+                        new_msg["content"] = list(msg["content"]) + [{"type": "text", "text": placeholder_text}]
+                new_messages.append(new_msg)
+            else:
+                new_messages.append(msg)
+        else:
+            new_messages.append(msg)
+
+    return new_messages
+
+
 def execute_tool(tool_name, arguments):
     """Dispatch a tool call and return the result string."""
     if tool_name == "bash":
@@ -895,6 +978,10 @@ def main():
                         "content": tool_result,
                     }
                 )
+
+            # Trim old tool result pairs to manage context size
+            if CONTEXT_KEEP_TOOL_RESULTS > 0:
+                messages = trim_tool_results(messages, CONTEXT_KEEP_TOOL_RESULTS)
 
             if done:
                 break


### PR DESCRIPTION
Two tunable context management improvements, both off-by-default and configurable via inline debug args (see debug.md):

**bash_output_limit** (default 8000): caps bash tool output to N chars. Single biggest driver of context bloat on long runs with verbose commands.

**context_keep_tool_results** (default 0 = keep all): drops oldest tool call/result pairs from the message history, keeping the last N. Converts O(N²) context growth into O(N × window).

Both args are documented in debug.md (not linked from README — intentionally undiscoverable except by those who know to look).