### PR TITLE
feat: unified context management for design and review modes

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -67,6 +67,8 @@ jobs:
       graceful_wrapup_enabled: ${{ steps.parse.outputs.graceful_wrapup_enabled }}
       graceful_wrapup_iteration: ${{ steps.parse.outputs.graceful_wrapup_iteration }}
       timeout_minutes: ${{ steps.parse.outputs.timeout_minutes }}
+      design_context_keep_tool_results: ${{ steps.parse.outputs.design_context_keep_tool_results }}
+      review_context_keep_tool_results: ${{ steps.parse.outputs.review_context_keep_tool_results }}
 
     steps:
       - name: Generate app token
@@ -640,13 +642,19 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
           REVIEW_MAX_ITERATIONS: ${{ needs.parse.outputs.review_max_iterations }}
+          REVIEW_CONTEXT_KEEP_TOOL_RESULTS: ${{ needs.parse.outputs.review_context_keep_tool_results }}
+          REVIEW_WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
+          REVIEW_WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
         run: |
           python3 << 'PYEOF'
           import json
           import os
           import subprocess
+          import sys
           import yaml
 
+          sys.path.insert(0, ".remote-dev-bot/lib")
+          from context import trim_tool_results
           from litellm import completion
 
           model = "${{ needs.parse.outputs.model }}"
@@ -660,6 +668,14 @@ jobs:
 
           # Get max iterations from config (default 10)
           max_iterations = int(os.environ.get("REVIEW_MAX_ITERATIONS", "10") or "10")
+
+          # Graceful wrapup settings
+          wrapup_enabled = os.environ.get("REVIEW_WRAPUP_ENABLED", "true").lower() == "true"
+          wrapup_iteration = int(os.environ.get("REVIEW_WRAPUP_ITERATION", "0") or "0")
+          wrapup_injected = False
+
+          # Context trimming
+          context_keep_tool_results = int(os.environ.get("REVIEW_CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
 
           # Generate repository file listing (tracked files only — PR head branch)
           result = subprocess.run(
@@ -960,8 +976,29 @@ jobs:
                       "content": result,
                   })
 
+              # Trim old tool result pairs to manage context size
+              if context_keep_tool_results > 0:
+                  messages = trim_tool_results(messages, context_keep_tool_results)
+
               if done:
                   break
+
+              # Graceful wrapup: at 80% of max_iterations, inject a user message
+              # telling the agent to wrap up and call submit_review with what it has.
+              if (wrapup_enabled and wrapup_iteration > 0
+                      and not wrapup_injected and iteration + 1 >= wrapup_iteration):
+                  remaining = max_iterations - (iteration + 1)
+                  messages.append({
+                      "role": "user",
+                      "content": (
+                          f"You have used {iteration + 1} of {max_iterations} iterations "
+                          f"({remaining} remaining). "
+                          "Please wrap up your review now and call submit_review with "
+                          "whatever analysis you have gathered so far. "
+                          "Do not start new lines of inquiry."
+                      ),
+                  })
+                  wrapup_injected = True
 
           # Save usage data for the cost comment step
           with open("/tmp/llm_usage.json", "w") as f:
@@ -1200,14 +1237,20 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
           DESIGN_MAX_ITERATIONS: ${{ needs.parse.outputs.design_max_iterations }}
+          DESIGN_CONTEXT_KEEP_TOOL_RESULTS: ${{ needs.parse.outputs.design_context_keep_tool_results }}
+          DESIGN_WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
+          DESIGN_WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
         run: |
           python3 << 'PYEOF'
           import json
           import os
           import re
           import subprocess
+          import sys
           import yaml
 
+          sys.path.insert(0, ".remote-dev-bot/lib")
+          from context import trim_tool_results
           from litellm import completion
 
           model = "${{ needs.parse.outputs.model }}"
@@ -1225,6 +1268,14 @@ jobs:
 
           # Get max iterations from config (default 10)
           max_iterations = int(os.environ.get("DESIGN_MAX_ITERATIONS", "10") or "10")
+
+          # Graceful wrapup settings
+          wrapup_enabled = os.environ.get("DESIGN_WRAPUP_ENABLED", "true").lower() == "true"
+          wrapup_iteration = int(os.environ.get("DESIGN_WRAPUP_ITERATION", "0") or "0")
+          wrapup_injected = False
+
+          # Context trimming
+          context_keep_tool_results = int(os.environ.get("DESIGN_CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
 
           # Generate repository file listing (tracked files only)
           result = subprocess.run(
@@ -1488,8 +1539,29 @@ jobs:
                       "content": result,
                   })
 
+              # Trim old tool result pairs to manage context size
+              if context_keep_tool_results > 0:
+                  messages = trim_tool_results(messages, context_keep_tool_results)
+
               if done:
                   break
+
+              # Graceful wrapup: at 80% of max_iterations, inject a user message
+              # telling the agent to wrap up and call submit_analysis with what it has.
+              if (wrapup_enabled and wrapup_iteration > 0
+                      and not wrapup_injected and iteration + 1 >= wrapup_iteration):
+                  remaining = max_iterations - (iteration + 1)
+                  messages.append({
+                      "role": "user",
+                      "content": (
+                          f"You have used {iteration + 1} of {max_iterations} iterations "
+                          f"({remaining} remaining). "
+                          "Please wrap up your analysis now and call submit_analysis with "
+                          "whatever analysis you have gathered so far. "
+                          "Do not start new lines of inquiry."
+                      ),
+                  })
+                  wrapup_injected = True
 
           # Save usage data for the cost comment step
           with open("/tmp/llm_usage.json", "w") as f:

--- a/lib/config.py
+++ b/lib/config.py
@@ -61,7 +61,9 @@ ALLOWED_ARGS = {
     "target_branch": str,
     "status_log_interval": int,       # rolling status log interval (0 = disabled)
     "bash_output_limit": int,          # agent bash output truncation
-    "context_keep_tool_results": int,  # how many tool result pairs to keep
+    "context_keep_tool_results": int,  # how many tool result pairs to keep (resolve)
+    "design_context_keep_tool_results": int,  # how many tool result pairs to keep (design)
+    "review_context_keep_tool_results": int,  # how many tool result pairs to keep (review)
 }
 
 
@@ -337,6 +339,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     # Read agent settings (formerly openhands:)
     # BACKCOMPAT(v0→v1, 2026-03-05): accept openhands: as alias for agent:
     oh = config.get("agent", config.get("openhands", {}))
+    # max_iter: mode_config wins over global agent config (per-mode default),
+    # and inline arg wins over both (applied below after action is resolved).
     max_iter = oh.get("max_iterations", 50)
     pr_type = oh.get("pr_type", "ready")
     on_failure = oh.get("on_failure", "comment")
@@ -373,6 +377,12 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     # Mode settings
     action = mode_config.get("action", "pr")
 
+    # For agentic loop modes (design, review), the mode config can specify its own
+    # max_iterations as a per-mode default, overriding the global agent.max_iterations.
+    # Inline args win over both (applied below).
+    if action in ("design", "review") and "max_iterations" in mode_config:
+        max_iter = mode_config["max_iterations"]
+
     # Apply command-line arg overrides
     target_branch_explicit = False  # True only when set via inline arg
     if "max_iterations" in args:
@@ -390,6 +400,8 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     status_log_interval = args.get("status_log_interval", 0)
     bash_output_limit = args.get("bash_output_limit", None)
     context_keep_tool_results = args.get("context_keep_tool_results", None)
+    design_context_keep_tool_results = args.get("design_context_keep_tool_results", None)
+    review_context_keep_tool_results = args.get("review_context_keep_tool_results", None)
 
     # Calculate the iteration warning threshold (iteration number at which to warn)
     wrapup_iteration = int(max_iter * wrapup_threshold) if wrapup_enabled else 0
@@ -418,6 +430,10 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         result["bash_output_limit"] = bash_output_limit
     if context_keep_tool_results is not None:
         result["context_keep_tool_results"] = context_keep_tool_results
+    if design_context_keep_tool_results is not None:
+        result["design_context_keep_tool_results"] = design_context_keep_tool_results
+    if review_context_keep_tool_results is not None:
+        result["review_context_keep_tool_results"] = review_context_keep_tool_results
 
     # Include extra_instructions if the mode defines one (appended to canonical prompt)
     if "extra_instructions" in mode_config:
@@ -446,11 +462,14 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
             print(f"  {key}: {value}")
         print()
 
-    # Include max_iterations for agentic loop modes (design and review)
-    if action == "design" and "max_iterations" in mode_config:
-        result["design_max_iterations"] = mode_config["max_iterations"]
-    if action == "review" and "max_iterations" in mode_config:
-        result["review_max_iterations"] = mode_config["max_iterations"]
+    # Include max_iterations for agentic loop modes (design and review).
+    # Use max_iter (already resolved, including any inline arg override) rather than
+    # mode_config["max_iterations"] so that e.g. `max_iterations = 20` in the comment
+    # body is honoured for design and review modes, not just for resolve.
+    if action == "design":
+        result["design_max_iterations"] = max_iter
+    if action == "review":
+        result["review_max_iterations"] = max_iter
 
     return result
 
@@ -562,6 +581,10 @@ def main():
                 f.write(f"bash_output_limit={result['bash_output_limit']}\n")
             if "context_keep_tool_results" in result:
                 f.write(f"context_keep_tool_results={result['context_keep_tool_results']}\n")
+            if "design_context_keep_tool_results" in result:
+                f.write(f"design_context_keep_tool_results={result['design_context_keep_tool_results']}\n")
+            if "review_context_keep_tool_results" in result:
+                f.write(f"review_context_keep_tool_results={result['review_context_keep_tool_results']}\n")
 
     # Log for visibility
     override_label = "target repo" if result["has_override"] else "none"

--- a/lib/context.py
+++ b/lib/context.py
@@ -1,0 +1,82 @@
+"""Shared context management utilities for remote-dev-bot agent loops.
+
+Provides functions for managing conversation context size across
+resolve, design, and review modes.
+"""
+
+
+def trim_tool_results(messages, keep_n):
+    """Remove oldest tool call/result pairs, keeping the last keep_n pairs.
+
+    Preserves all assistant text content and the system prompt.
+    Operates on OpenAI-format messages where tool calls are in assistant messages
+    (role="assistant", tool_calls=[...]) and results are role="tool" messages.
+    """
+    if keep_n <= 0:
+        return messages
+
+    # Collect indices of all "tool" role messages (each is one tool result)
+    tool_result_indices = [i for i, m in enumerate(messages) if m.get("role") == "tool"]
+
+    if len(tool_result_indices) <= keep_n:
+        return messages
+
+    # Number of pairs to drop
+    n_drop = len(tool_result_indices) - keep_n
+    indices_to_drop = set(tool_result_indices[:n_drop])
+
+    # Also find the assistant messages that contain tool_calls for the pairs we're dropping.
+    # Each assistant message with tool_calls is immediately followed by one or more tool messages.
+    # We scan backwards from each tool_result index to find its owning assistant message.
+    dropped_tool_call_ids = set()
+    for idx in indices_to_drop:
+        dropped_tool_call_ids.add(messages[idx].get("tool_call_id"))
+
+    new_messages = []
+    for i, msg in enumerate(messages):
+        role = msg.get("role")
+        if i in indices_to_drop:
+            # Drop this tool result message entirely
+            continue
+        if role == "assistant" and msg.get("tool_calls"):
+            # Filter out tool_calls whose IDs are being dropped
+            remaining_calls = [
+                tc for tc in msg["tool_calls"]
+                if tc.get("id") not in dropped_tool_call_ids
+            ]
+            dropped_calls = [
+                tc for tc in msg["tool_calls"]
+                if tc.get("id") in dropped_tool_call_ids
+            ]
+            if dropped_calls:
+                # Build a new assistant message: preserve content, replace dropped calls
+                # with a placeholder text note. Keep remaining tool calls if any.
+                n_omitted = len(dropped_calls)
+                placeholder_text = f"[{n_omitted} tool call(s) omitted for context]"
+                new_msg = dict(msg)
+                if remaining_calls:
+                    new_msg["tool_calls"] = remaining_calls
+                    # Prepend placeholder to content (content may be str or list or None)
+                    if new_msg.get("content") is None:
+                        new_msg["content"] = placeholder_text
+                    elif isinstance(new_msg["content"], str):
+                        new_msg["content"] = placeholder_text + "\n" + new_msg["content"]
+                    else:
+                        # list of content blocks — prepend text block
+                        new_msg["content"] = [{"type": "text", "text": placeholder_text}] + list(new_msg["content"])
+                else:
+                    # No remaining calls — strip tool_calls entirely, keep only content
+                    new_msg = {"role": "assistant"}
+                    if msg.get("content") is None or msg.get("content") == []:
+                        new_msg["content"] = placeholder_text
+                    elif isinstance(msg["content"], str):
+                        new_msg["content"] = (msg["content"] + "\n" + placeholder_text).strip()
+                    else:
+                        new_msg["content"] = list(msg["content"]) + [{"type": "text", "text": placeholder_text}]
+                new_messages.append(new_msg)
+            else:
+                new_messages.append(msg)
+        else:
+            new_messages.append(msg)
+
+    return new_messages


### PR DESCRIPTION
## Summary

Implements [#332](https://github.com/gnovak/remote-dev-bot/issues/332) — unified context management across resolve, design, and review modes.

- **Fix max_iterations inline arg for design/review**: `design_max_iterations` and `review_max_iterations` were set from `mode_config["max_iterations"]` directly, silently ignoring any `max_iterations = N` inline arg. Fix: mode_config now acts as a per-mode default; inline args override it. All 128 config tests pass.
- **Graceful wrapup for design mode**: At `wrapup_iteration` threshold (80% of `DESIGN_MAX_ITERATIONS` by default), a user message is injected into the conversation asking the agent to call `submit_analysis` with whatever it has gathered.
- **Graceful wrapup for review mode**: Same pattern — at threshold, a user message is injected asking the agent to call `submit_review`.
- **Shared `trim_tool_results` utility**: Extracted from `lib/resolve.py` into new `lib/context.py`. Both the design and review inline loops now import it via `sys.path.insert(0, ".remote-dev-bot/lib")` and apply trimming after each tool batch when `DESIGN_CONTEXT_KEEP_TOOL_RESULTS` / `REVIEW_CONTEXT_KEEP_TOOL_RESULTS` is set.
- **New config args**: `design_context_keep_tool_results` and `review_context_keep_tool_results` added to `ALLOWED_ARGS` in `config.py`, written to `GITHUB_OUTPUT`, and plumbed through as env vars in the design and review job env blocks.

Closes #332.

## Test plan

- [x] `pytest tests/test_config.py -x -q` — 128 passed, 0 failed
- [x] `pytest tests/ -x -q` — 230 passed, 0 failed
- [ ] Trigger `/agent-design` on an issue and verify wrapup message appears in the log at 80% of iterations
- [ ] Trigger `/agent-review` on a PR and verify wrapup message appears in the log at 80% of iterations
- [ ] Pass `max_iterations = 5` as inline arg on a design invocation and verify `DESIGN_MAX_ITERATIONS=5` in the run log
- [ ] Pass `design_context_keep_tool_results = 3` and verify context trimming kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)