### PR TITLE
feat: generate repo index at agent setup time

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -238,6 +238,19 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
+      - name: Generate repo index
+        run: |
+          python3 .remote-dev-bot/lib/generate_index.py > /tmp/rdb-index.md
+          EXTRA_FILES_RAW='${{ needs.parse.outputs.extra_files }}'
+          RDB_EXTRA_FILES=$(python3 -c "
+import json, sys
+raw = sys.argv[1]
+files = json.loads(raw) if raw and raw not in ('null', '') else []
+files.append('/tmp/rdb-index.md')
+print(json.dumps(files))
+" "$EXTRA_FILES_RAW")
+          echo "RDB_EXTRA_FILES=$RDB_EXTRA_FILES" >> "$GITHUB_ENV"
+
       - name: Resolve issue
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
@@ -261,7 +274,7 @@ jobs:
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
           STATUS_LOG_INTERVAL: ${{ needs.parse.outputs.status_log_interval }}
           ALIAS: ${{ needs.parse.outputs.alias }}
-          EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.extra_instructions }}
           MODEL_EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.model_extra_instructions }}
         run: |
@@ -662,6 +675,19 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
+      - name: Generate repo index
+        run: |
+          python3 .remote-dev-bot/lib/generate_index.py > /tmp/rdb-index.md
+          EXTRA_FILES_RAW='${{ needs.parse.outputs.extra_files }}'
+          RDB_EXTRA_FILES=$(python3 -c "
+import json, sys
+raw = sys.argv[1]
+files = json.loads(raw) if raw and raw not in ('null', '') else []
+files.append('/tmp/rdb-index.md')
+print(json.dumps(files))
+" "$EXTRA_FILES_RAW")
+          echo "RDB_EXTRA_FILES=$RDB_EXTRA_FILES" >> "$GITHUB_ENV"
+
       - name: Resolve issue
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
@@ -685,7 +711,7 @@ jobs:
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
           STATUS_LOG_INTERVAL: ${{ needs.parse.outputs.status_log_interval }}
           ALIAS: ${{ needs.parse.outputs.alias }}
-          EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.extra_instructions }}
           MODEL_EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.model_extra_instructions }}
         run: |
@@ -1142,6 +1168,19 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
+      - name: Generate repo index
+        run: |
+          python3 .remote-dev-bot/lib/generate_index.py > /tmp/rdb-index.md
+          EXTRA_FILES_RAW='${{ needs.parse.outputs.extra_files }}'
+          RDB_EXTRA_FILES=$(python3 -c "
+import json, sys
+raw = sys.argv[1]
+files = json.loads(raw) if raw and raw not in ('null', '') else []
+files.append('/tmp/rdb-index.md')
+print(json.dumps(files))
+" "$EXTRA_FILES_RAW")
+          echo "RDB_EXTRA_FILES=$RDB_EXTRA_FILES" >> "$GITHUB_ENV"
+
       - name: Determine API key
         id: apikey
         env:
@@ -1286,7 +1325,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           REVIEW_MAX_ITERATIONS: ${{ needs.parse.outputs.review_max_iterations }}
           REVIEW_CONTEXT_KEEP_TOOL_RESULTS: ${{ needs.parse.outputs.review_context_keep_tool_results }}
           REVIEW_WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
@@ -1855,6 +1894,19 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
+      - name: Generate repo index
+        run: |
+          python3 .remote-dev-bot/lib/generate_index.py > /tmp/rdb-index.md
+          EXTRA_FILES_RAW='${{ needs.parse.outputs.extra_files }}'
+          RDB_EXTRA_FILES=$(python3 -c "
+import json, sys
+raw = sys.argv[1]
+files = json.loads(raw) if raw and raw not in ('null', '') else []
+files.append('/tmp/rdb-index.md')
+print(json.dumps(files))
+" "$EXTRA_FILES_RAW")
+          echo "RDB_EXTRA_FILES=$RDB_EXTRA_FILES" >> "$GITHUB_ENV"
+
       - name: Determine API key
         id: apikey
         env:
@@ -1955,7 +2007,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           DESIGN_MAX_ITERATIONS: ${{ needs.parse.outputs.design_max_iterations }}
           DESIGN_CONTEXT_KEEP_TOOL_RESULTS: ${{ needs.parse.outputs.design_context_keep_tool_results }}
           DESIGN_WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
@@ -2499,6 +2551,19 @@ jobs:
       - name: Install dependencies
         run: pip install PyYAML litellm
 
+      - name: Generate repo index
+        run: |
+          python3 .remote-dev-bot/lib/generate_index.py > /tmp/rdb-index.md
+          EXTRA_FILES_RAW='${{ needs.parse.outputs.extra_files }}'
+          RDB_EXTRA_FILES=$(python3 -c "
+import json, sys
+raw = sys.argv[1]
+files = json.loads(raw) if raw and raw not in ('null', '') else []
+files.append('/tmp/rdb-index.md')
+print(json.dumps(files))
+" "$EXTRA_FILES_RAW")
+          echo "RDB_EXTRA_FILES=$RDB_EXTRA_FILES" >> "$GITHUB_ENV"
+
       - name: Determine API key
         id: apikey
         env:
@@ -2606,7 +2671,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           MAX_ITERATIONS: ${{ needs.parse.outputs.workshop_max_iterations }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
-          EXTRA_FILES: ${{ needs.parse.outputs.extra_files }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
         run: |

--- a/lib/generate_index.py
+++ b/lib/generate_index.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Generate a repo index (class fields and function signatures) for agent context.
+
+Walks Python source files in the current directory, extracts dataclass fields
+and function/method signatures via the AST, and writes a Markdown document to
+stdout. No LLM required — output is always in sync with the code.
+
+Usage:
+    python generate_index.py [root_dir]  # defaults to current directory
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+SKIP_DIRS = {
+    ".git", "__pycache__", "venv", ".venv", "env", ".env",
+    "node_modules", "dist", ".tox", ".mypy_cache", ".ruff_cache",
+    "site-packages", ".remote-dev-bot",
+}
+
+
+def unparse(node):
+    return ast.unparse(node) if node else ""
+
+
+def format_args(args_node):
+    """Format an arguments node into a parameter string."""
+    parts = []
+    all_args = args_node.posonlyargs + args_node.args
+    # Build defaults map: last N defaults correspond to last N args
+    defaults_map = {}
+    for arg, default in zip(reversed(all_args), reversed(args_node.defaults)):
+        defaults_map[arg.arg] = default
+
+    for i, arg in enumerate(args_node.posonlyargs):
+        s = arg.arg
+        if arg.annotation:
+            s += f": {unparse(arg.annotation)}"
+        if arg.arg in defaults_map:
+            s += f" = {unparse(defaults_map[arg.arg])}"
+        parts.append(s)
+    if args_node.posonlyargs:
+        parts.append("/")
+
+    for arg in args_node.args:
+        s = arg.arg
+        if arg.annotation:
+            s += f": {unparse(arg.annotation)}"
+        if arg.arg in defaults_map:
+            s += f" = {unparse(defaults_map[arg.arg])}"
+        parts.append(s)
+
+    if args_node.vararg:
+        parts.append(f"*{args_node.vararg.arg}")
+    elif args_node.kwonlyargs:
+        parts.append("*")
+
+    kw_defaults = {
+        a.arg: d
+        for a, d in zip(args_node.kwonlyargs, args_node.kw_defaults)
+        if d is not None
+    }
+    for arg in args_node.kwonlyargs:
+        s = arg.arg
+        if arg.annotation:
+            s += f": {unparse(arg.annotation)}"
+        if arg.arg in kw_defaults:
+            s += f" = {unparse(kw_defaults[arg.arg])}"
+        parts.append(s)
+
+    if args_node.kwarg:
+        parts.append(f"**{args_node.kwarg.arg}")
+
+    return ", ".join(parts)
+
+
+def is_dataclass(node):
+    for d in node.decorator_list:
+        if isinstance(d, ast.Name) and d.id == "dataclass":
+            return True
+        if isinstance(d, ast.Attribute) and d.attr == "dataclass":
+            return True
+    return False
+
+
+def format_func_sig(node, indent=""):
+    params = format_args(node.args)
+    sig = f"{indent}def {node.name}({params})"
+    if node.returns:
+        sig += f" -> {unparse(node.returns)}"
+    return sig
+
+
+def process_file(path):
+    """Return index lines for a single Python file, or [] if nothing useful."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    lines = []
+
+    for node in ast.iter_child_nodes(tree):
+        # Module-level functions (skip private/dunder)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                lines.append(format_func_sig(node))
+
+        # Classes
+        elif isinstance(node, ast.ClassDef):
+            bases = ", ".join(unparse(b) for b in node.bases)
+            class_line = f"class {node.name}" + (f"({bases})" if bases else "") + ":"
+            if is_dataclass(node):
+                lines.append("@dataclass")
+            lines.append(class_line)
+
+            if is_dataclass(node):
+                # Show field definitions
+                for item in node.body:
+                    if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                        field = f"    {item.target.id}: {unparse(item.annotation)}"
+                        if item.value:
+                            field += f" = {unparse(item.value)}"
+                        lines.append(field)
+            else:
+                # Show public method signatures
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        if not item.name.startswith("_") or item.name == "__init__":
+                            lines.append(format_func_sig(item, indent="    "))
+
+    return lines
+
+
+def find_source_files(root):
+    root = Path(root)
+    files = []
+    for path in sorted(root.rglob("*.py")):
+        # Skip unwanted directories
+        if any(skip in path.parts for skip in SKIP_DIRS):
+            continue
+        # Skip test files
+        if path.name.startswith("test_") or path.name.endswith("_test.py"):
+            continue
+        files.append(path)
+    return files
+
+
+def main():
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    files = find_source_files(root)
+
+    python_files = [(f, process_file(f)) for f in files]
+    python_files = [(f, lines) for f, lines in python_files if lines]
+
+    if not python_files:
+        return  # No output — nothing to add to context
+
+    print("# Repo Index (auto-generated)")
+    print()
+    print("> Class fields and function signatures extracted from source.")
+    print("> **Trust these definitions.** Read source files only if you need")
+    print("> implementation details or are about to modify a specific function.")
+    print()
+
+    for path, lines in python_files:
+        rel = path.relative_to(root)
+        print(f"## `{rel}`")
+        print()
+        print("```python")
+        print("\n".join(lines))
+        print("```")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `lib/generate_index.py`: walks Python source files via AST, extracts dataclass fields and function/method signatures, writes Markdown to stdout. Pure stdlib, runs in milliseconds.
- Adds a **Generate repo index** step to all five agentic jobs (resolve, build Stage 1, review, design, workshop Stage 1). Runs after `Install dependencies`, before the main agent step.
- The step writes `/tmp/rdb-index.md` and appends it to `EXTRA_FILES` via `RDB_EXTRA_FILES` in GITHUB_ENV. Main steps now read `EXTRA_FILES` from the env var set by the generate step.
- The index header instructs the agent to trust the definitions and skip exploratory reads unless modifying a specific file.

## Why

Every RDB run currently spends 50-150K tokens re-discovering the codebase from scratch. This generates an always-accurate index at setup time (free, no LLM cost) and gives the agent a head start.

## What's not changed

- Non-agentic jobs (workshop Stage 2, build Stage 2 council review) are unchanged.
- `extra_files` config is unchanged — this is an RDB-internal addition, invisible to users.
- `lib/generate_index.py` is fetched as part of the existing `lib/` sparse checkout.
