### PR TITLE
test: add parse_command tests for single-word and multi-dash model aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ pytest --doctest-modules lib/config.py
 2. Add a job to `.github/workflows/remote-dev-bot.yml`
 3. `resolve_config()` in `lib/config.py` reads the mode's config from the YAML — no code change needed unless the mode has a novel output field
 
+> **Mode names must be single words (no hyphens).** The command parser splits
+> `/agent-<verb>-<model>` on the first hyphen to separate verb from model alias,
+> so a hyphenated mode name like `very-cool` would be misread as verb `very`.
+> Model aliases, which are user-defined, may contain any number of hyphens.
+
 ### Adding a new model provider (e.g., a new LLM vendor)
 
 1. Add the provider prefix to `KNOWN_PROVIDERS` in `lib/config.py` (e.g., `"newvendor/"`)

--- a/lib/config.py
+++ b/lib/config.py
@@ -285,6 +285,11 @@ def parse_command(command_string, known_modes):
     # Normalize to lowercase for case-insensitive matching
     command_string = command_string.lower().strip()
 
+    # Split on the first hyphen only. Everything before is the verb/mode;
+    # everything after is the model alias. This means mode names MUST be
+    # single words (no hyphens) — a mode named "very-cool" would parse as
+    # verb="very", which would fail the known_modes check. Model aliases, by
+    # contrast, can have any number of hyphens (e.g. "gpt-4o-mini", "my-model").
     parts = command_string.split("-", 1)
     verb = parts[0]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,6 +113,16 @@ def test_parse_command_multi_segment_model():
     assert parse_command("resolve-gpt-large", KNOWN_MODES) == ("resolve", "gpt-large")
 
 
+def test_parse_command_single_word_model():
+    """Model aliases with no hyphens (single word) should work."""
+    assert parse_command("resolve-bob", KNOWN_MODES) == ("resolve", "bob")
+
+
+def test_parse_command_many_segment_model():
+    """Model aliases with multiple hyphens should be preserved in full."""
+    assert parse_command("resolve-bob-very-large", KNOWN_MODES) == ("resolve", "bob-very-large")
+
+
 def test_parse_command_bare_agent_errors():
     """Empty command string (bare /agent) should raise ValueError."""
     with pytest.raises(ValueError, match="Bare /agent is not supported"):


### PR DESCRIPTION
Adds two regression tests to lock in the model alias parsing behavior:

- `test_parse_command_single_word_model` — model with no hyphens (`bob`)
- `test_parse_command_many_segment_model` — model with 2+ hyphens (`bob-very-large`)

The existing `test_parse_command_multi_segment_model` only covered a one-hyphen alias (`gpt-large`). The split-on-first-dash logic already handles all cases correctly; these tests make it regression-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)