### PR TITLE
Fix YAML indentation in python3 -c blocks (workflow parse failure)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -464,14 +464,14 @@ jobs:
           LINES_PER_DOLLAR=""
           if [[ -n "$SHORTSTAT" && "${COST:-0}" != "0" ]]; then
             LINES_PER_DOLLAR=$(python3 -c "
-import re, math
-s = '''${SHORTSTAT}'''
-ins = int(m.group(1)) if (m := re.search(r'(\d+) insertion', s)) else 0
-dels = int(m.group(1)) if (m := re.search(r'(\d+) deletion', s)) else 0
-lines = ins + dels
-c = float('${COST}')
-print(f'{lines / c:.0f}' if c > 0 and lines > 0 else 'N/A')
-" 2>/dev/null || true)
+          import re, math
+          s = '''${SHORTSTAT}'''
+          ins = int(m.group(1)) if (m := re.search(r'(\d+) insertion', s)) else 0
+          dels = int(m.group(1)) if (m := re.search(r'(\d+) deletion', s)) else 0
+          lines = ins + dels
+          c = float('${COST}')
+          print(f'{lines / c:.0f}' if c > 0 and lines > 0 else 'N/A')
+          " 2>/dev/null || true)
           fi
 
           # Format cost comment
@@ -1141,16 +1141,16 @@ print(f'{lines / c:.0f}' if c > 0 and lines > 0 else 'N/A')
           BITS_PER_DOLLAR=""
           if [[ -f /tmp/review_result.txt && "${COST:-0}" != "0" ]]; then
             BITS_PER_DOLLAR=$(python3 -c "
-import zlib, math
-data = open('/tmp/review_result.txt', 'rb').read()
-bits = len(zlib.compress(data)) * 8
-c = float('${COST}')
-if c > 0 and bits > 0:
-    bpd = bits / c
-    if bpd >= 1_000_000: print(f'{bpd/1_000_000:.1f} Mb/\$')
-    elif bpd >= 1_000: print(f'{bpd/1_000:.0f} kb/\$')
-    else: print(f'{bpd:.0f} b/\$')
-" 2>/dev/null || true)
+          import zlib, math
+          data = open('/tmp/review_result.txt', 'rb').read()
+          bits = len(zlib.compress(data)) * 8
+          c = float('${COST}')
+          if c > 0 and bits > 0:
+              bpd = bits / c
+              if bpd >= 1_000_000: print(f'{bpd/1_000_000:.1f} Mb/\$')
+              elif bpd >= 1_000: print(f'{bpd/1_000:.0f} kb/\$')
+              else: print(f'{bpd:.0f} b/\$')
+          " 2>/dev/null || true)
           fi
 
           # Format cost comment
@@ -1747,16 +1747,16 @@ if c > 0 and bits > 0:
           BITS_PER_DOLLAR=""
           if [[ -f /tmp/design_analysis.txt && "${COST:-0}" != "0" ]]; then
             BITS_PER_DOLLAR=$(python3 -c "
-import zlib, math
-data = open('/tmp/design_analysis.txt', 'rb').read()
-bits = len(zlib.compress(data)) * 8
-c = float('${COST}')
-if c > 0 and bits > 0:
-    bpd = bits / c
-    if bpd >= 1_000_000: print(f'{bpd/1_000_000:.1f} Mb/\$')
-    elif bpd >= 1_000: print(f'{bpd/1_000:.0f} kb/\$')
-    else: print(f'{bpd:.0f} b/\$')
-" 2>/dev/null || true)
+          import zlib, math
+          data = open('/tmp/design_analysis.txt', 'rb').read()
+          bits = len(zlib.compress(data)) * 8
+          c = float('${COST}')
+          if c > 0 and bits > 0:
+              bpd = bits / c
+              if bpd >= 1_000_000: print(f'{bpd/1_000_000:.1f} Mb/\$')
+              elif bpd >= 1_000: print(f'{bpd/1_000:.0f} kb/\$')
+              else: print(f'{bpd:.0f} b/\$')
+          " 2>/dev/null || true)
           fi
 
           # Format cost comment


### PR DESCRIPTION
## Summary

- The workflow file failed to parse because three `python3 -c "..."` inline blocks had their Python code at **column 1** (zero indentation) inside `run: |` block scalars
- YAML requires all content inside a literal block scalar to be indented past the scalar's established indent level (10 spaces here); lines at column 1 caused the YAML scanner to try to parse Python statements (`import re, math`, `import zlib, math`, etc.) as top-level YAML mapping keys, failing with `could not find expected ':'`
- Fixed by prepending 10 spaces to all under-indented lines in the three affected blocks

## Affected blocks

| Job | Step | Lines (original) | Python code |
|-----|------|---------|-------------|
| `resolve` | Calculate and post cost | 467-474 | lines-per-dollar from git diff --shortstat |
| `review` | Post cost comment | 1144-1153 | bits-per-dollar from compressed review output |
| `design` | Post cost comment | 1750-1759 | bits-per-dollar from compressed design analysis |

## Test plan

- [ ] Confirm `python3 -c "import yaml; yaml.safe_load(...)"` returns no errors on the fixed file
- [ ] Confirm GitHub Actions can parse the workflow (no "workflow file issue" failure on next trigger)
- [ ] Verify the workshop job still triggers correctly on `/agent workshop` comments
- [ ] Verify the resolve/review/design cost comment steps still function correctly at runtime

Generated with [Claude Code](https://claude.com/claude-code)
