### PR TITLE
fix: improve status log — merge-base diff and compaction events

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1080,6 +1080,11 @@ def main():
                               f"{stats['messages_compacted']} messages compacted, "
                               f"tokens {total_tokens} -> {new_total} "
                               f"({ratio:.1f}% reduction)")
+                        status_log.append((
+                            iteration + 1,
+                            f"[Context compaction] {stats['messages_compacted']} messages summarized, "
+                            f"tokens {total_tokens:,} → {new_total:,} ({ratio:.1f}% reduction)",
+                        ))
 
             if done:
                 break

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1088,11 +1088,26 @@ def main():
             # API call to ask the agent for a brief status update.
             if STATUS_LOG_INTERVAL > 0 and (iteration + 1) % STATUS_LOG_INTERVAL == 0:
                 try:
-                    # Get git diff --stat for ground-truth file changes
-                    diff_result = subprocess.run(
-                        ["git", "diff", "--stat", "HEAD"],
+                    # Get git diff --stat for ground-truth file changes.
+                    # Diff against the merge-base with the target branch so we
+                    # capture ALL changes on the branch (committed + uncommitted)
+                    # rather than only uncommitted working-tree changes.
+                    merge_base_result = subprocess.run(
+                        ["git", "merge-base", "HEAD", f"origin/{TARGET_BRANCH}"],
                         capture_output=True, text=True, timeout=10,
                     )
+                    if merge_base_result.returncode == 0:
+                        merge_base = merge_base_result.stdout.strip()
+                        diff_result = subprocess.run(
+                            ["git", "diff", "--stat", merge_base],
+                            capture_output=True, text=True, timeout=10,
+                        )
+                    else:
+                        # Fallback: no origin or no common ancestor
+                        diff_result = subprocess.run(
+                            ["git", "diff", "--stat", "HEAD"],
+                            capture_output=True, text=True, timeout=10,
+                        )
                     diff_lines = diff_result.stdout.strip().splitlines()
                     # Format as "file.py +N/-M" per file, skip the summary line
                     file_changes = []


### PR DESCRIPTION
## Summary

- Replaces `git diff --stat HEAD` (uncommitted changes only) with a diff against the merge-base of `HEAD` and `origin/TARGET_BRANCH`
- The command `git diff --stat <merge_base>` captures both committed and uncommitted changes on the branch, giving a cumulative view of everything done since the branch diverged from `dev`/`main`
- Graceful fallback to `git diff --stat HEAD` when `git merge-base` fails (e.g., no `origin` remote, no common ancestor)

## Test plan

- [ ] Verify status log entries show changes across all commits on the branch, not just the working tree
- [ ] Verify fallback triggers cleanly when run in a repo with no `origin` remote or no shared history
- [ ] Confirm formatting of `file.py +N/-M` output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)