### PR TITLE
feat: Anthropic OAuth token support for Claude Pro/Max (#414)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -33,6 +33,8 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: false
+      ANTHROPIC_AUTH_TOKEN:
+        required: false
       OPENAI_API_KEY:
         required: false
       GEMINI_API_KEY:
@@ -207,13 +209,19 @@ jobs:
           }
 
           if [[ "$MODEL" == anthropic/* ]]; then
+            AUTH_TOKEN="${{ secrets.ANTHROPIC_AUTH_TOKEN }}"
             API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-            if [[ -z "$API_KEY" ]]; then
+            # OAuth token takes precedence over API key.
+            if [[ -n "$AUTH_TOKEN" ]]; then
+              echo "key=$AUTH_TOKEN" >> "$GITHUB_OUTPUT"
+              echo "anthropic_auth_via=oauth" >> "$GITHUB_OUTPUT"
+            elif [[ -n "$API_KEY" ]]; then
+              echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
+            else
               post_no_api_key_comment "ANTHROPIC_API_KEY"
-              echo "::error::No ANTHROPIC_API_KEY secret configured for model: $MODEL"
+              echo "::error::No ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN secret configured for model: $MODEL"
               exit 1
             fi
-            echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
           elif [[ "$MODEL" == openai/* ]]; then
             API_KEY="${{ secrets.OPENAI_API_KEY }}"
             if [[ -z "$API_KEY" ]]; then
@@ -250,6 +258,7 @@ jobs:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
@@ -695,13 +704,19 @@ jobs:
           }
 
           if [[ "$MODEL" == anthropic/* ]]; then
+            AUTH_TOKEN="${{ secrets.ANTHROPIC_AUTH_TOKEN }}"
             API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-            if [[ -z "$API_KEY" ]]; then
+            # OAuth token takes precedence over API key.
+            if [[ -n "$AUTH_TOKEN" ]]; then
+              echo "key=$AUTH_TOKEN" >> "$GITHUB_OUTPUT"
+              echo "anthropic_auth_via=oauth" >> "$GITHUB_OUTPUT"
+            elif [[ -n "$API_KEY" ]]; then
+              echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
+            else
               post_no_api_key_comment "ANTHROPIC_API_KEY"
-              echo "::error::No ANTHROPIC_API_KEY secret configured for model: $MODEL"
+              echo "::error::No ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN secret configured for model: $MODEL"
               exit 1
             fi
-            echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
           elif [[ "$MODEL" == openai/* ]]; then
             API_KEY="${{ secrets.OPENAI_API_KEY }}"
             if [[ -z "$API_KEY" ]]; then
@@ -738,6 +753,7 @@ jobs:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
@@ -903,6 +919,7 @@ jobs:
       - name: Run council code review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
@@ -1312,13 +1329,19 @@ jobs:
           }
 
           if [[ "$MODEL" == anthropic/* ]]; then
+            AUTH_TOKEN="${{ secrets.ANTHROPIC_AUTH_TOKEN }}"
             API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-            if [[ -z "$API_KEY" ]]; then
+            # OAuth token takes precedence over API key.
+            if [[ -n "$AUTH_TOKEN" ]]; then
+              echo "key=$AUTH_TOKEN" >> "$GITHUB_OUTPUT"
+              echo "anthropic_auth_via=oauth" >> "$GITHUB_OUTPUT"
+            elif [[ -n "$API_KEY" ]]; then
+              echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
+            else
               post_no_api_key_comment "ANTHROPIC_API_KEY"
-              echo "::error::No ANTHROPIC_API_KEY secret configured for model: $MODEL"
+              echo "::error::No ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN secret configured for model: $MODEL"
               exit 1
             fi
-            echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
           elif [[ "$MODEL" == openai/* ]]; then
             API_KEY="${{ secrets.OPENAI_API_KEY }}"
             if [[ -z "$API_KEY" ]]; then
@@ -1419,6 +1442,7 @@ jobs:
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
@@ -2030,13 +2054,19 @@ jobs:
           }
 
           if [[ "$MODEL" == anthropic/* ]]; then
+            AUTH_TOKEN="${{ secrets.ANTHROPIC_AUTH_TOKEN }}"
             API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-            if [[ -z "$API_KEY" ]]; then
+            # OAuth token takes precedence over API key.
+            if [[ -n "$AUTH_TOKEN" ]]; then
+              echo "key=$AUTH_TOKEN" >> "$GITHUB_OUTPUT"
+              echo "anthropic_auth_via=oauth" >> "$GITHUB_OUTPUT"
+            elif [[ -n "$API_KEY" ]]; then
+              echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
+            else
               post_no_api_key_comment "ANTHROPIC_API_KEY"
-              echo "::error::No ANTHROPIC_API_KEY secret configured for model: $MODEL"
+              echo "::error::No ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN secret configured for model: $MODEL"
               exit 1
             fi
-            echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
           elif [[ "$MODEL" == openai/* ]]; then
             API_KEY="${{ secrets.OPENAI_API_KEY }}"
             if [[ -z "$API_KEY" ]]; then
@@ -2093,6 +2123,7 @@ jobs:
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
@@ -2679,13 +2710,19 @@ jobs:
           }
 
           if [[ "$MODEL" == anthropic/* ]]; then
+            AUTH_TOKEN="${{ secrets.ANTHROPIC_AUTH_TOKEN }}"
             API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-            if [[ -z "$API_KEY" ]]; then
+            # OAuth token takes precedence over API key.
+            if [[ -n "$AUTH_TOKEN" ]]; then
+              echo "key=$AUTH_TOKEN" >> "$GITHUB_OUTPUT"
+              echo "anthropic_auth_via=oauth" >> "$GITHUB_OUTPUT"
+            elif [[ -n "$API_KEY" ]]; then
+              echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
+            else
               post_no_api_key_comment "ANTHROPIC_API_KEY"
-              echo "::error::No ANTHROPIC_API_KEY secret configured for model: $MODEL"
+              echo "::error::No ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN secret configured for model: $MODEL"
               exit 1
             fi
-            echo "key=$API_KEY" >> "$GITHUB_OUTPUT"
           elif [[ "$MODEL" == openai/* ]]; then
             API_KEY="${{ secrets.OPENAI_API_KEY }}"
             if [[ -z "$API_KEY" ]]; then
@@ -2743,6 +2780,7 @@ jobs:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           LLM_MODEL: ${{ needs.parse.outputs.model }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}

--- a/install.md
+++ b/install.md
@@ -292,7 +292,7 @@ least one key for whichever provider you want to use.
 > a separate key for each one and name it after the repo (e.g.,
 > "remote-dev-bot-myrepo"). This is optional — most users share one key.
 
-**For Anthropic (Claude models):**
+**For Anthropic (Claude models) — API key:**
 
 1. Go to https://console.anthropic.com/settings/keys
 2. Click "+ Create Key"
@@ -300,6 +300,25 @@ least one key for whichever provider you want to use.
 4. Leave the workspace as "Default" (unless you have a specific workspace)
 5. Click "Add"
 6. **Copy the key immediately** — you won't be able to see it again
+
+**For Anthropic (Claude models) — Claude Pro/Max subscription (OAuth token):**
+
+If you have a Claude Pro or Max subscription you can use it instead of a
+pay-per-token API key.  Store your OAuth token as `ANTHROPIC_AUTH_TOKEN`
+instead of `ANTHROPIC_API_KEY`.  If both are set, `ANTHROPIC_AUTH_TOKEN`
+takes precedence.
+
+To generate an OAuth token:
+
+1. Install Claude Code: `npm install -g @anthropic-ai/claude-code`
+2. Run `claude` and log in with your Claude Pro/Max account
+3. Run `claude setup-token` to generate an OAuth token
+4. Store the token as the `ANTHROPIC_AUTH_TOKEN` secret (see Step 2.3)
+
+> **Note:** OAuth tokens expire after approximately one hour.  For long-running
+> GitHub Actions workflows, generate a fresh token immediately before the
+> workflow runs, or keep a regular `ANTHROPIC_API_KEY` as a fallback.  Future
+> versions may add automatic token refresh.
 
 **For OpenAI (GPT models):**
 
@@ -430,6 +449,10 @@ assistant's shell) so you can paste the key when prompted.
 # Set the API key for whichever provider(s) you're using:
 gh secret set ANTHROPIC_API_KEY --repo {owner}/{repo}
 # Paste your Anthropic API key when prompted, then press Enter
+
+# --- OR, if using a Claude Pro/Max subscription OAuth token instead: ---
+gh secret set ANTHROPIC_AUTH_TOKEN --repo {owner}/{repo}
+# Paste the token from `claude setup-token` when prompted
 
 gh secret set OPENAI_API_KEY --repo {owner}/{repo}
 gh secret set GEMINI_API_KEY --repo {owner}/{repo}

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -20,11 +20,32 @@ import sys
 import time
 
 import litellm
-from litellm import completion
+from litellm import completion as _litellm_completion
 
 # Ensure the rdb root is on sys.path so `lib.context` is importable when
 # resolve.py runs from a target repo's working directory.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_ANTHROPIC_AUTH_TOKEN = os.environ.get("ANTHROPIC_AUTH_TOKEN", "")
+
+def completion(*args, **kwargs):
+    """Wrapper around litellm.completion that supports Anthropic OAuth tokens.
+
+    When ANTHROPIC_AUTH_TOKEN is set (a Claude Pro/Max subscription OAuth token),
+    injects an Authorization: Bearer header so the Anthropic API authenticates via
+    OAuth rather than the X-Api-Key mechanism used for regular API keys.
+    ANTHROPIC_AUTH_TOKEN takes precedence over ANTHROPIC_API_KEY.
+    """
+    if _ANTHROPIC_AUTH_TOKEN:
+        model = kwargs.get("model", args[0] if args else "")
+        if model.startswith(("anthropic/", "claude")):
+            headers = dict(kwargs.get("extra_headers") or {})
+            headers["Authorization"] = f"Bearer {_ANTHROPIC_AUTH_TOKEN}"
+            kwargs["extra_headers"] = headers
+            # Provide a non-empty api_key so LiteLLM doesn't raise on missing key;
+            # Anthropic will authenticate via the Bearer header instead.
+            kwargs.setdefault("api_key", _ANTHROPIC_AUTH_TOKEN)
+    return _litellm_completion(*args, **kwargs)
 
 from lib.context import compact_messages, completion_with_retries, estimate_tokens
 


### PR DESCRIPTION
## Summary

- Accept `ANTHROPIC_AUTH_TOKEN` as an alternative to `ANTHROPIC_API_KEY` for Anthropic models; OAuth token takes precedence if both are set
- All 5 job types (resolve, build, council + multi-step variants) updated
- `resolve.py` wraps `litellm.completion()` to inject `Authorization: Bearer` header when the OAuth token is present — Anthropic's API uses this for Pro/Max subscription auth
- `install.md` documents the setup: `claude setup-token` → store as `ANTHROPIC_AUTH_TOKEN` secret

## How it works

LiteLLM normally sends `X-Api-Key` for Anthropic. OAuth tokens (`sk-ant-oat01-*`) don't work as API keys — they need `Authorization: Bearer`. The wrapper in `resolve.py` detects Anthropic model names and adds the Bearer header via `extra_headers` while also setting `api_key` to a non-empty value to prevent LiteLLM from raising on missing key.

## Testing needed

- [ ] Generate an OAuth token with `claude setup-token`, store as `ANTHROPIC_AUTH_TOKEN` secret, trigger a resolve with an `anthropic/*` model
- [ ] Verify it works when only `ANTHROPIC_AUTH_TOKEN` is set (no `ANTHROPIC_API_KEY`)
- [ ] Verify `ANTHROPIC_API_KEY` still works normally when `ANTHROPIC_AUTH_TOKEN` is absent

## Known limitations

- OAuth tokens expire (~1 hour); for long runs, a fresh token should be generated before the workflow runs
- `distill.py` imports `litellm.completion` directly and would need the same wrapper if `DISTILL_ENABLED=true` + OAuth token are used together (that feature is off by default)

Fixes #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)