### PR TITLE
Observability: rolling status log, conversation summary, step summary

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -255,6 +255,7 @@ jobs:
           MAX_ITERATIONS: ${{ needs.parse.outputs.max_iterations }}
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
+          STATUS_LOG_INTERVAL: ${{ needs.parse.outputs.status_log_interval }}
           ALIAS: ${{ needs.parse.outputs.alias }}
           EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
         run: |
@@ -347,6 +348,38 @@ jobs:
           fi
           # Success case: PR was already created by resolve.py — no comment needed here
 
+
+      - name: Write step summary
+        if: always()
+        env:
+          ALIAS: ${{ needs.parse.outputs.alias }}
+          LLM_MODEL: ${{ needs.parse.outputs.model }}
+        run: |
+          if [ -f /tmp/llm_usage.json ]; then
+            cost=$(python3 -c "import json; d=json.load(open('/tmp/llm_usage.json')); print(f\"\${d.get('cost',0):.2f}\")")
+            iters=$(python3 -c "import json; d=json.load(open('/tmp/llm_usage.json')); print(d.get('iterations',0))")
+          else
+            cost="unknown"
+            iters="unknown"
+          fi
+          if [ -f /tmp/resolve_status.json ]; then
+            success=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('✅' if d.get('success') else '❌')")
+            explanation=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print(d.get('explanation','')[:200])")
+          else
+            success="❓"
+            explanation="No status recorded"
+          fi
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## Resolve Run Summary
+          | | |
+          |---|---|
+          | **Result** | $success |
+          | **Cost** | \$$cost |
+          | **Iterations** | $iters |
+          | **Model** | ${{ env.ALIAS }} (${{ env.LLM_MODEL }}) |
+
+          **Status:** $explanation
+          EOF
 
       - name: Assign triggerer to PR
         if: needs.parse.outputs.assign_pr == 'true'

--- a/debug.md
+++ b/debug.md
@@ -1,0 +1,41 @@
+# Debugging and Observability
+
+This document describes the observability features available in remote-dev-bot.
+
+## Configuration Arguments
+
+These arguments can be passed inline in the trigger comment (after the command line):
+
+```
+/agent resolve
+status_log_interval = 5
+max_iterations = 50
+```
+
+### `status_log_interval`
+
+Every N iterations, the agent is asked for a 1-2 sentence status update (a side-channel
+call that does not affect the main conversation). The collected updates are posted as an
+issue comment at the end of the run.
+
+- **Default:** `0` (disabled)
+- **Suggested:** `5` for a 50-iteration run (gives ~10 checkpoints)
+- **Cost:** One small extra API call per interval; output is tiny so cost impact is minimal
+
+## PR Description
+
+When the agent calls `finish()`, it is required to provide a `conversation_summary` —
+a 3-5 sentence description of the approach taken, key decisions made, and any dead ends
+hit. This appears as a `## Summary` section at the top of the PR description.
+
+## GitHub Actions Step Summary
+
+After each resolve run, a summary table is written to the GitHub Actions run page
+(`$GITHUB_STEP_SUMMARY`). This appears at the top of the Actions run without needing
+to dig through logs, and includes:
+
+- Result (success/failure)
+- Estimated cost
+- Number of iterations used
+- Model alias and ID
+- Agent's final status explanation

--- a/lib/config.py
+++ b/lib/config.py
@@ -53,12 +53,13 @@ DEFAULT_TIMEOUT_MINUTES = 120
 
 # Arguments that can be overridden via inline args (lines after the command)
 ALLOWED_ARGS = {
-    "max_iterations": int,   # agent.max_iterations
-    "timeout_minutes": int,  # agent.timeout_minutes
-    "extra_files": list,     # mode's extra_files
-    "branch": str,           # agent.branch (target branch for PRs)
+    "max_iterations": int,       # agent.max_iterations
+    "timeout_minutes": int,      # agent.timeout_minutes
+    "extra_files": list,         # mode's extra_files
+    "branch": str,               # agent.branch (target branch for PRs)
     # BACKCOMPAT(v0→v1, 2026-03-05): target_branch accepted as alias for branch
     "target_branch": str,
+    "status_log_interval": int,  # rolling status log interval (0 = disabled)
 }
 
 
@@ -384,6 +385,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         target_branch = args["target_branch"]
         target_branch_explicit = True
 
+    status_log_interval = args.get("status_log_interval", 0)
+
     # Calculate the iteration warning threshold (iteration number at which to warn)
     wrapup_iteration = int(max_iter * wrapup_threshold) if wrapup_enabled else 0
 
@@ -404,6 +407,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         "graceful_wrapup_threshold": wrapup_threshold,
         "graceful_wrapup_iteration": wrapup_iteration,
         "timeout_minutes": resolved_timeout,
+        "status_log_interval": status_log_interval,
     }
 
     # Include extra_instructions if the mode defines one (appended to canonical prompt)
@@ -544,6 +548,7 @@ def main():
             f.write(f"graceful_wrapup_enabled={str(result['graceful_wrapup_enabled']).lower()}\n")
             f.write(f"graceful_wrapup_iteration={result['graceful_wrapup_iteration']}\n")
             f.write(f"timeout_minutes={result['timeout_minutes']}\n")
+            f.write(f"status_log_interval={result['status_log_interval']}\n")
 
     # Log for visibility
     override_label = "target repo" if result["has_override"] else "none"

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -32,6 +32,7 @@ ON_FAILURE = os.environ.get("ON_FAILURE", "comment")  # "comment" | "draft"
 MAX_ITERATIONS = int(os.environ.get("MAX_ITERATIONS", "50") or "50")
 WRAPUP_ENABLED = os.environ.get("WRAPUP_ENABLED", "true").lower() == "true"
 WRAPUP_ITERATION = int(os.environ.get("WRAPUP_ITERATION", "0") or "0")
+STATUS_LOG_INTERVAL = int(os.environ.get("STATUS_LOG_INTERVAL", "0") or "0")
 COMMIT_TRAILER = os.environ.get("COMMIT_TRAILER", "")
 ALIAS = os.environ.get("ALIAS", "")
 LLM_MODEL = os.environ.get("LLM_MODEL", "")
@@ -646,8 +647,16 @@ TOOLS = [
                             "to enable GitHub auto-close on merge."
                         ),
                     },
+                    "conversation_summary": {
+                        "type": "string",
+                        "description": (
+                            "3-5 sentence summary of the approach taken, key decisions made, "
+                            "any interesting paths explored or dead ends hit. "
+                            "This appears in the PR description."
+                        ),
+                    },
                 },
-                "required": ["success", "explanation"],
+                "required": ["success", "explanation", "conversation_summary"],
             },
         },
     },
@@ -782,6 +791,7 @@ def main():
     finish_args = None
     last_iteration = 0
     no_tool_call_count = 0
+    status_log = []  # list of (iteration, status_text) tuples
 
     rate_limit_retries = 0
     MAX_RATE_LIMIT_RETRIES = 3
@@ -915,9 +925,54 @@ def main():
             if done:
                 break
 
+            # Rolling status log: every STATUS_LOG_INTERVAL iterations, make a side-channel
+            # API call to ask the agent for a brief status update.
+            if STATUS_LOG_INTERVAL > 0 and (iteration + 1) % STATUS_LOG_INTERVAL == 0:
+                try:
+                    status_messages = messages + [
+                        {
+                            "role": "user",
+                            "content": (
+                                "STATUS CHECK: In 1-2 sentences, what are you currently doing "
+                                "and what is your immediate next step? "
+                                "(This is logged for the run summary — answer briefly then continue your work.)"
+                            ),
+                        }
+                    ]
+                    status_response = completion(
+                        model=LLM_MODEL,
+                        messages=status_messages,
+                        max_tokens=256,
+                    )
+                    status_text = ""
+                    if status_response.choices:
+                        sc = status_response.choices[0].message
+                        if hasattr(sc, "content") and sc.content:
+                            status_text = sc.content.strip()
+                    if status_text:
+                        status_log.append((iteration + 1, status_text))
+                        print(f"  [Status log iter {iteration + 1}]: {status_text[:100]}")
+                except Exception as e:
+                    print(f"  [Status log] failed at iteration {iteration + 1}: {e}")
+
     # Write usage data (always, even on exception)
     finally:
         write_usage(total_input_tokens, total_output_tokens, total_cost, last_iteration + 1)
+
+    # Post rolling status log as issue comment (if any entries were collected)
+    if status_log and ISSUE_NUMBER and GITHUB_REPO:
+        try:
+            log_text = "\n".join(f"**Iter {i}:** {text}" for i, text in status_log)
+            comment_body = f"## Agent Status Log\n\n{log_text}"
+            comment_file = "/tmp/rdb_status_log_comment.txt"
+            with open(comment_file, "w") as f:
+                f.write(comment_body)
+            run(
+                f"gh issue comment {ISSUE_NUMBER} --repo {GITHUB_REPO} --body-file {comment_file}",
+                check=False,
+            )
+        except Exception as e:
+            print(f"Could not post status log comment: {e}")
 
     # Handle finish
     if finish_args is None:
@@ -949,6 +1004,10 @@ def main():
     explanation = finish_args.get("explanation", "")
     pr_title = finish_args.get("pr_title") or f"Fix for issue #{ISSUE_NUMBER}"
     pr_body = finish_args.get("pr_body") or ""
+
+    conv_summary = finish_args.get("conversation_summary", "")
+    if conv_summary:
+        pr_body = f"## Summary\n\n{conv_summary}\n\n---\n\n{pr_body}"
 
     write_status(success, explanation)
 


### PR DESCRIPTION
Three observability improvements:

**finish() conversation_summary**: Agent required to write 3-5 sentence summary of approach/decisions when calling finish(). Appears as a '## Summary' section in the PR description.

**status_log_interval** (default 0 = off): Every N iterations, makes a side-channel API call asking the agent for a 1-2 sentence status update. Collected updates posted as issue comment at end of run. Documented in debug.md.

**$GITHUB_STEP_SUMMARY**: Adds a formatted summary table to the GitHub Actions run page (cost, iterations, model, result, explanation). Visible at the top of the Actions run without digging through logs.