### PR TITLE
fix: two remaining bugs from merge audit (explore context_files, RF_FAIL)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1817,7 +1817,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          CONTEXT_FILES: ${{ needs.parse.outputs.context_files }}
+          CONTEXT_FILES: ${{ needs.parse.outputs.extra_files }}
           EXPLORE_MAX_ITERATIONS: ${{ needs.parse.outputs.explore_max_iterations }}
         run: |
           python3 << 'PYEOF'

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -1006,7 +1006,7 @@ log "  Total cost:     \$$total_cost"
 log "========================================="
 
 # Exit with failure if any test didn't pass
-total_fail=$((fail + timeout_count + REVIEW_FAIL + TIMEOUT_PHASE_FAIL + WRAPUP_PHASE_FAIL))
+total_fail=$((fail + timeout_count + RF_FAIL + TIMEOUT_PHASE_FAIL + WRAPUP_PHASE_FAIL))
 if [[ $total_fail -gt 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
Follow-up to PRs #346 and #349. Audit of merge commit `31625fd` found these two additional bugs still present on dev.

## Bug 1 — explore job silently received no context files

`remote-dev-bot.yml` line 1820 was reading `needs.parse.outputs.context_files` (old name from main). The parse job emits `extra_files`. Since `context_files` never exists in parse outputs, explore mode always got `[]` for context files regardless of config.

Fixed to `needs.parse.outputs.extra_files`.

## Bug 2 — RF test failures excluded from exit code

`tests/e2e.sh` total_fail calculation used `REVIEW_FAIL` (never assigned — evaluates to 0) instead of `RF_FAIL`. RF failures (rf-resolve, rf-review, rf-feedback) were excluded from the exit code, allowing the suite to exit 0 with real failures.

Fixed to `RF_FAIL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)