### PR TITLE
feat: status log off by default, one-sentence prompt

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1057,9 +1057,11 @@ def main():
                         {
                             "role": "user",
                             "content": (
-                                "STATUS CHECK: In 1-2 sentences, what are you currently doing "
-                                "and what is your immediate next step? "
-                                "(This is logged for the run summary — answer briefly then continue your work.)"
+                                "STATUS CHECK: One sentence only — what specific files/components "
+                                "have you modified so far, and what are you currently doing? "
+                                "Be concrete (e.g. 'Updated lib/config.py and remote-dev-bot.yaml, "
+                                "now adding the workshop job to the workflow.'), not high-level "
+                                "(e.g. 'Implementing the feature for issue N.'). No preamble."
                             ),
                         }
                     ]

--- a/remote-dev-bot.local.yaml
+++ b/remote-dev-bot.local.yaml
@@ -15,3 +15,5 @@ agent:
   on_failure: draft
   # PRs for self-dev work go to dev (the long-lived integration branch), not main.
   branch: dev
+  # Enable status log for rdb self-dev — useful for monitoring longer runs.
+  status_log_interval: 5

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -89,9 +89,9 @@ agent:
   bash_output_limit: 8000
   # Graceful wrap-up: inject instructions when approaching max iterations
   # This helps the agent commit partial work before hitting the limit
-  # Rolling status log: post a 1-2 sentence status update every N iterations
-  # as an issue comment. Set to 0 to disable.
-  status_log_interval: 5
+  # Rolling status log: post a one-sentence status update every N iterations
+  # as an issue comment. Set to 0 to disable (default — enable per-repo).
+  status_log_interval: 0
   # Number of recent tool call/result pairs to keep in context. Older pairs
   # are replaced with a placeholder to prevent O(N²) token growth on long runs.
   # Set to 0 to keep all tool results (not recommended for runs > ~20 iterations).


### PR DESCRIPTION
Status log is experimental — make it opt-in rather than default-on. Tighten the prompt to elicit a specific, concrete sentence rather than a high-level restatement of the task.

- `status_log_interval` defaults to 0 (disabled) in base config
- Enable in `remote-dev-bot.local.yaml` (rdb self-dev) and bridge-analysis
- Prompt: one sentence, concrete and specific, with positive/negative examples to calibrate