### PR TITLE
Fix status log error; promote context_keep_tool_results to yaml config (default 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ agent:
   # bloat. The agent is told how many chars were dropped. Set to 0 to disable.
   # (default: 8000)
   bash_output_limit: 8000
+
+  # Number of recent tool call/result pairs kept in context. Older pairs are
+  # replaced with a placeholder to prevent O(N²) token growth on long runs.
+  # Set to 0 to keep all results. (default: 10)
+  context_keep_tool_results: 10
 ```
 
 You can also override `max_iterations`, `branch`, and `context` on a

--- a/debug.md
+++ b/debug.md
@@ -32,10 +32,11 @@ truncation.
 
 Number of recent tool call/result pairs to keep in the conversation context.
 Older pairs are replaced with a placeholder. This prevents O(N²) context growth
-over long runs. Set to `0` to keep all tool results (default behavior).
+over long runs. Set to `0` to keep all tool results.
 
-- **Default:** `0` (keep all)
-- **Suggested starting point:** `20` (keeps the last 20 tool interactions)
+Configurable in `remote-dev-bot.yaml` under `agent:`, or as an inline arg.
+
+- **Default:** `10`
 - **Lower values:** Smaller context, lower cost, but agent may "forget" earlier work
 - **Higher values / 0:** Full history; safe but expensive on long runs
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -399,9 +399,9 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
 
     status_log_interval = args.get("status_log_interval", oh.get("status_log_interval", 5))
     bash_output_limit = args.get("bash_output_limit", oh.get("bash_output_limit", None))
-    context_keep_tool_results = args.get("context_keep_tool_results", None)
-    design_context_keep_tool_results = args.get("design_context_keep_tool_results", None)
-    review_context_keep_tool_results = args.get("review_context_keep_tool_results", None)
+    context_keep_tool_results = args.get("context_keep_tool_results", oh.get("context_keep_tool_results", None))
+    design_context_keep_tool_results = args.get("design_context_keep_tool_results", oh.get("design_context_keep_tool_results", None))
+    review_context_keep_tool_results = args.get("review_context_keep_tool_results", oh.get("review_context_keep_tool_results", None))
 
     # Calculate the iteration warning threshold (iteration number at which to warn)
     wrapup_iteration = int(max_iter * wrapup_threshold) if wrapup_enabled else 0

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -38,7 +38,7 @@ ALIAS = os.environ.get("ALIAS", "")
 LLM_MODEL = os.environ.get("LLM_MODEL", "")
 EXTRA_FILES = json.loads(os.environ.get("EXTRA_FILES", "[]") or "[]")
 BASH_OUTPUT_LIMIT = int(os.environ.get("BASH_OUTPUT_LIMIT", "8000") or "8000")
-CONTEXT_KEEP_TOOL_RESULTS = int(os.environ.get("CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
+CONTEXT_KEEP_TOOL_RESULTS = int(os.environ.get("CONTEXT_KEEP_TOOL_RESULTS", "10") or "10")
 
 GH_TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
 GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "")
@@ -1021,7 +1021,15 @@ def main():
             # API call to ask the agent for a brief status update.
             if STATUS_LOG_INTERVAL > 0 and (iteration + 1) % STATUS_LOG_INTERVAL == 0:
                 try:
-                    status_messages = messages + [
+                    # Strip tool-call messages — the status check call omits
+                    # tools=TOOLS, so Anthropic rejects history containing
+                    # tool_calls/tool roles. Keep only text turns.
+                    text_messages = [
+                        m for m in messages
+                        if m.get("role") in ("system", "user")
+                        or (m.get("role") == "assistant" and not m.get("tool_calls"))
+                    ]
+                    status_messages = text_messages + [
                         {
                             "role": "user",
                             "content": (

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -94,6 +94,10 @@ agent:
   # Rolling status log: post a 1-2 sentence status update every N iterations
   # as an issue comment. Set to 0 to disable.
   status_log_interval: 5
+  # Number of recent tool call/result pairs to keep in context. Older pairs
+  # are replaced with a placeholder to prevent O(N²) token growth on long runs.
+  # Set to 0 to keep all tool results (not recommended for runs > ~20 iterations).
+  context_keep_tool_results: 10
   graceful_wrapup:
     # Enable/disable graceful wrap-up instructions
     enabled: true


### PR DESCRIPTION
Two fixes before the v0.7.0 release tag:

1. **Status log bug**: the side-channel status check call passed the full message history (including tool_call records) but omitted `tools=TOOLS`, causing Anthropic to reject it with `UnsupportedParamsError` every N iterations. Fix: strip tool-call and tool-result messages before the status check call.

2. **context_keep_tool_results**: change default from 0 (keep all) to 10, read from `agent:` yaml section, document in README and debug.md. Prevents O(N²) token growth on long runs out of the box.