### PR TITLE
Fix resolve.py crash: ModuleNotFoundError lib.context

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -22,6 +22,10 @@ import time
 import litellm
 from litellm import completion
 
+# Ensure the rdb root is on sys.path so `lib.context` is importable when
+# resolve.py runs from a target repo's working directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from lib.context import compact_messages, estimate_tokens
 
 # --- Environment ---


### PR DESCRIPTION
resolve.py does from lib.context import ... which fails with ModuleNotFoundError when running from a target repo working directory. Added sys.path.insert() before the import. Fixes all resolve failures since PR 369 merged (bridge-analysis issues 96, 98, etc).