### PR TITLE
Remove stale OpenHands references from docs

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,1 +1,0 @@
-**Read AGENTS.md in the repository root now before doing anything else.** It contains project conventions, key files, dev cycle, PR policy, and code style guidelines that govern all work in this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Three separate GitHub identities are used so each role is cleanly separated:
 - Installed on all `gnovak` repos (blanket install). Only repos with `RDB_APP_PRIVATE_KEY` secret actually use it. Currently configured on: `gnovak/remote-dev-bot`, `gnovak/remote-dev-bot-test`
 - Permissions (all Read & write): Contents, Issues, Pull Requests, Workflows, Actions, Checks
   - **Workflows** is included because this app devs rdb itself, so the agent may need to modify `.github/workflows/` files. Regular rdb users should *not* grant this — the runbook intentionally omits it.
-  - **Actions + Checks** are included so the agent can inspect CI logs and check run results when debugging ("PR XYZ is failing, dig into the logs"). The OpenHands sandbox has `gh` CLI and GitHub API access, so these work. Regular rdb users don't need these unless they specifically want the agent to debug CI.
+  - **Actions + Checks** are included so the agent can inspect CI logs and check run results when debugging ("PR XYZ is failing, dig into the logs"). The agent sandbox has `gh` CLI and GitHub API access, so these work. Regular rdb users don't need these unless they specifically want the agent to debug CI.
 - Webhooks: inactive (tokens are generated on-demand via `actions/create-github-app-token`)
 - Private key stored as `RDB_APP_PRIVATE_KEY` secret; App ID stored as `RDB_APP_ID` variable
 
@@ -189,9 +189,9 @@ the `e2e-test` branch pointer works and how to trigger test runs.
 #### Keeping defaults in sync
 
 `lib/config.py` and `scripts/compile.py` both have a fallback default for
-`openhands.version` (used when the config file has no `openhands` section).
-These must stay in sync. Both currently default to `"1.4.0"`. Each has a
-`# NOTE: keep in sync` comment pointing to the other.
+`agent.version` (used when the config file has no `agent` section).
+These must stay in sync. Each has a `# NOTE: keep in sync` comment pointing
+to the other.
 
 ### E2E tests (`tests/e2e.sh`)
 

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -49,11 +49,10 @@ This is the "engine" — the shared infrastructure that all target repos use.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, installs OpenHands, resolves issues, creates PRs. Target repos call this. |
-| `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and OpenHands settings (version, max iterations, PR type). |
+| `.github/workflows/remote-dev-bot.yml` | The reusable workflow. Contains all the logic: parses model aliases, runs the LiteLLM agent loop, resolves issues, creates PRs. Target repos call this. |
+| `remote-dev-bot.yaml` | Base configuration. Defines model aliases (`claude-small`, `claude-large`, etc.) and agent settings (max iterations, PR type). |
 | `.github/workflows/agent.yml` | Shim workflow. Also serves as the template — copy this to target repos. |
-| `lib/workshop.py` | Council logic for workshop and build modes: runs each council model, posts critique or code review comments. |
-| `runbook.md` | Step-by-step setup instructions for humans or AI assistants. |
+| `install.md` | Step-by-step setup instructions for humans or AI assistants. |
 
 **Who maintains this:** The upstream maintainer (gnovak), or you if you forked it. Updates here automatically flow to all target repos that reference it.
 
@@ -65,7 +64,7 @@ This is where you want the AI agent to help with development.
 |------|---------|
 | `.github/workflows/agent.yml` | **Required.** The shim workflow. Triggers on `/agent-resolve`, `/agent-design`, `/agent-review`, `/agent-workshop`, and `/agent-build` comments and calls `remote-dev-bot.yml` from remote-dev-bot. This is the only workflow file you need. |
 | `remote-dev-bot.yaml` | **Optional.** Override config. Add model aliases, change settings, or override defaults for this specific repo. Merged on top of the base config. |
-| `.openhands/microagents/repo.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. You can also use `AGENTS.md` or `CLAUDE.md` and add them to `context_files` in your `remote-dev-bot.yaml`. |
+| `AGENTS.md` / `CLAUDE.md` | **Optional.** Context for the AI agent. Describe your codebase, coding conventions, test commands, architecture — anything the agent should know. Add them to `extra_files` in your `remote-dev-bot.yaml` so the agent reads them before starting work. |
 
 **Repository Secrets (required):**
 
@@ -90,7 +89,7 @@ When someone comments `/agent-resolve-claude-large` on an issue:
 4. **Config merge** — base config from remote-dev-bot is merged with any override config in the target repo
 5. **Model resolution** — The alias `claude-large` is resolved to a model ID like `anthropic/claude-opus-4-5`
 6. **Feedback** — A rocket emoji is added to your comment and you're assigned to the issue, so you can see at a glance which issues have active work
-7. **Agent runs** — OpenHands reads the issue, explores the codebase, makes changes
+7. **Agent runs** — LiteLLM agent loop (resolve.py) reads the issue, explores the codebase, makes changes
 8. **PR created** — A draft (or ready) PR is opened with the changes
 
 For `/agent-workshop` and `/agent-build`, steps 1–6 are identical. Step 7 runs the same agent loop (design or resolve), then `lib/workshop.py` runs each council model in sequence and posts a review comment. The bot pauses there; no further automation happens until a human triggers the next command.
@@ -174,8 +173,8 @@ the command in their GitHub comment:
 ```
 /agent-resolve
 max iterations = 75
-target branch = my-feature
-context_files = docs/architecture.md extra-context.md
+branch = my-feature
+extra_files = docs/architecture.md extra-context.md
 ```
 
 **How it works:**
@@ -186,10 +185,10 @@ context_files = docs/architecture.md extra-context.md
 
 | Argument | Applies to | Description |
 |----------|-----------|-------------|
-| `max_iterations` | `openhands.max_iterations` | Override iteration limit for this run |
-| `target_branch` | `openhands.target_branch` | Override target branch for this run |
-| `timeout_minutes` | `openhands.timeout_minutes` | Override watchdog timeout for this run |
-| `context_files` | the mode's `context_files` | Append extra files (space-separated) — does not replace existing list |
+| `max_iterations` | `agent.max_iterations` | Override iteration limit for this run |
+| `branch` | `agent.branch` | Override target branch for this run |
+| `timeout_minutes` | `agent.timeout_minutes` | Override watchdog timeout for this run |
+| `extra_files` | the mode's `extra_files` | Add files (space-separated) — appended to base and config-layer lists |
 
 Unknown argument names are rejected with an error comment.
 
@@ -232,7 +231,7 @@ same org, `secrets: inherit` will work.
 
 ### Advanced: GitHub App setup
 
-A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and triggers CI on bot PRs. See [runbook.md](runbook.md) for step-by-step setup instructions.
+A GitHub App gives the bot a distinct identity (e.g., `remote-dev-bot[bot]`) and triggers CI on bot PRs. See [install.md](install.md) for step-by-step setup instructions.
 
 ### Advanced: PAT setup
 
@@ -276,8 +275,8 @@ repo workflows). Set the Actions access level as described in step 3.
 
 | I want to... | Where |
 |--------------|-------|
-| Set up a new repo to use the bot | Follow [runbook.md](runbook.md) |
+| Set up a new repo to use the bot | Follow [install.md](install.md) |
 | Change the default model for my repo | `remote-dev-bot.yaml` in target repo |
-| Give the agent context about my codebase | `.openhands/microagents/repo.md` in target repo |
+| Give the agent context about my codebase | `AGENTS.md` / `CLAUDE.md` via `extra_files` in `remote-dev-bot.yaml` |
 | Override a setting for a single run | Inline args in the trigger comment (see above) |
 


### PR DESCRIPTION
## Summary

- A silent auto-merge in `31625fd` (merging main into dev) dropped v0.6.0's OpenHands-to-agent rename from several doc sections. The dev branch had reformatted the same lines, so git's 3-way merge silently chose dev's stale content without flagging a conflict.
- Fixes 8 stale OpenHands references in `how-it-works.md`, 2 in `CONTRIBUTING.md`
- Also fixes stale `runbook.md` → `install.md` links and `target_branch`/`context_files` → `branch`/`extra_files` arg names
- Deletes `.openhands/microagents/repo.md` which was never removed in v0.6.0

## Test plan

- [ ] Verify no unexpected `openhands` references remain: `git grep -i openhands -- '*.md' | grep -v CHANGELOG | grep -v AGENTS.md`
- [ ] Verify no `runbook.md` references remain: `git grep runbook -- '*.md'`
- [ ] Spot-check how-it-works.md reads correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)