### PR TITLE
fix: remove dead openhands wrapup step

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -238,23 +238,6 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
-      - name: Inject iteration budget hint
-        if: needs.parse.outputs.graceful_wrapup_enabled == 'true'
-        run: |
-          mkdir -p .openhands/microagents
-          cat >> .openhands/microagents/remote-dev-bot-wrapup.md << WRAPUP_EOF
-          # Iteration Budget (injected by remote-dev-bot)
-
-          This task has a budget of **${{ needs.parse.outputs.max_iterations }} iterations**.
-
-          When you reach iteration **${{ needs.parse.outputs.graceful_wrapup_iteration }}**, begin wrapping up:
-          1. Commit all changes you have made so far with a clear commit message
-          2. If the task is not fully complete, add a brief TODO comment or update the issue description with what remains
-          3. Call \`finish()\` with your honest assessment of what was accomplished
-
-          Do not start new work after iteration ${{ needs.parse.outputs.graceful_wrapup_iteration }}.
-          WRAPUP_EOF
-
       - name: Resolve issue
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}


### PR DESCRIPTION
Removes the 'Inject iteration budget hint' step from the resolve job. It wrote to `.openhands/microagents/remote-dev-bot-wrapup.md` which was only ever read by OpenHands. The wrapup budget is already passed to `resolve.py` via `WRAPUP_ENABLED`/`WRAPUP_ITERATION` env vars and injected as a user message at the right iteration.