### PR TITLE
refactor: remove WORKED_EXAMPLE from resolve system prompt

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -428,37 +428,6 @@ If tests keep failing after multiple attempts:
 Do not repeat the same failing approach more than twice.
 """
 
-WORKED_EXAMPLE = """
-## Example Interaction
-
-The following shows the expected pattern — one tool call per turn, explore before implement, commit before finish.
-
-**Turn 1** — explore:
-```
-bash(command="grep -rn 'def paginate' src/ | head -20")
-```
-
-**Turn 2** — read the relevant file:
-```
-read_file(path="src/pagination.py")
-```
-
-**Turn 3** — implement the fix, commit, and push in one turn:
-```
-bash(command="sed -i 's/page_size - 1/page_size/' src/pagination.py && git add src/pagination.py && git commit -m 'Fix off-by-one error in paginate()' && git push origin HEAD")
-```
-
-**Turn 4** — verify and finish:
-```
-bash(command="git status && python -m pytest tests/test_pagination.py -q")
-```
-
-**Turn 5** — call finish:
-```
-finish(success=True, pr_title="Fix off-by-one error in pagination", pr_body="Fixes #42\n\nRoot cause: paginate() subtracted 1 from page_size incorrectly, causing the last item on each page to be dropped. Fix: removed the erroneous subtraction in src/pagination.py.")
-```
-"""
-
 GIT_INSTRUCTIONS = """
 ## Working in the Repository
 
@@ -562,7 +531,6 @@ is complete before committing — call `finish()` now.
         + GIT_INSTRUCTIONS
         + EFFICIENCY
         + STUCK_RECOVERY
-        + WORKED_EXAMPLE
         + SECURITY_RULES
     )
     if wrapup_hint:


### PR DESCRIPTION
## Why it was added

WORKED_EXAMPLE was introduced after observing models (specifically Gemini) spinning indefinitely without calling `finish()`. The 5-step walkthrough ending with an explicit `finish()` call was meant to reinforce that `finish()` is required to terminate the loop.

## Why removing it now

1. **Better mechanisms exist**: The wrapup system (`WRAPUP_ENABLED`) injects iteration-budget instructions at 80% of `max_iterations`, and the max-iterations exhaustion path now opens a draft PR regardless. These are more reliable signals than a worked example.
2. **Cost**: ~200 tokens per run saved. `WORKFLOW` and `GIT_INSTRUCTIONS` already cover the expected pattern. Mature models don't need a worked example to understand call-one-tool-per-turn or that `finish()` is required.

## If this causes a regression

If a model stops calling `finish()` or stops committing before calling it, revert this commit. Then add back a minimal `finish()`-focused reminder (1-2 lines) rather than the full 5-turn example — the example is more tokens than needed to convey the key constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)