### PR TITLE
fix: reduce default max_iterations, add claude-mini, strengthen efficiency prompt

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -409,10 +409,12 @@ Never add documentation files (CHANGES.md, NOTES.md, etc.) to version control un
 EFFICIENCY = """
 ## Efficiency
 
-Each tool call costs time and budget. Where possible:
-- Combine multiple bash operations into a single command
-- Use grep with path filters rather than broad searches
-- Prefer targeted reads over reading entire large files
+Each tool call costs real money. Be targeted and deliberate:
+
+- **Don't over-explore.** If the issue + comments already identify the files and changes needed, go straight to implementing. Read only the files you are actually about to change.
+- **Read files once.** Don't re-read a file you already read unless it changed.
+- **Call finish() as soon as the task is done.** Don't do unnecessary verification passes after a successful test run.
+- **Exploration should be proportional to task complexity.** A one-line fix does not warrant reading 10 files.
 """
 
 STUCK_RECOVERY = """


### PR DESCRIPTION
Addresses expensive rdb agent runs (issues 336, 338).

**Root causes:**
- Issue 338: O(N²) context growth + status log errors — already fixed in v0.7.0
- Issue 336 and general cost: agent over-explores before making simple changes; default iteration ceiling too high

**Changes:**

`remote-dev-bot.yaml`:
- `max_iterations` 50 → 30. Lower cost ceiling for typical tasks. Users can raise with `max_iterations = 50` inline arg or in their yaml.
- Add `claude-mini` (claude-haiku-4-5) — ~20× cheaper than Sonnet for trivial one-file changes. Use as `/agent-resolve-claude-mini`.

`remote-dev-bot.local.yaml`:
- Restore `max_iterations: 50` for rdb self-dev (rdb changes often touch many files and deserve the higher ceiling).

`lib/resolve.py` EFFICIENCY section — stronger guidance:
- Don't read files you're not about to change
- If the issue already tells you exactly what to change, skip the exploration phase
- Call finish() as soon as the task is done
- Exploration proportional to task complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)