### PR TITLE
Add `build` mode: resolve + council code review

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -141,7 +141,7 @@ jobs:
   # --- Mode: resolve (action=pr) — run LiteLLM agent loop, open a PR ---
   resolve:
     needs: parse
-    if: needs.parse.outputs.action == 'pr'
+    if: needs.parse.outputs.action == 'pr' || needs.parse.outputs.action == 'build'
     runs-on: ubuntu-latest
 
     steps:
@@ -352,6 +352,119 @@ jobs:
           fi
           # Success case: PR was already created by resolve.py — no comment needed here
 
+      - name: Run council code review
+        if: needs.parse.outputs.action == 'build'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
+          GITHUB_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Read the PR URL written by resolve.py
+          PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
+
+          if [[ -z "$PR_URL" ]]; then
+            echo "No PR URL found — resolve may have failed. Posting notice and skipping council review."
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPO" \
+              --body "## 🏛️ Build Stage 2 — Council Code Review
+
+          ⚠️ **Skipped** — the implementation stage did not produce a pull request. Council code review requires a PR to review. See the [workflow run logs]($RUN_URL) for details."
+            exit 0
+          fi
+
+          export PR_URL
+          python3 << 'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          sys.path.insert(0, ".remote-dev-bot/lib")
+          from workshop import run_build_council
+
+          github_repo = os.environ["GITHUB_REPO"]
+          github_token = os.environ["GH_TOKEN"]
+          pr_url = os.environ.get("PR_URL", "")
+          issue_number = os.environ["ISSUE_NUMBER"]
+
+          pr_number_match = re.search(r'/pull/(\d+)$', pr_url)
+          if not pr_number_match:
+              print("No PR number found in URL, exiting")
+              sys.exit(0)
+          pr_number = pr_number_match.group(1)
+
+          env = {**os.environ, "GH_TOKEN": github_token}
+
+          # Fetch PR details
+          pr_json = subprocess.run(
+              ["gh", "api", f"repos/{github_repo}/pulls/{pr_number}"],
+              capture_output=True, text=True, env=env,
+          ).stdout
+          pr_data = json.loads(pr_json)
+          pr_title = pr_data.get("title", "")
+          pr_body = pr_data.get("body", "") or ""
+
+          # Fetch PR diff (truncate very large diffs to avoid token blowout)
+          diff_result = subprocess.run(
+              ["gh", "api", f"repos/{github_repo}/pulls/{pr_number}",
+               "--header", "Accept: application/vnd.github.diff"],
+              capture_output=True, text=True, env=env,
+          )
+          pr_diff = diff_result.stdout[:40000]
+
+          # Fetch issue title + body
+          issue_json = subprocess.run(
+              ["gh", "api", f"repos/{github_repo}/issues/{issue_number}"],
+              capture_output=True, text=True, env=env,
+          ).stdout
+          issue_data = json.loads(issue_json)
+          issue_title = issue_data.get("title", "")
+          issue_body_text = issue_data.get("body", "") or ""
+
+          council_models = json.loads(os.environ.get("COUNCIL_MODELS", "[]") or "[]")
+
+          def post_pr_comment(body):
+              proc = subprocess.run(
+                  ["gh", "pr", "comment", pr_number,
+                   "--repo", github_repo,
+                   "--body", body],
+                  env=env,
+                  capture_output=True, text=True,
+              )
+              if proc.returncode != 0:
+                  print(f"Warning: failed to post PR comment: {proc.stderr}", file=sys.stderr)
+
+          build_result = run_build_council(
+              council_models=council_models,
+              issue_title=issue_title,
+              issue_body=issue_body_text,
+              pr_title=pr_title,
+              pr_body=pr_body,
+              pr_diff=pr_diff,
+              post_comment_fn=post_pr_comment,
+          )
+
+          # Merge council usage into resolve.py's existing usage data
+          existing = {}
+          if os.path.exists("/tmp/llm_usage.json"):
+              with open("/tmp/llm_usage.json") as f:
+                  existing = json.load(f)
+
+          combined = {
+              "input_tokens": existing.get("input_tokens", 0) + build_result["total_input_tokens"],
+              "output_tokens": existing.get("output_tokens", 0) + build_result["total_output_tokens"],
+              "cost": (existing.get("cost") or 0.0) + build_result["total_cost"],
+              "iterations": existing.get("iterations", 0),
+          }
+          with open("/tmp/llm_usage.json", "w") as f:
+              json.dump(combined, f)
+          PYEOF
 
       - name: Write step summary
         if: always()

--- a/lib/config.py
+++ b/lib/config.py
@@ -421,10 +421,10 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     # Mode settings
     action = mode_config.get("action", "pr")
 
-    # For agentic loop modes (design, review, workshop), the mode config can specify
+    # For agentic loop modes (design, review, workshop, build), the mode config can specify
     # its own max_iterations as a per-mode default, overriding the global
     # agent.max_iterations. Inline args win over both (applied below).
-    if action in ("design", "review", "workshop") and "max_iterations" in mode_config:
+    if action in ("design", "review", "workshop", "build") and "max_iterations" in mode_config:
         max_iter = mode_config["max_iterations"]
 
     # Apply command-line arg overrides
@@ -537,7 +537,9 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     if action == "workshop":
         result["workshop_max_iterations"] = max_iter
 
-        # Council models: explicit list from mode config, or all models except design model
+    if action in ("workshop", "build"):
+        # Council models: explicit list from mode config, or all configured models.
+        # Used by workshop (design critique) and build (code review) modes.
         council_config = mode_config.get("council", [])
         council_models = []
         if council_config:

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -226,6 +226,259 @@ def run_council_review(
 
 
 # ---------------------------------------------------------------------------
+# Council code review (build mode Stage 2)
+# ---------------------------------------------------------------------------
+
+COUNCIL_CODE_REVIEW_SYSTEM_PROMPT = (
+    "You are a senior software engineer participating in a code review council. "
+    "You have been given a pull request that resolves a GitHub issue, and you "
+    "must provide a structured code review.\n\n"
+    "Your review should be thorough but constructive. Focus on:\n"
+    "- Correctness: does this actually solve the issue? Any edge cases missed?\n"
+    "- Code quality: readability, maintainability, appropriate abstractions\n"
+    "- Potential bugs or regressions introduced by the change\n"
+    "- Alternative approaches that might be simpler or more robust\n\n"
+    "Be specific and actionable. Reference file names when raising concerns. "
+    "If the change looks good overall, say so clearly — do not manufacture concerns."
+)
+
+COUNCIL_CODE_REVIEW_FORMAT = """\
+Format your response EXACTLY as follows (use these exact headers):
+
+## Code Review by {model_alias}
+
+**Overall:** [LGTM / Looks good with minor comments / Needs changes]
+
+**What I'd approve:** …
+
+**Concerns:** …
+
+**Suggestions:** …
+
+**Questions for the author:** …
+"""
+
+
+def build_council_code_review_prompt(
+    *,
+    issue_title,
+    issue_body,
+    pr_title,
+    pr_body,
+    pr_diff,
+    model_alias,
+):
+    """Build the user prompt for a council code review."""
+    return (
+        f"## Issue being resolved: {issue_title}\n\n"
+        f"{issue_body}\n\n"
+        f"## Pull Request: {pr_title}\n\n"
+        f"{pr_body}\n\n"
+        f"## Diff:\n\n```diff\n{pr_diff}\n```\n\n"
+        f"---\n\n"
+        f"Please review the pull request above and provide your code review.\n\n"
+        f"{COUNCIL_CODE_REVIEW_FORMAT.format(model_alias=model_alias)}"
+    )
+
+
+def run_council_code_review(
+    *,
+    model_id,
+    model_alias,
+    issue_title,
+    issue_body,
+    pr_title,
+    pr_body,
+    pr_diff,
+    api_keys=None,
+):
+    """Run a single council code review (non-agentic single LLM call).
+
+    Returns dict with keys: review, model_alias, model_id,
+    input_tokens, output_tokens, cost.
+    """
+    from litellm import completion as litellm_completion
+
+    if api_keys:
+        for key, value in api_keys.items():
+            if value:
+                os.environ[key] = value
+
+    user_content = build_council_code_review_prompt(
+        issue_title=issue_title,
+        issue_body=issue_body,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        pr_diff=pr_diff,
+        model_alias=model_alias,
+    )
+
+    messages = [
+        {"role": "system", "content": COUNCIL_CODE_REVIEW_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    response = litellm_completion(
+        model=model_id,
+        messages=messages,
+        max_tokens=8192,
+    )
+
+    usage = getattr(response, "usage", None)
+    input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+    output_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+    cost = getattr(response, "_hidden_params", {}).get("response_cost", None) or 0.0
+
+    review_text = response.choices[0].message.content or ""
+
+    return {
+        "review": review_text,
+        "model_alias": model_alias,
+        "model_id": model_id,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost": cost,
+    }
+
+
+def run_build_council(
+    *,
+    council_models,
+    issue_title,
+    issue_body,
+    pr_title,
+    pr_body,
+    pr_diff,
+    post_comment_fn=None,
+):
+    """Run Stage 2 council code reviews for build mode.
+
+    Runs each council model's review in parallel (non-agentic). Posts each
+    review via post_comment_fn (defaults to print if None).
+
+    Returns dict with council_results, total_input_tokens,
+    total_output_tokens, total_cost.
+    """
+    import concurrent.futures
+    from design_loop import has_agent_command
+
+    def post(body):
+        if post_comment_fn:
+            post_comment_fn(body)
+        else:
+            print(body)
+
+    if not council_models:
+        post(
+            "## 🏛️ Build Stage 2 — Council Code Review\n\n"
+            "⚠️ No council models configured. Skipping council code review.\n"
+        )
+        return {
+            "council_results": [],
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_cost": 0.0,
+        }
+
+    post(
+        f"## 🏛️ Build Stage 2 — Council Code Review\n\n"
+        f"Requesting code reviews from {len(council_models)} council member(s): "
+        f"{', '.join(f'`{m[\"alias\"]}`' for m in council_models)}...\n"
+    )
+
+    council_results = []
+
+    def _run_single_code_review(council_model):
+        model_id = council_model["id"]
+        key_name = _get_required_api_key_name(model_id)
+        if key_name is not None:
+            key_value = os.environ.get(key_name, "")
+            if not key_value:
+                print(
+                    f"Skipping {council_model['alias']} — API key not configured "
+                    f"({key_name} is empty or missing)",
+                    flush=True,
+                )
+                return None
+
+        review_start = time.time()
+        result = run_council_code_review(
+            model_id=model_id,
+            model_alias=council_model["alias"],
+            issue_title=issue_title,
+            issue_body=issue_body,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            pr_diff=pr_diff,
+        )
+        result["elapsed"] = time.time() - review_start
+        return result
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(council_models)) as executor:
+        futures = {
+            executor.submit(_run_single_code_review, cm): cm
+            for cm in council_models
+        }
+        for future in concurrent.futures.as_completed(futures):
+            cm = futures[future]
+            try:
+                result = future.result()
+                if result is None:
+                    continue
+                council_results.append(result)
+            except Exception as e:
+                council_results.append({
+                    "review": f"⚠️ Error during review: {e}",
+                    "model_alias": cm["alias"],
+                    "model_id": cm["id"],
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cost": 0.0,
+                    "elapsed": 0.0,
+                })
+
+    for cr in council_results:
+        if has_agent_command(cr["review"]):
+            post(
+                f"⚠️ **Agent loop blocked!** Review from `{cr['model_alias']}` "
+                f"contained `/agent` command(s). Blocked for safety."
+            )
+        else:
+            cost_table = _build_cost_table(
+                input_tokens=cr.get("input_tokens", 0),
+                output_tokens=cr.get("output_tokens", 0),
+                cost=cr.get("cost", 0.0),
+                elapsed=cr.get("elapsed", 0.0),
+                output_text=cr.get("review", ""),
+            )
+            post(
+                f"🤖 **Council reviewer:** `{cr['model_alias']}` (`{cr['model_id']}`)\n\n"
+                f"{cr['review']}\n\n"
+                f"---\n"
+                f"_Council code review by `/agent-build` Stage 2 (`{cr['model_alias']}`)_\n\n"
+                f"{cost_table}"
+            )
+
+    n = len(council_results)
+    post(
+        f"## Build Stage 2 complete — awaiting human review\n\n"
+        f"{n} model(s) have posted code reviews above. Please review the feedback "
+        f"and address any concerns before merging.\n"
+    )
+
+    total_input = sum(cr.get("input_tokens", 0) for cr in council_results)
+    total_output = sum(cr.get("output_tokens", 0) for cr in council_results)
+    total_cost = sum(cr.get("cost", 0.0) for cr in council_results)
+
+    return {
+        "council_results": council_results,
+        "total_input_tokens": total_input,
+        "total_output_tokens": total_output,
+        "total_cost": total_cost,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Council filtering
 # ---------------------------------------------------------------------------
 

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -6,6 +6,8 @@
 #   /agent-design-claude-large  — design analysis with specific model
 #   /agent-review               — code review on a PR, post comment
 #   /agent-review-claude-large  — code review with specific model
+#   /agent-build               — implement issue as a team: open PR, then council reviews the code
+#   /agent-build-claude-large  — build with specific model
 
 default_model: claude-small
 
@@ -56,6 +58,21 @@ modes:
       - claude-small
       - gpt-small
       - gemini-small
+
+
+  build:
+    action: build             # Run agent loop, open a PR, then council reviews the code
+    default_model: claude-small
+    max_iterations: 50        # Iteration limit for the implementation loop
+    extra_files:
+      - AGENTS.md
+      - README.md
+    # Council: models that review the PR. Defaults to all configured models if not specified.
+    council:
+      - claude-small
+      - gpt-small
+      - gemini-small
+
 
 models:
   claude-small:


### PR DESCRIPTION
## Summary

Adds a new `build` mode that combines the existing `resolve` (PR-opening) flow with an automated council code review stage.

- **Stage 1:** Runs `resolve.py` (same as `/agent-resolve`) to implement the issue and open a PR
- **Stage 2:** Each configured council model does a non-agentic single-call code review of the PR diff and posts its review as a PR comment

## Files changed

- **`lib/workshop.py`** (new file on this branch): adds `COUNCIL_CODE_REVIEW_SYSTEM_PROMPT`, `COUNCIL_CODE_REVIEW_FORMAT`, `build_council_code_review_prompt`, `run_council_code_review`, and `run_build_council` — the Stage 2 council review logic, running in parallel via `ThreadPoolExecutor`
- **`lib/config.py`**: `build` action included in per-mode `max_iterations` override; `council_models` resolved for both `workshop` and `build` actions; `workshop_max_iterations` and `council_models` written to `GITHUB_OUTPUT`
- **`remote-dev-bot.yaml`**: adds `build` mode entry with `action: build`, `max_iterations: 50`, and a default council of `claude-small`, `gpt-small`, `gemini-small`; also adds usage comment lines for `/agent-build` and `/agent-build-claude-large`
- **`.github/workflows/remote-dev-bot.yml`**: resolve job `if` condition expanded to include `action == 'build'`; new "Run council code review" step inserted after "Post result comment" that fetches the PR diff and runs `run_build_council`; `workshop_max_iterations` and `council_models` added to `parse` job outputs

## Test plan

- [ ] Trigger `/agent-build` on a test issue — verify Stage 1 opens a PR and Stage 2 posts council code review comments on that PR
- [ ] Trigger `/agent-build-claude-large` — verify model override works
- [ ] Verify that `/agent-resolve` (action=`pr`) still works unchanged
- [ ] Verify that if Stage 1 fails to open a PR, Stage 2 posts a skip notice on the issue instead of crashing
- [ ] Verify cost from council reviews is merged into the final cost summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)