### PR TITLE
docs: document workshop and build modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,16 @@ comment (no code changes).
 
 ## Commands
 
-| Command                       | What it does                                         |
-| ----------------------------- | ---------------------------------------------------- |
-| `/agent-resolve`              | Resolve the issue and open a PR (default model)      |
-| `/agent-resolve-claude-large` | Resolve with a specific model                        |
-| `/agent-design`               | Explore codebase and post a design analysis comment  |
-| `/agent-design-claude-large`  | Design analysis with a specific model                |
-| `/agent-review`               | Post a code review comment on a PR (no code changes) |
-| `/agent-review-claude-large`  | Code review with a specific model                    |
+| Command                         | What it does                                         |
+| ------------------------------- | ---------------------------------------------------- |
+| `/agent-resolve`                | Resolve the issue and open a PR (default model)      |
+| `/agent-resolve-claude-large`   | Resolve with a specific model                        |
+| `/agent-design`                 | Explore codebase and post a design analysis comment  |
+| `/agent-design-claude-large`    | Design analysis with a specific model                |
+| `/agent-review`                 | Post a code review comment on a PR (no code changes) |
+| `/agent-review-claude-large`    | Code review with a specific model                    |
+| `/agent-workshop[-<model>]`     | Design analysis + multi-model council critique       |
+| `/agent-build[-<model>]`        | Implement issue + multi-model council code review    |
 
 Modes and model aliases are configured in `remote-dev-bot.yaml`.
 
@@ -176,6 +178,33 @@ Sign all commits with a trailer: Model: <your model name and version>
 
 There is no built-in trailer — commit message format is entirely up to you.
 
+## Workshop and Build Modes
+
+Workshop and Build are council modes: after the agent finishes its primary
+task, each model in the configured `council` independently reviews the result
+and posts a structured comment. Human reads the council's feedback, then
+decides what to do next.
+
+**Workshop** (`/agent-workshop`):
+
+- Stage 1: one agent explores the codebase and produces a design proposal
+  (same as `/agent-design`)
+- Stage 2: each council model independently critiques the proposal and posts a
+  structured review comment on the issue
+- Bot pauses — human reads the critiques and replies, then can trigger
+  `/agent-design` for a revised proposal or `/agent-build` to implement
+
+**Build** (`/agent-build`):
+
+- Stage 1: one agent implements the issue and opens a PR (same as
+  `/agent-resolve`)
+- Stage 2: each council model reviews the PR diff and posts a code review
+  comment on the PR
+- Bot pauses — human reviews the code reviews and decides whether to merge
+
+Both modes use a configurable `council:` list in the mode config. If omitted,
+the council defaults to all configured models.
+
 ## Architecture
 
 The system has two parts:
@@ -259,19 +288,19 @@ Sometimes the agent judges that it couldn't completely fix the issue (it reports
 `success=False` in its evaluation). The `on_failure` setting controls what
 happens next:
 
-| Value               | Behaviour                                                                                                                                                          |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `comment` (default) | Posts a comment with the agent's evaluation and a link to the run logs. No PR is created.                                                                                                                       |
-| `draft`             | Posts the same comment **and** opens a draft PR with whatever changes the agent made. Also creates a draft PR if the agent exhausts its iteration budget or crashes mid-run with committed work on the branch. |
+| Value            | Behaviour                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `draft` (default)| Posts the agent's evaluation comment **and** opens a draft PR with whatever changes were made. Also opens a draft PR if the agent exhausts its iteration budget or fails mid-run with committed work on the branch. |
+| `comment`        | Posts a comment with the agent's evaluation and a link to the run logs. No PR is created.                                                                          |
 
 ```yaml
 agent:
-  on_failure: draft # create a draft PR with partial changes
+  on_failure: comment # post a comment only, no draft PR
 ```
 
-Use `draft` if you want to review and complete partial work yourself. The
-default `comment` is safer — it surfaces what happened without creating a PR
-that might be accidentally merged.
+Use the default `draft` to preserve partial work for review and completion.
+Set `comment` if you prefer a comment-only failure mode and don't want a draft
+PR created.
 
 ### Other Configuration Options
 
@@ -305,6 +334,24 @@ agent:
 You can also override `max_iterations`, `branch`, and `context` on a
 per-invocation basis without editing the config file — see
 [Per-Invocation Arguments](#per-invocation-arguments).
+
+### Council Configuration (Workshop and Build)
+
+The `workshop:` and `build:` mode entries accept a `council:` list that
+controls which models participate in the review stage. If omitted, all
+configured models are used.
+
+```yaml
+modes:
+  workshop:
+    council:
+      - claude-small
+      - gpt-small
+  build:
+    council:
+      - claude-small
+      - gemini-small
+```
 
 ## Security
 

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -52,6 +52,7 @@ This is the "engine" — the shared infrastructure that all target repos use.
 | `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
 | `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
+| `lib/workshop.py` | Council logic for workshop and build modes: runs each council model, posts critique or code review comments. |
 | `runbook.md` | Step-by-step setup instructions for humans or AI assistants. |
 
 **Who maintains this:** The upstream maintainer (gnovak), or you if you forked it. Updates here automatically flow to all target repos that reference it.
@@ -62,7 +63,7 @@ This is where you want the AI agent to help with development.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, and `/agent-review` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
+| `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, `/agent-review`, `/agent-workshop`, and `/agent-build` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
 | `remote-dev-bot.yaml` | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config. |
 | `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. You can also use `AGENTS.md` or `CLAUDE.md` and add them to `context_files` in your `remote-dev-bot.yaml`. |
 
@@ -91,6 +92,8 @@ When someone comments `/agent-resolve-claude-large` on an issue:
 6. **Feedback** — A rocket emoji is added to your comment and you're assigned to the issue, so you can see at a glance which issues have active work
 7. **Agent runs** — OpenHands reads the issue, explores the codebase, makes changes
 8. **PR created** — A draft (or ready) PR is opened with the changes
+
+For `/agent-workshop` and `/agent-build`, steps 1–6 are identical. Step 7 runs the same agent loop (design or resolve), then `lib/workshop.py` runs each council model in sequence and posts a review comment. The bot pauses there; no further automation happens until a human triggers the next command.
 
 ```
 User comments /agent-resolve-claude-large


### PR DESCRIPTION
## Summary

- **README.md**: Added `workshop` and `build` to the commands table; added a new "Workshop and Build Modes" section explaining both council modes (stages, behavior, human checkpoints); updated the `on_failure` table to show `draft` as the default and corrected the description; added a "Council Configuration" subsection showing how to configure `council:` in `workshop:` and `build:` mode entries.
- **how-it-works.md**: Added `lib/workshop.py` row to the "What Lives Where" table; updated the target repo `agent.yml` row to include `/agent-workshop` and `/agent-build`; added a note to "How the Pieces Connect" explaining how workshop/build differ from resolve/design as alternative paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)