### PR TITLE
fix: move branch:dev from global config to local config

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -69,8 +69,6 @@ agent:
   max_iterations: 50
   # PR type: "draft" or "ready"
   pr_type: ready
-  # Target branch for PRs created by the agent
-  branch: dev
   # What to do when the agent can't fully resolve the issue (success=False):
   #   comment — post a comment with the agent's evaluation, no PR (default)
   #   draft   — post the same comment AND open a draft PR with partial changes


### PR DESCRIPTION
remote-dev-bot.yaml is fetched via sparse-checkout into every target repo. Setting branch:dev there means every user's agent tries to target a dev branch that probably doesn't exist — and it caused rdb-test e2e failures for the same reason.

branch:dev belongs in remote-dev-bot.local.yaml, the self-dev override layer that is not distributed to users. That file already had this setting, so no functional change for rdb self-development.

Users get the default (main) unless they override in their own remote-dev-bot.yaml.

Generated with Claude Code