### PR TITLE
fix: update cost table row order, Info/$ label, and Iterations row

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -449,16 +449,20 @@ jobs:
           def _fmt_bpd(text, cost):
               if cost <= 0: return 'N/A'
               data = text.encode('utf-8') if isinstance(text, str) else text
-              bpd = (len(gzip.compress(data))) / cost
-              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit/$"
-              return f"{bpd / 1_000:.1f} Kbit/$"
+              bpd = (len(gzip.compress(data)) * 8) / cost  # bits per dollar
+              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit"
+              return f"{bpd / 1_000:.1f} Kbit"
           if os.path.exists("/tmp/llm_usage.json"):
               _d = json.load(open("/tmp/llm_usage.json"))
               input_tokens = _d.get('input_tokens', 0)
               output_tokens = _d.get('output_tokens', 0)
               cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
           else:
-              input_tokens = output_tokens = 0; cost = 0.0
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("MAX_ITERATIONS", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
           try:
               _st = int(open('/tmp/start_time').read().strip())
           except Exception:
@@ -476,9 +480,17 @@ jobs:
           _m = _re.search(r"(\d+) deletion", shortstat)
           if _m: loc_changed += int(_m.group(1))
           bits_text = diff_text
-          extra_rows = [('Diff', shortstat if shortstat else 'N/A'), ('LOC/$', f'{loc_changed / cost:,.0f} loc/$' if cost > 0 and loc_changed > 0 else 'N/A')]
           rounded = math.ceil(cost * 100) / 100
-          rows = [('Time', _fmt_ela(elapsed)), ('Input', _fmt_tok(input_tokens) + ' tokens'), ('Output', _fmt_tok(output_tokens) + ' tokens'), ('Bytes/$', _fmt_bpd(bits_text, cost))] + extra_rows + [('**Cost**', f'**${rounded:.2f}**')]
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('Diff', shortstat if shortstat else 'N/A'),
+              ('LOC/$', f'{loc_changed / cost:,.0f} loc/$' if cost > 0 and loc_changed > 0 else 'N/A'),
+              ('Info/$', _fmt_bpd(bits_text, cost)),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
@@ -522,6 +534,12 @@ jobs:
           else
             INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
           fi
+          MAX_ITER="${MAX_ITERATIONS:-}"
+          ITERATIONS_FMT=$(python3 -c "
+          max_i = '${MAX_ITER}'
+          iters = '${ITERATIONS}'
+          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
+          ")
           ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
           IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
           def fmt(n):
@@ -546,6 +564,7 @@ jobs:
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Time | ${ELAPSED_FMT} |"
+            echo "| Iterations | ${ITERATIONS_FMT} |"
             echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
             echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
             printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
@@ -1137,16 +1156,20 @@ jobs:
           def _fmt_bpd(text, cost):
               if cost <= 0: return 'N/A'
               data = text.encode('utf-8') if isinstance(text, str) else text
-              bpd = (len(gzip.compress(data))) / cost
-              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit/$"
-              return f"{bpd / 1_000:.1f} Kbit/$"
+              bpd = (len(gzip.compress(data)) * 8) / cost  # bits per dollar
+              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit"
+              return f"{bpd / 1_000:.1f} Kbit"
           if os.path.exists("/tmp/llm_usage.json"):
               _d = json.load(open("/tmp/llm_usage.json"))
               input_tokens = _d.get('input_tokens', 0)
               output_tokens = _d.get('output_tokens', 0)
               cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
           else:
-              input_tokens = output_tokens = 0; cost = 0.0
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("REVIEW_MAX_ITERATIONS", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
           try:
               _st = int(open('/tmp/start_time').read().strip())
           except Exception:
@@ -1154,9 +1177,15 @@ jobs:
           elapsed = int(time.time()) - _st
           output_text = open("/tmp/review_result.txt").read() if os.path.exists("/tmp/review_result.txt") else ""
           bits_text = output_text
-          extra_rows = []
           rounded = math.ceil(cost * 100) / 100
-          rows = [('Time', _fmt_ela(elapsed)), ('Input', _fmt_tok(input_tokens) + ' tokens'), ('Output', _fmt_tok(output_tokens) + ' tokens'), ('Bytes/$', _fmt_bpd(bits_text, cost))] + extra_rows + [('**Cost**', f'**${rounded:.2f}**')]
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('Info/$', _fmt_bpd(bits_text, cost)),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
@@ -1213,6 +1242,12 @@ jobs:
           else
             INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
           fi
+          MAX_ITER="${REVIEW_MAX_ITERATIONS:-}"
+          ITERATIONS_FMT=$(python3 -c "
+          max_i = '${MAX_ITER}'
+          iters = '${ITERATIONS}'
+          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
+          ")
           ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
           IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
           def fmt(n):
@@ -1237,6 +1272,7 @@ jobs:
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Time | ${ELAPSED_FMT} |"
+            echo "| Iterations | ${ITERATIONS_FMT} |"
             echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
             echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
             printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
@@ -1765,16 +1801,20 @@ jobs:
           def _fmt_bpd(text, cost):
               if cost <= 0: return 'N/A'
               data = text.encode('utf-8') if isinstance(text, str) else text
-              bpd = (len(gzip.compress(data))) / cost
-              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit/$"
-              return f"{bpd / 1_000:.1f} Kbit/$"
+              bpd = (len(gzip.compress(data)) * 8) / cost  # bits per dollar
+              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit"
+              return f"{bpd / 1_000:.1f} Kbit"
           if os.path.exists("/tmp/llm_usage.json"):
               _d = json.load(open("/tmp/llm_usage.json"))
               input_tokens = _d.get('input_tokens', 0)
               output_tokens = _d.get('output_tokens', 0)
               cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
           else:
-              input_tokens = output_tokens = 0; cost = 0.0
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("DESIGN_MAX_ITERATIONS", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
           try:
               _st = int(open('/tmp/start_time').read().strip())
           except Exception:
@@ -1782,9 +1822,15 @@ jobs:
           elapsed = int(time.time()) - _st
           output_text = open("/tmp/design_analysis.txt").read() if os.path.exists("/tmp/design_analysis.txt") else ""
           bits_text = output_text
-          extra_rows = []
           rounded = math.ceil(cost * 100) / 100
-          rows = [('Time', _fmt_ela(elapsed)), ('Input', _fmt_tok(input_tokens) + ' tokens'), ('Output', _fmt_tok(output_tokens) + ' tokens'), ('Bytes/$', _fmt_bpd(bits_text, cost))] + extra_rows + [('**Cost**', f'**${rounded:.2f}**')]
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('Info/$', _fmt_bpd(bits_text, cost)),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
@@ -1846,6 +1892,12 @@ jobs:
           else
             INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
           fi
+          MAX_ITER="${DESIGN_MAX_ITERATIONS:-}"
+          ITERATIONS_FMT=$(python3 -c "
+          max_i = '${MAX_ITER}'
+          iters = '${ITERATIONS}'
+          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
+          ")
           ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
           IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
           def fmt(n):
@@ -1870,6 +1922,7 @@ jobs:
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Time | ${ELAPSED_FMT} |"
+            echo "| Iterations | ${ITERATIONS_FMT} |"
             echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
             echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
             printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
@@ -2298,16 +2351,20 @@ jobs:
           def _fmt_bpd(text, cost):
               if cost <= 0: return 'N/A'
               data = text.encode('utf-8') if isinstance(text, str) else text
-              bpd = (len(gzip.compress(data))) / cost
-              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit/$"
-              return f"{bpd / 1_000:.1f} Kbit/$"
+              bpd = (len(gzip.compress(data)) * 8) / cost  # bits per dollar
+              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit"
+              return f"{bpd / 1_000:.1f} Kbit"
           if os.path.exists("/tmp/llm_usage.json"):
               _d = json.load(open("/tmp/llm_usage.json"))
               input_tokens = _d.get('input_tokens', 0)
               output_tokens = _d.get('output_tokens', 0)
               cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
           else:
-              input_tokens = output_tokens = 0; cost = 0.0
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("EXPLORE_MAX_ITERATIONS", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
           try:
               _st = int(open('/tmp/start_time').read().strip())
           except Exception:
@@ -2315,9 +2372,15 @@ jobs:
           elapsed = int(time.time()) - _st
           output_text = open("/tmp/explore_analysis.txt").read() if os.path.exists("/tmp/explore_analysis.txt") else ""
           bits_text = output_text
-          extra_rows = []
           rounded = math.ceil(cost * 100) / 100
-          rows = [('Time', _fmt_ela(elapsed)), ('Input', _fmt_tok(input_tokens) + ' tokens'), ('Output', _fmt_tok(output_tokens) + ' tokens'), ('Bytes/$', _fmt_bpd(bits_text, cost))] + extra_rows + [('**Cost**', f'**${rounded:.2f}**')]
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('Info/$', _fmt_bpd(bits_text, cost)),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
@@ -2369,6 +2432,12 @@ jobs:
           else
             INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
           fi
+          MAX_ITER="${EXPLORE_MAX_ITERATIONS:-}"
+          ITERATIONS_FMT=$(python3 -c "
+          max_i = '${MAX_ITER}'
+          iters = '${ITERATIONS}'
+          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
+          ")
           ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
           IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
           def fmt(n):
@@ -2393,6 +2462,7 @@ jobs:
             echo "| Metric | Value |"
             echo "|--------|-------|"
             echo "| Time | ${ELAPSED_FMT} |"
+            echo "| Iterations | ${ITERATIONS_FMT} |"
             echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
             echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
             printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
@@ -2712,6 +2782,13 @@ jobs:
           print(fmt(${INPUT_TOKENS}), fmt(${OUTPUT_TOKENS}), sep='\t')
           ")
 
+          WORKSHOP_MAX_ITER="${{ needs.parse.outputs.workshop_max_iterations }}"
+          ITERATIONS_FMT=$(python3 -c "
+          max_i = '${WORKSHOP_MAX_ITER}'
+          iters = '${ITERATIONS}'
+          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
+          ")
+
           # Format cost comment
           {
             echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
@@ -2722,9 +2799,7 @@ jobs:
             echo ""
             echo "| Metric | Value |"
             echo "|--------|-------|"
-            if [[ -n "$ITERATIONS" && "$ITERATIONS" != "0" ]]; then
-              echo "| Design iterations | ${ITERATIONS} / ${{ needs.parse.outputs.workshop_max_iterations }} |"
-            fi
+            echo "| Iterations | ${ITERATIONS_FMT} |"
             echo "| Input tokens | ${INPUT_TOKENS_FMT} |"
             echo "| Output tokens | ${OUTPUT_TOKENS_FMT} |"
             printf "| **Estimated cost** | **\$%s** |\n" "$ROUNDED"

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -481,13 +481,17 @@ jobs:
           if _m: loc_changed += int(_m.group(1))
           bits_text = diff_text
           rounded = math.ceil(cost * 100) / 100
+          def _fmt_loc(n):
+              if n >= 1_000_000: return f"{n/1_000_000:.1f}M"
+              if n >= 1_000: return f"{n/1_000:.1f}k"
+              return str(n)
           rows = [
               ('Time', _fmt_ela(elapsed)),
               ('Iterations', iterations_fmt),
               ('Input', _fmt_tok(input_tokens) + ' tokens'),
               ('Output', _fmt_tok(output_tokens) + ' tokens'),
               ('Diff', shortstat if shortstat else 'N/A'),
-              ('LOC/$', f'{loc_changed / cost:,.0f} loc/$' if cost > 0 and loc_changed > 0 else 'N/A'),
+              ('LOC/$', f'{_fmt_loc(int(loc_changed / cost))} loc/$' if cost > 0 and loc_changed > 0 else 'N/A'),
               ('Info/$', _fmt_bpd(bits_text, cost)),
               ('**Cost**', f'**${rounded:.2f}**'),
           ]


### PR DESCRIPTION
## Summary

- **Row order**: All cost tables (resolve, review, design, explore, workshop) now follow the spec: Time → Iterations → Input → Output → [Diff, LOC/$ for resolve only] → Info/$ → **Cost**
- **Label rename**: `Bytes/$` → `Info/$`; `_fmt_bpd` now returns the amount without `/$` suffix (e.g. `3.2 Mbit`), since the label already contains the `/$`
- **bpd fix**: multiply compressed byte count by 8 to get true bits-per-dollar
- **Iterations row**: added to all four Python cost-table blocks and all four bash fallback blocks; each mode reads from its correct env var (`MAX_ITERATIONS`, `REVIEW_MAX_ITERATIONS`, `DESIGN_MAX_ITERATIONS`, `EXPLORE_MAX_ITERATIONS`); workshop reads `workshop_max_iterations` from the parse job output; format is `"N / MAX"` when max is set and nonzero, else just `"N"`

## Test plan

- [x] YAML validation: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/remote-dev-bot.yml'))"`
- [x] Unit tests: `python -m pytest tests/ -x -q` — 302 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)