### PR TITLE
feat: workshop cost tables, council includes design model, API key skip

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -2551,6 +2551,7 @@ jobs:
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
         run: |
+          date +%s > /tmp/start_time
           python3 << 'PYEOF'
           import json
           import os
@@ -2639,7 +2640,7 @@ jobs:
               post_comment_fn=post_comment,
           )
 
-          # Save usage data for the cost comment step
+          # Save usage data for the cost fallback step
           with open("/tmp/llm_usage.json", "w") as f:
               json.dump({
                   "input_tokens": workshop_result.get("total_input_tokens", 0),
@@ -2648,6 +2649,9 @@ jobs:
                   "iterations": workshop_result.get("design_result", {}).get("iterations", 0),
               }, f)
           PYEOF
+
+          # Cost is embedded in each workshop comment by workshop.py — write sentinel
+          echo "cost embedded" > /tmp/cost_embedded
 
       - name: Post result comment
         if: always()
@@ -2676,63 +2680,58 @@ jobs:
               --body-file /tmp/failure_comment.md
           fi
 
-      - name: Post cost comment
+      - name: Post cost comment (fallback)
         if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
+          # Sentinel: if cost was embedded in workshop comments, skip
+          if [ -f /tmp/cost_embedded ]; then
+            echo "Cost already embedded in workshop comments — skipping fallback"
+            exit 0
+          fi
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODEL="${{ needs.parse.outputs.model }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
-          MODE="${{ needs.parse.outputs.mode }}"
-
-          # Read usage data — default to 0 if file missing (shows $0.00, signals no data)
-          read INPUT_TOKENS OUTPUT_TOKENS COST ITERATIONS < <(python3 -c "
-          import json, os
-          if os.path.exists('/tmp/llm_usage.json'):
-              d = json.load(open('/tmp/llm_usage.json'))
-              print(d.get('input_tokens', 0), d.get('output_tokens', 0), d.get('cost') or 0, d.get('iterations', 0))
-          else:
-              print(0, 0, 0, 0)
+          ELAPSED=$(( $(date +%s) - $(cat /tmp/start_time 2>/dev/null || date +%s) ))
+          ELAPSED_FMT=$(python3 -c "s=${ELAPSED}; print(f'{s//60}m {s%60}s' if s >= 60 else f'{s}s')")
+          if [ -f /tmp/llm_usage.json ]; then
+            read INPUT_TOKENS OUTPUT_TOKENS COST ITERATIONS < <(python3 -c "
+          import json
+          d = json.load(open('/tmp/llm_usage.json'))
+          print(d.get('input_tokens', 0), d.get('output_tokens', 0), d.get('cost') or 0, d.get('iterations', 0))
           ")
-
-          # Round UP to nearest penny — $0.00 means no cost data was available.
+          else
+            INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
+          fi
           ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
-
-          # Format token counts as human-readable (2 sig figs, k and M suffixes)
           IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
           def fmt(n):
               if n >= 1_000_000:
                   v = n / 1_000_000
-                  return f'{round(v)} M' if v >= 10 else f'{round(v, 1)} M'
+                  return f'{round(v)}M' if v >= 10 else f'{round(v, 1)}M'
               elif n >= 1_000:
                   v = n / 1_000
-                  return f'{round(v)} k' if v >= 10 else f'{round(v, 1)} k'
+                  return f'{round(v)}K' if v >= 10 else f'{round(v, 1)}K'
               return str(n)
           print(fmt(${INPUT_TOKENS}), fmt(${OUTPUT_TOKENS}), sep='\t')
           ")
-
-          # Format cost comment
           {
+            echo "⚠️ Workshop did not complete — partial cost:"
+            echo ""
             echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
             echo ""
-            echo "### 💰 Cost Summary"
+            echo "---"
             echo ""
-            echo "**Mode:** ${MODE}"
+            echo "### 💰 Cost"
             echo ""
             echo "| Metric | Value |"
             echo "|--------|-------|"
-            if [[ -n "$ITERATIONS" && "$ITERATIONS" != "0" ]]; then
-              echo "| Design iterations | ${ITERATIONS} / ${{ needs.parse.outputs.workshop_max_iterations }} |"
-            fi
-            echo "| Input tokens | ${INPUT_TOKENS_FMT} |"
-            echo "| Output tokens | ${OUTPUT_TOKENS_FMT} |"
-            printf "| **Estimated cost** | **\$%s** |\n" "$ROUNDED"
-            echo ""
-            echo "_Cost is estimated based on token usage and may vary from actual billing._"
-          } > /tmp/cost_comment.md
-
-          # Post comment
+            echo "| Time | ${ELAPSED_FMT} |"
+            echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
+            echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
+            printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
+          } > /tmp/cost_comment_fallback.md
           gh issue comment "$ISSUE_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body-file /tmp/cost_comment.md
+            --body-file /tmp/cost_comment_fallback.md

--- a/lib/config.py
+++ b/lib/config.py
@@ -549,13 +549,13 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
                         "id": models[council_alias]["id"],
                     })
         else:
-            # Default: all models except the design model (no self-review)
+            # Default: all configured models (design model included — self-review
+            # in a critic role is valuable)
             for model_alias_key, model_cfg in models.items():
-                if model_alias_key != alias:
-                    council_models.append({
-                        "alias": model_alias_key,
-                        "id": model_cfg["id"],
-                    })
+                council_models.append({
+                    "alias": model_alias_key,
+                    "id": model_cfg["id"],
+                })
         result["council_models"] = council_models
 
     return result

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -14,13 +14,80 @@ critiques, then optionally triggers Stage 3 (adjust) — implemented in a
 follow-up.
 """
 
+import gzip
 import json
+import math
 import os
 import re
 import sys
+import time
 
 # Ensure sibling modules are importable when run from the workflow
 sys.path.insert(0, os.path.dirname(__file__))
+
+
+# ---------------------------------------------------------------------------
+# Cost formatting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_tok(n):
+    n = int(n)
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{round(v)}M" if v >= 10 else f"{round(v, 1)}M"
+    elif n >= 1_000:
+        v = n / 1_000
+        return f"{round(v)}K" if v >= 10 else f"{round(v, 1)}K"
+    return str(n)
+
+
+def _fmt_ela(s):
+    s = int(s)
+    return f"{s // 60}m {s % 60}s" if s >= 60 else f"{s}s"
+
+
+def _fmt_bpd(text, cost):
+    if cost <= 0:
+        return 'N/A'
+    data = text.encode('utf-8') if isinstance(text, str) else text
+    bpd = len(gzip.compress(data)) / cost  # compressed bytes / dollar
+    if bpd >= 1_000_000:
+        return f"{bpd / 1_000_000:.1f} Mbit/$"
+    return f"{bpd / 1_000:.1f} Kbit/$"
+
+
+def _build_cost_table(input_tokens, output_tokens, cost, elapsed, output_text):
+    rounded = math.ceil(cost * 100) / 100
+    rows = [
+        ('Time', _fmt_ela(elapsed)),
+        ('Input', _fmt_tok(input_tokens) + ' tokens'),
+        ('Output', _fmt_tok(output_tokens) + ' tokens'),
+        ('Bits/$', _fmt_bpd(output_text, cost)),
+        ('**Cost**', f'**${rounded:.2f}**'),
+    ]
+    lines = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
+    lines += [f'| {k} | {v} |' for k, v in rows]
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# API key resolution
+# ---------------------------------------------------------------------------
+
+# Map from model ID prefix to environment variable name
+_PROVIDER_KEY_MAP = {
+    'anthropic/': 'ANTHROPIC_API_KEY',
+    'openai/': 'OPENAI_API_KEY',
+    'gemini/': 'GEMINI_API_KEY',
+}
+
+
+def _get_required_api_key_name(model_id):
+    """Return the env var name required for model_id, or None if unknown."""
+    for prefix, key_name in _PROVIDER_KEY_MAP.items():
+        if model_id.startswith(prefix):
+            return key_name
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -170,10 +237,11 @@ def resolve_council_models(models, design_alias, council_config=None):
     models : dict
         All configured models (alias -> {"id": ...}).
     design_alias : str
-        The alias of the design model (excluded by default).
+        The alias of the design model.  Included in the default council so
+        it can critique its own work in a critic role.
     council_config : list or None
         Explicit council list from mode config. If empty/None, defaults to
-        all models except the design model.
+        all configured models (including the design model).
 
     Returns
     -------
@@ -190,13 +258,13 @@ def resolve_council_models(models, design_alias, council_config=None):
                     "id": models[alias]["id"],
                 })
     else:
-        # Default: all models except the design model (no self-review)
+        # Default: all configured models (design model included — self-review
+        # in a critic role is valuable)
         for alias, cfg in models.items():
-            if alias != design_alias:
-                council_models.append({
-                    "alias": alias,
-                    "id": cfg["id"],
-                })
+            council_models.append({
+                "alias": alias,
+                "id": cfg["id"],
+            })
 
     return council_models
 
@@ -270,6 +338,7 @@ def run_workshop(
         f"Running design exploration with `{model_alias}` (`{model}`)...\n"
     )
 
+    design_start = time.time()
     design_result = run_design_loop(
         model=model,
         issue_title=issue_title,
@@ -282,6 +351,7 @@ def run_workshop(
         wrapup_iteration=wrapup_iteration,
         context_keep_tool_results=context_keep_tool_results,
     )
+    design_elapsed = time.time() - design_start
 
     design_analysis = design_result.get("analysis", "")
 
@@ -313,12 +383,20 @@ def run_workshop(
             "total_cost": design_result.get("cost", 0.0),
         }
 
-    # Post design analysis
+    # Post design analysis with embedded cost table
+    design_cost_table = _build_cost_table(
+        input_tokens=design_result.get("input_tokens", 0),
+        output_tokens=design_result.get("output_tokens", 0),
+        cost=design_result.get("cost", 0.0),
+        elapsed=design_elapsed,
+        output_text=design_analysis,
+    )
     post(
         f"🤖 **Model:** `{model_alias}` (`{model}`)\n\n"
         f"{design_analysis}\n\n"
         f"---\n"
-        f"_Design analysis by `/agent-workshop` Stage 1 (`{model_alias}`)_"
+        f"_Design analysis by `/agent-workshop` Stage 1 (`{model_alias}`)_\n\n"
+        f"{design_cost_table}"
     )
 
     # --- Stage 2: Council Review ---
@@ -351,14 +429,30 @@ def run_workshop(
     council_results = []
 
     def _run_single_review(council_model):
-        return run_council_review(
-            model_id=council_model["id"],
+        # Check if the required API key is available before attempting the call.
+        model_id = council_model["id"]
+        key_name = _get_required_api_key_name(model_id)
+        if key_name is not None:
+            key_value = os.environ.get(key_name, "")
+            if not key_value:
+                print(
+                    f"Skipping {council_model['alias']} — API key not configured "
+                    f"({key_name} is empty or missing)",
+                    flush=True,
+                )
+                return None  # Signal skip
+
+        review_start = time.time()
+        result = run_council_review(
+            model_id=model_id,
             model_alias=council_model["alias"],
             issue_title=issue_title,
             issue_body=issue_body,
             issue_comments=issue_comments,
             design_analysis=design_analysis,
         )
+        result["elapsed"] = time.time() - review_start
+        return result
 
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=len(council_models)
@@ -371,6 +465,9 @@ def run_workshop(
             cm = futures[future]
             try:
                 result = future.result()
+                if result is None:
+                    # Model was skipped due to missing API key
+                    continue
                 council_results.append(result)
             except Exception as e:
                 council_results.append({
@@ -380,6 +477,7 @@ def run_workshop(
                     "input_tokens": 0,
                     "output_tokens": 0,
                     "cost": 0.0,
+                    "elapsed": 0.0,
                 })
 
     # Post each council review as a separate comment
@@ -391,11 +489,19 @@ def run_workshop(
                 f"contained `/agent` command(s). Blocked for safety."
             )
         else:
+            cost_table = _build_cost_table(
+                input_tokens=cr.get("input_tokens", 0),
+                output_tokens=cr.get("output_tokens", 0),
+                cost=cr.get("cost", 0.0),
+                elapsed=cr.get("elapsed", 0.0),
+                output_text=cr.get("review", ""),
+            )
             post(
                 f"🤖 **Council reviewer:** `{cr['model_alias']}` (`{cr['model_id']}`)\n\n"
                 f"{cr['review']}\n\n"
                 f"---\n"
-                f"_Council review by `/agent-workshop` Stage 2 (`{cr['model_alias']}`)_"
+                f"_Council review by `/agent-workshop` Stage 2 (`{cr['model_alias']}`)_\n\n"
+                f"{cost_table}"
             )
 
     # Post summary comment

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -49,11 +49,13 @@ modes:
       - .gemini/GEMINI.md
       - how-it-works.md
     # Council: models that review the design. Defaults to all configured models
-    # (excluding the design model) if not specified.
-    # council:
-    #   - claude-small
-    #   - gpt-small
-    #   - gemini-small
+    # (including the design model) if not specified. Override per-repo to
+    # select a different set. The value of the council is diverse perspectives
+    # across model families; depth within one family adds less value.
+    council:
+      - claude-small
+      - gpt-small
+      - gemini-small
 
 models:
   claude-small:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1395,26 +1395,27 @@ class TestWorkshopConfig:
         )
         assert result["workshop_max_iterations"] == 25
 
-    def test_workshop_default_council_excludes_design_model(self, workshop_config_dir):
-        """Default council (no explicit list) excludes the design model."""
+    def test_workshop_default_council_includes_design_model(self, workshop_config_dir):
+        """Default council (no explicit list) includes all models, including the design model."""
         tmp_path, base_path = workshop_config_dir
         result = resolve_config(base_path, "nonexistent.yaml", "workshop")
         council = result["council_models"]
         aliases = [m["alias"] for m in council]
         # design model is claude-large (default_model for workshop mode)
-        assert "claude-large" not in aliases
+        # it should now be included — self-review in critic role is valuable
+        assert "claude-large" in aliases
         assert "claude-small" in aliases
         assert "gpt-small" in aliases
         assert "gemini-small" in aliases
 
     def test_workshop_default_council_with_explicit_model(self, workshop_config_dir):
-        """Default council excludes the explicit model when user specifies one."""
+        """Default council includes all models even when user specifies a design model explicitly."""
         tmp_path, base_path = workshop_config_dir
         result = resolve_config(base_path, "nonexistent.yaml", "workshop-claude-small")
         council = result["council_models"]
         aliases = [m["alias"] for m in council]
-        # design model is now claude-small (explicitly specified)
-        assert "claude-small" not in aliases
+        # design model is now claude-small (explicitly specified) — still included
+        assert "claude-small" in aliases
         assert "claude-large" in aliases
 
     def test_workshop_explicit_council(self, workshop_config_dir):

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -52,23 +52,25 @@ class TestResolveCouncilModels:
         assert "claude-large" in aliases
         assert "gpt-small" in aliases
 
-    def test_default_council_excludes_design_model(self):
-        """Default council (no config) includes all models except the design model."""
+    def test_default_council_includes_design_model(self):
+        """Default council (no config) includes all models, including the design model."""
         result = resolve_council_models(
             self.SAMPLE_MODELS,
             design_alias="claude-large",
         )
         aliases = [m["alias"] for m in result]
-        assert "claude-large" not in aliases
+        # Design model is included so it can critique its own work
+        assert "claude-large" in aliases
         assert "claude-small" in aliases
         assert "gpt-small" in aliases
         assert "gemini-small" in aliases
 
-    def test_default_council_empty_when_only_design_model(self):
-        """If only the design model is configured, council is empty."""
+    def test_default_council_single_model(self):
+        """If only the design model is configured, council contains just that model."""
         models = {"claude-large": {"id": "anthropic/claude-opus-4-6"}}
         result = resolve_council_models(models, design_alias="claude-large")
-        assert result == []
+        assert len(result) == 1
+        assert result[0]["alias"] == "claude-large"
 
     def test_explicit_council_skips_unknown_aliases(self):
         """Unknown aliases in the council config are silently skipped."""
@@ -81,26 +83,27 @@ class TestResolveCouncilModels:
         assert aliases == ["claude-small"]
 
     def test_empty_council_config_uses_default(self):
-        """An empty council_config list falls back to default behavior."""
+        """An empty council_config list falls back to default behavior (all models)."""
         result = resolve_council_models(
             self.SAMPLE_MODELS,
             design_alias="claude-large",
             council_config=[],
         )
         aliases = [m["alias"] for m in result]
-        assert "claude-large" not in aliases
-        assert len(aliases) == 3  # all except design model
+        # Default includes all models including design model
+        assert "claude-large" in aliases
+        assert len(aliases) == 4  # all models
 
     def test_none_council_config_uses_default(self):
-        """None council_config falls back to default behavior."""
+        """None council_config falls back to default behavior (all models)."""
         result = resolve_council_models(
             self.SAMPLE_MODELS,
             design_alias="claude-large",
             council_config=None,
         )
         aliases = [m["alias"] for m in result]
-        assert "claude-large" not in aliases
-        assert len(aliases) == 3
+        assert "claude-large" in aliases
+        assert len(aliases) == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Set 1 — Workshop cost reporting**: Embeds per-comment cost tables in workshop output using the same pattern as design/review jobs. The design analysis comment gets a cost table at the bottom; each council review comment gets its own cost table (important since each model has different costs). The workflow's standalone cost step is replaced by a fallback-only step that skips when cost was already embedded.

- **Set 2A — Design model no longer excluded from council**: `resolve_council_models` default now includes all configured models (previously excluded the design model). The design agent reviewing its own work in a critic role provides independent signal.

- **Set 2B — claude-small only as default council**: `remote-dev-bot.yaml` now has an explicit `council` list of `[claude-small, gpt-small, gemini-small]`, dropping `claude-large`. Diverse perspectives across model families beats depth within one family. Users can override `council_models` per-repo.

- **Set 2C — Runtime skip for missing API keys**: Before spawning a council thread, workshop.py checks whether the required env var for the model's provider is set. If empty/missing, logs "Skipping [model] — API key not configured" and skips without erroring out.

## Test plan

- [ ] `python -m pytest tests/ -x -q` passes (302 tests)
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/remote-dev-bot.yml'))"` validates
- [ ] Design comment in workshop run includes cost table
- [ ] Each council review comment includes its own cost table
- [ ] If OPENAI_API_KEY / GEMINI_API_KEY is missing, those council models are skipped gracefully
- [ ] Claude-large is no longer in the default council list

🤖 Generated with [Claude Code](https://claude.com/claude-code)