### PR TITLE
Fix install prompt framing: 'read and follow' to avoid Claude security refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ like delegating work to an experienced coworker. This system aims to provide
 that alternative.
 
 > **To install, say to your AI agent:**
-> "Follow the instructions at https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/install.md to install gnovak/remote-dev-bot for use in {your-username}/{your-repo}"
+> ```
+> claude "Read https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/install.md and follow it to set up remote-dev-bot for my repo {owner}/{repo}. This is my first time — walk me through each step, explain what's happening, and ask before doing anything."
+> ```
 
 There are already excellent vendor-specific implementations of this pattern
 (GitHub Copilot Workspace, Cursor, etc.), so this project isn't necessarily

--- a/install.md
+++ b/install.md
@@ -1,5 +1,7 @@
 # Remote Dev Bot — Setup Guide
 
+> **For AI agents reading this file:** This is a guided installation runbook, not a script to execute blindly. Read it fully, then walk the user through each phase — explaining what each step does and asking for confirmation before making changes. Experienced users may ask you to go faster; see "Using This Guide with an AI Coding Agent" below for guidance on both modes.
+
 ## Quick Start
 
 This guide will walk you through setting up Remote Dev Bot on your GitHub
@@ -7,8 +9,7 @@ repository. By the end, you'll have an AI-powered bot that can automatically
 resolve issues and create pull requests when triggered by a `/agent-resolve`
 comment.
 
-The easiest way to install is to tell your favorite AI agent "Follow the
-runbook.md file to set up remote-dev-bot for my repo {owner}/{repo}."
+The easiest way to install is to tell your favorite AI agent "Read https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/install.md and follow it to set up remote-dev-bot for my repo {owner}/{repo}."
 
 > **First time?** If you'd like to see remote-dev-bot in action before
 > installing, check out [demo.md](demo.md) for annotated examples showing the
@@ -105,13 +106,13 @@ setup process.
 **First time? Use the guided setup** (recommended):
 
 ```bash
-claude "Follow the install.md file to set up remote-dev-bot for my repo {owner}/{repo}. This is my first time — walk me through each step, explain what's happening, and ask before doing anything."
+claude "Read https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/install.md and follow it to set up remote-dev-bot for my repo {owner}/{repo}. This is my first time — walk me through each step, explain what's happening, and ask before doing anything."
 ```
 
 **Done this before? Use the fast setup:**
 
 ```bash
-claude "Follow the install.md file to set up remote-dev-bot for my repo {owner}/{repo}. I'm familiar with the process — go fast, just ask me for secrets and confirmations."
+claude "Read https://raw.githubusercontent.com/gnovak/remote-dev-bot/main/install.md and follow it to set up remote-dev-bot for my repo {owner}/{repo}. I'm familiar with the process — go fast, just ask me for secrets and confirmations."
 ```
 
 These examples use Claude Code, but the same prompts work with any AI coding


### PR DESCRIPTION
## Summary

Fixes #328. Claude (and similar agents) can refuse to execute a prompt that says "Follow the instructions at <URL>" because it pattern-matches as an instruction to blindly run arbitrary remote content. Rephrasing to "Read <URL> and follow it" sidesteps that security trigger while making the intent clearer.

- **README.md**: Replace the install prompt blockquote with the new phrasing that includes the full recommended guided-mode prompt.
- **install.md**: Add an agent preamble blockquote at the very top of the file (right after the heading) so agents that fetch the raw URL cold understand this is a guided runbook, not a script to execute blindly. Update all three in-file `claude "..."` prompt examples to use "Read ... and follow it".

## Test plan

- [ ] Copy the new README.md prompt and paste it to Claude Code — verify it does not refuse and proceeds to guide the install.
- [ ] Fetch the raw install.md URL in an agent context — verify the preamble is visible and the agent treats it as a guided runbook.
- [ ] Confirm the two prompt examples in the "Using This Guide with an AI Coding Agent" section work in both guided and fast modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)