### PR TITLE
Fix cost comment diff stats: capture agent_start_sha after branch setup

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -287,12 +287,11 @@ jobs:
           TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
           echo $(date +%s) > /tmp/start_time
-          # Capture HEAD before the agent runs so post-run diff steps use the
-          # correct base regardless of branch name or remote structure.
-          git rev-parse HEAD > /tmp/agent_start_sha
-
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
           # Subsequent cleanup steps run regardless via if:always().
+          # /tmp/agent_start_sha is written by resolve.py/setup_branch() after
+          # branching from TARGET_BRANCH — gives correct diff base even when
+          # the workflow checkout lands on a different branch (e.g. main).
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \
             python3 -u .remote-dev-bot/lib/resolve.py
           RESOLVE_EXIT_CODE=$?
@@ -520,8 +519,8 @@ jobs:
           elapsed = int(time.time()) - _st
           output_text = open("/tmp/spr_output.log").read() if os.path.exists("/tmp/spr_output.log") else ""
           import subprocess as _sp, re as _re
-          # Use the SHA captured before the agent started so diff is always
-          # "what the agent changed", not "everything since origin/main".
+          # SHA written by resolve.py/setup_branch() after branching — reflects
+          # the true diff base regardless of what the workflow checked out.
           _base = open('/tmp/agent_start_sha').read().strip() if os.path.exists('/tmp/agent_start_sha') else None
           _base_ref = _base or '$(git merge-base HEAD origin/main)'
           _dp = _sp.run(f'git diff {_base_ref} HEAD 2>/dev/null || echo ""', shell=True, capture_output=True, text=True)
@@ -782,12 +781,11 @@ jobs:
           TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
           echo $(date +%s) > /tmp/start_time
-          # Capture HEAD before the agent runs so post-run diff steps use the
-          # correct base regardless of branch name or remote structure.
-          git rev-parse HEAD > /tmp/agent_start_sha
-
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
           # Subsequent cleanup steps run regardless via if:always().
+          # /tmp/agent_start_sha is written by resolve.py/setup_branch() after
+          # branching from TARGET_BRANCH — gives correct diff base even when
+          # the workflow checkout lands on a different branch (e.g. main).
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \
             python3 -u .remote-dev-bot/lib/resolve.py
           RESOLVE_EXIT_CODE=$?
@@ -1131,8 +1129,8 @@ jobs:
           elapsed = int(time.time()) - _st
           output_text = open("/tmp/spr_output.log").read() if os.path.exists("/tmp/spr_output.log") else ""
           import subprocess as _sp, re as _re
-          # Use the SHA captured before the agent started so diff is always
-          # "what the agent changed", not "everything since origin/main".
+          # SHA written by resolve.py/setup_branch() after branching — reflects
+          # the true diff base regardless of what the workflow checked out.
           _base = open('/tmp/agent_start_sha').read().strip() if os.path.exists('/tmp/agent_start_sha') else None
           _base_ref = _base or '$(git merge-base HEAD origin/main)'
           _dp = _sp.run(f'git diff {_base_ref} HEAD 2>/dev/null || echo ""', shell=True, capture_output=True, text=True)

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -138,6 +138,19 @@ def setup_branch():
         branch = _find_available_branch(ISSUE_NUMBER)
         run(f"git checkout -b {branch}")
 
+    # Record the current HEAD as the diff base for post-run cost metrics.
+    # This must happen after branch setup: for issue triggers the workflow's
+    # initial checkout lands on the default branch (main), but the agent
+    # branches from TARGET_BRANCH (e.g. dev), so capturing HEAD here — after
+    # `git checkout -b` — gives the correct base. For PR triggers the PR
+    # branch is checked out directly, so HEAD is also correct here.
+    import subprocess as _subprocess
+    sha = _subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout.strip()
+    with open("/tmp/agent_start_sha", "w") as _f:
+        _f.write(sha)
+
     return branch
 
 


### PR DESCRIPTION
## Summary

The cost comment on agent-created PRs was reporting inflated diff stats (e.g. 1805 insertions vs 145 actual in PR #437).

**Root cause:** The workflow wrote `/tmp/agent_start_sha` via `git rev-parse HEAD` *before* running `resolve.py`. For issue triggers, `HEAD` at that point is the workflow's initial checkout — typically `main` for `issue_comment` events. But `setup_branch()` then does `git checkout {TARGET_BRANCH} && git checkout -b {new-branch}`, so the feature branch starts from `TARGET_BRANCH` (e.g. `dev`). The post-run diff computed `git diff <main-sha> HEAD`, pulling in all `main`→`dev` divergence on top of the agent's actual work.

**Fix:** Move the `/tmp/agent_start_sha` write into `setup_branch()` in `resolve.py`, right after the working branch is checked out. At that point `HEAD` is exactly the parent commit of the new branch — the correct base for both issue triggers (after `git checkout -b`) and PR triggers (after `gh pr checkout`). The now-redundant workflow-level writes are removed.

## Test plan

- [ ] 344 unit tests pass (verified locally)
- [ ] Dogfood a simple issue and confirm the diff stats in the cost comment match GitHub's PR diff view

Fixes #439