### PR TITLE
fix: draft PR cost reporting, issue cross-linking, default on_failure=draft

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -344,6 +344,7 @@ jobs:
           if [[ "$SUCCESS" == "false" ]]; then
             ALIAS="${{ needs.parse.outputs.alias }}"
             MODEL="${{ needs.parse.outputs.model }}"
+            DRAFT_PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
             {
               echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
               echo ""
@@ -355,12 +356,11 @@ jobs:
                 echo "$EXPLANATION"
                 echo ""
               fi
-              echo "See the [workflow run logs]($RUN_URL) for full details."
-              if [[ "$ON_FAILURE" == "comment" ]]; then
+              if [[ -n "$DRAFT_PR_URL" ]]; then
+                echo "A draft PR with partial work was created: $DRAFT_PR_URL"
                 echo ""
-                echo "---"
-                echo "_To receive a draft PR with partial changes when this happens, set \`agent.on_failure: draft\` in your \`remote-dev-bot.yaml\`._"
               fi
+              echo "See the [workflow run logs]($RUN_URL) for full details."
             } > /tmp/failure_comment.md
 
             gh issue comment "$ISSUE_NUMBER" \

--- a/lib/config.py
+++ b/lib/config.py
@@ -387,7 +387,7 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     # and inline arg wins over both (applied below after action is resolved).
     max_iter = oh.get("max_iterations", 50)
     pr_type = oh.get("pr_type", "ready")
-    on_failure = oh.get("on_failure", "comment")
+    on_failure = oh.get("on_failure", "draft")
     # BACKCOMPAT(v0→v1, 2026-03-05): accept target_branch as alias for branch
     target_branch = oh.get("branch", oh.get("target_branch", "main"))
     assign_issue = oh.get("assign_issue", True)

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1179,7 +1179,8 @@ def main():
                     f"This draft PR contains whatever was committed and pushed during the run. "
                     f"To continue, trigger `/agent-resolve` as a comment on this PR and the "
                     f"agent will pick up from this branch.\n\n"
-                    f"**Agent's last status:** {last_status}"
+                    f"**Agent's last status:** {last_status}\n\n"
+                    f"Fixes #{ISSUE_NUMBER}"
                 )
                 pr_url = create_pr(branch, f"WIP: partial work on #{ISSUE_NUMBER}", draft_body, draft=True)
                 write_pr_url(pr_url)
@@ -1240,10 +1241,14 @@ def main():
         if ON_FAILURE == "draft" and ISSUE_TYPE == "issue":
             print("Creating draft PR (on_failure=draft)...")
             try:
+                _body = pr_body or explanation
+                _fixes = f"Fixes #{ISSUE_NUMBER}"
+                if _fixes not in _body:
+                    _body = _body + ("\n\n" if _body else "") + _fixes
                 pr_url = create_pr(
                     branch,
                     f"[Draft] Fix for issue #{ISSUE_NUMBER}",
-                    pr_body or explanation,
+                    _body,
                     draft=True,
                 )
                 write_pr_url(pr_url)
@@ -1268,7 +1273,8 @@ def _cleanup():
                     f"\u26a0\ufe0f **Partial work** \u2014 agent terminated unexpectedly before completing the task.\n\n"
                     f"This draft PR contains whatever was committed and pushed during the run. "
                     f"To continue, trigger `/agent-resolve` as a comment on this PR and the "
-                    f"agent will pick up from this branch."
+                    f"agent will pick up from this branch.\n\n"
+                    f"Fixes #{ISSUE_NUMBER}"
                 )
                 pr_url = create_pr(
                     _branch_created,

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1182,6 +1182,7 @@ def main():
                     f"**Agent's last status:** {last_status}"
                 )
                 pr_url = create_pr(branch, f"WIP: partial work on #{ISSUE_NUMBER}", draft_body, draft=True)
+                write_pr_url(pr_url)
                 print(f"Created draft PR for partial work: {pr_url}")
                 _pr_created = True
             except Exception as e:

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -90,9 +90,9 @@ agent:
   # PR type: "draft" or "ready"
   pr_type: ready
   # What to do when the agent can't fully resolve the issue (success=False):
-  #   comment — post a comment with the agent's evaluation, no PR (default)
-  #   draft   — post the same comment AND open a draft PR with partial changes
-  on_failure: comment
+  #   draft   — open a draft PR with partial changes (default)
+  #   comment — post a comment only, no PR
+  on_failure: draft
   # Assign the triggering user to the issue when the agent starts
   assign_issue: true
   # Assign the triggering user to the resulting PR

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -635,7 +635,7 @@ def test_resolve_config_agent_defaults():
         result = resolve_config(path, "nonexistent.yaml", "resolve")
         assert result["max_iterations"] == 50
         assert result["pr_type"] == "ready"
-        assert result["on_failure"] == "comment"
+        assert result["on_failure"] == "draft"
         assert result["target_branch"] == "main"
         assert result["assign_issue"] is True
         assert result["assign_pr"] is True
@@ -666,10 +666,10 @@ def test_resolve_config_openhands_key_backcompat():
 
 
 def test_resolve_config_on_failure_default(config_dir):
-    """on_failure defaults to 'comment'."""
+    """on_failure defaults to 'draft'."""
     tmp_path, base_path = config_dir
     result = resolve_config(base_path, "nonexistent.yaml", "resolve")
-    assert result["on_failure"] == "comment"
+    assert result["on_failure"] == "draft"
 
 
 def test_resolve_config_on_failure_draft(config_dir):


### PR DESCRIPTION
## Summary

Three related fixes for the agent-failure experience:

- **Cost in draft PR body**: When iteration exhaustion creates a draft PR, `write_pr_url()` was never called. Downstream "Append cost to PR" step had nothing to work with and fell back to a bare issue comment (no LOC/\$, no Info/\$). Now the PR URL is written, so cost (with all metrics) goes into the PR body as intended.
- **Issue→PR cross-link**: The "Post result comment" step now reads the draft PR URL and includes it in the failure comment on the issue. Previously the PR linked back to the issue (via its title) but the issue had no link forward to the PR.
- **Default `on_failure: draft`**: Changed from `comment` to `draft` in `lib/config.py`, `remote-dev-bot.yaml`, and tests. A draft PR is strictly better UX — partial work is preserved, linkable, retryable with `/agent-resolve`, and visible without hunting for branches.

## Test plan

- [x] `pytest tests/test_config.py` — 146 passed
- [ ] Trigger an agent run that exhausts iterations on a test issue — verify draft PR created, cost table in PR body, issue comment includes PR link