### PR TITLE
Repeat wrapup injection on every remaining iteration

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1338,7 +1338,6 @@ jobs:
           # Graceful wrapup settings
           wrapup_enabled = os.environ.get("REVIEW_WRAPUP_ENABLED", "true").lower() == "true"
           wrapup_iteration = int(os.environ.get("REVIEW_WRAPUP_ITERATION", "0") or "0")
-          wrapup_injected = False
 
           # Context trimming
           context_keep_tool_results = int(os.environ.get("REVIEW_CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
@@ -1655,7 +1654,7 @@ jobs:
               # Graceful wrapup: at 80% of max_iterations, inject a user message
               # telling the agent to wrap up and call submit_review with what it has.
               if (wrapup_enabled and wrapup_iteration > 0
-                      and not wrapup_injected and iteration + 1 >= wrapup_iteration):
+                      and iteration + 1 >= wrapup_iteration):
                   remaining = max_iterations - (iteration + 1)
                   messages.append({
                       "role": "user",
@@ -1667,7 +1666,6 @@ jobs:
                           "Do not start new lines of inquiry."
                       ),
                   })
-                  wrapup_injected = True
 
           # Save usage data for the cost comment step
           with open("/tmp/llm_usage.json", "w") as f:
@@ -2015,7 +2013,6 @@ jobs:
           # Graceful wrapup settings
           wrapup_enabled = os.environ.get("DESIGN_WRAPUP_ENABLED", "true").lower() == "true"
           wrapup_iteration = int(os.environ.get("DESIGN_WRAPUP_ITERATION", "0") or "0")
-          wrapup_injected = False
 
           # Context trimming
           context_keep_tool_results = int(os.environ.get("DESIGN_CONTEXT_KEEP_TOOL_RESULTS", "0") or "0")
@@ -2294,7 +2291,7 @@ jobs:
               # Graceful wrapup: at 80% of max_iterations, inject a user message
               # telling the agent to wrap up and call submit_analysis with what it has.
               if (wrapup_enabled and wrapup_iteration > 0
-                      and not wrapup_injected and iteration + 1 >= wrapup_iteration):
+                      and iteration + 1 >= wrapup_iteration):
                   remaining = max_iterations - (iteration + 1)
                   messages.append({
                       "role": "user",
@@ -2306,7 +2303,6 @@ jobs:
                           "Do not start new lines of inquiry."
                       ),
                   })
-                  wrapup_injected = True
 
           # Save usage data for the cost comment step
           with open("/tmp/llm_usage.json", "w") as f:

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -914,7 +914,7 @@ def main():
             # Inject live wrapup message when the threshold is reached.
             # This is more effective than the system prompt hint alone — the agent
             # is deep in context by this point and needs a fresh, visible reminder.
-            if WRAPUP_ENABLED and WRAPUP_ITERATION > 0 and iteration + 1 == WRAPUP_ITERATION:
+            if WRAPUP_ENABLED and WRAPUP_ITERATION > 0 and iteration + 1 >= WRAPUP_ITERATION:
                 remaining = MAX_ITERATIONS - WRAPUP_ITERATION
                 print(f"  [Wrapup] Injecting wrapup message at iteration {iteration + 1}")
                 messages.append({


### PR DESCRIPTION
The wrapup message was previously injected only once (at exactly WRAPUP_ITERATION). Agents acknowledged it but then continued working through the remaining iterations trying to perfect their solution, ultimately running out without pushing. By firing on every remaining iteration from WRAPUP_ITERATION onward, the agent gets escalating "N iterations remain -- push NOW" pressure that is much harder to ignore. Affects resolve loop (resolve.py) and the inline review/design loops in the workflow.

## Changes

- `lib/resolve.py`: Change `iteration + 1 == WRAPUP_ITERATION` to `iteration + 1 >= WRAPUP_ITERATION`
- `.github/workflows/remote-dev-bot.yml` (review loop): Remove `not wrapup_injected and` guard, `wrapup_injected = True` assignment, and `wrapup_injected = False` init
- `.github/workflows/remote-dev-bot.yml` (design loop): Same removals as review loop

Generated with [Claude Code](https://claude.com/claude-code)
