### PR TITLE
doc: clarify dev also requires PRs, never direct push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ gh run view RUN_ID --repo gnovak/remote-dev-bot-test --log | tail -40
 
 ## PR Policy
 
-- **All changes go through a PR. Never commit or push directly to main.** Open a PR and let the user merge it.
+- **All changes go through a PR. Never commit or push directly to `main` or `dev`.** Open a PR and let the user merge it.
 - For small changes, a single-commit PR self-merged immediately is fine — the point is the artifact, not the review ceremony.
 
 ## Commit Attribution


### PR DESCRIPTION
Adds `dev` explicitly to the PR Policy rule. Also adds branch protection to `dev` (done via API already).