### PR TITLE
fix: force unbuffered output in resolve.py (-u flag)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -291,7 +291,7 @@ jobs:
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
           # Subsequent cleanup steps run regardless via if:always().
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \
-            python3 .remote-dev-bot/lib/resolve.py
+            python3 -u .remote-dev-bot/lib/resolve.py
           RESOLVE_EXIT_CODE=$?
 
           if [[ $RESOLVE_EXIT_CODE -eq 124 ]]; then
@@ -722,7 +722,7 @@ jobs:
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
           # Subsequent cleanup steps run regardless via if:always().
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \
-            python3 .remote-dev-bot/lib/resolve.py
+            python3 -u .remote-dev-bot/lib/resolve.py
           RESOLVE_EXIT_CODE=$?
 
           if [[ $RESOLVE_EXIT_CODE -eq 124 ]]; then


### PR DESCRIPTION
## Problem

Python buffers stdout when running in a non-TTY environment (such as a
GitHub Actions runner). When the runner process is killed by SIGTERM — for
example when a job timeout fires — the buffer is never flushed. Every
`print()` call inside `resolve.py` that hadn't yet been written out is
silently discarded.

The practical consequence: every crash or timeout shows up in the Actions
log with **no error messages at all**, making failures impossible to
diagnose.

## Fix

Add `-u` to the two `python3` invocations that call `resolve.py`:

```yaml
# before
python3 .remote-dev-bot/lib/resolve.py

# after
python3 -u .remote-dev-bot/lib/resolve.py
```

The `-u` flag disables Python's internal output buffering, forcing stdout
and stderr to be written out line-by-line in real time. Output will now
survive SIGTERM, job cancellation, and unexpected crashes.

## Scope

Only the two `resolve.py` invocations are changed (resolve mode at line 294
and build/workshop/rdb-test mode at line 725). All other `python3` calls —
`generate_index.py`, inline `-c` snippets, heredoc scripts, etc. — are left
untouched.

## Test plan

- [ ] Trigger a run that hits the timeout; confirm resolve.py log output
  appears in the Actions log up to the point of SIGTERM
- [ ] Verify normal (non-timeout) runs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)