### PR TITLE
Fix: restore review job accidentally dropped in PR #371

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -553,6 +553,15 @@ jobs:
           gh issue comment "$ISSUE_NUMBER" \
             --repo "${{ github.repository }}" \
             --body-file /tmp/cost_comment_fallback.md
+
+  # --- Mode: review (action=review) — lightweight agentic loop to review a PR ---
+  review:
+    needs: parse
+    if: needs.parse.outputs.action == 'review'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
       - name: Generate app token
         if: vars.RDB_APP_ID != ''
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Summary

- PR #371 (embedded cost reporting) accidentally removed the `review:` job header from `.github/workflows/remote-dev-bot.yml`, causing the review steps to be orphaned inside the `resolve` job
- This PR restores the proper `review:` job header (including `needs: parse`, `if:`, `runs-on:`, `timeout-minutes:`, and `steps:`) before the existing review steps
- The review steps already have the embedded-cost-table treatment applied (cost table in main comment + sentinel + fallback) — only the job declaration was missing

## Test plan

- [x] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/remote-dev-bot.yml'))"`
- [x] All 302 tests pass: `python -m pytest tests/ -x -q`
- [x] Workflow now has 5 distinct jobs: `resolve`, `review`, `design`, `explore`, `workshop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)