### PR TITLE
docs: suggest noting project maturity in AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ starting work.
 An AI assistant can write this for you — just ask it to read your codebase and
 generate an `AGENTS.md` describing the architecture and conventions.
 
+It's also worth noting project maturity and constraints: whether backward
+compatibility matters, whether there are external users, whether data can be
+regenerated from scratch. Agents use this to calibrate how much weight to put
+on migration paths, API stability, and similar concerns. For example: *"This is
+a pre-alpha prototype with no external users; backward compatibility and data
+migration are non-concerns."*
+
 ### Model Aliases
 
 Add or modify model aliases in your repo's `remote-dev-bot.yaml` (create it in


### PR DESCRIPTION
## Summary

- Adds a paragraph to the "Add Repo Context for the Agent" section of the README
- Recommends that users document project maturity and constraints in their `AGENTS.md`: whether there are external users, whether backward compatibility matters, whether data can be regenerated from scratch
- Explains that agents use this to calibrate how much weight to give migration paths, API stability, and similar concerns
- Includes a concrete example: *"This is a pre-alpha prototype with no external users; backward compatibility and data migration are non-concerns."*

## Test plan

- [ ] Read the updated "Add Repo Context for the Agent" section in README.md and confirm the new paragraph fits naturally after the existing guidance
- [ ] Verify the example sentence is italicized correctly in the rendered Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)