### PR TITLE
Add Diff/LOC$/Info$ rows to reconcile job cost comment (#446)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -2210,50 +2210,90 @@ jobs:
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODEL="${{ needs.parse.outputs.model }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
-          ELAPSED=$(( $(date +%s) - $(cat /tmp/start_time 2>/dev/null || date +%s) ))
-          ELAPSED_FMT=$(python3 -c "s=${ELAPSED}; print(f'{s//60}m {s%60}s' if s >= 60 else f'{s}s')")
-          if [ -f /tmp/llm_usage.json ]; then
-            read INPUT_TOKENS OUTPUT_TOKENS COST ITERATIONS < <(python3 -c "
-          import json
-          d = json.load(open('/tmp/llm_usage.json'))
-          print(d.get('input_tokens', 0), d.get('output_tokens', 0), d.get('cost') or 0, d.get('iterations', 0))
-          ")
-          else
-            INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
-          fi
           MAX_ITER="${{ needs.parse.outputs.max_iterations }}"
-          ITERATIONS_FMT=$(python3 -c "
-          max_i = '${MAX_ITER}'
-          iters = '${ITERATIONS}'
-          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
-          ")
-          ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
-          IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
-          def fmt(n):
+
+          python3 << 'PYEOF'
+          import json, math, os, gzip, time
+          def _fmt_tok(n):
+              n = int(n)
               if n >= 1_000_000:
                   v = n / 1_000_000
-                  return f'{round(v)}M' if v >= 10 else f'{round(v, 1)}M'
+                  return f"{round(v)}M" if v >= 10 else f"{round(v, 1)}M"
               elif n >= 1_000:
                   v = n / 1_000
-                  return f'{round(v)}K' if v >= 10 else f'{round(v, 1)}K'
+                  return f"{round(v)}K" if v >= 10 else f"{round(v, 1)}K"
               return str(n)
-          print(fmt(${INPUT_TOKENS}), fmt(${OUTPUT_TOKENS}), sep='\t')
-          ")
-          {
-            echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
-            echo ""
-            echo "---"
-            echo ""
-            echo "### 💰 Cost"
-            echo ""
-            echo "| Metric | Value |"
-            echo "|--------|-------|"
-            echo "| Time | ${ELAPSED_FMT} |"
-            echo "| Iterations | ${ITERATIONS_FMT} |"
-            echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
-            echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
-            printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
-          } > /tmp/cost_comment.md
+          def _fmt_ela(s):
+              s = int(s)
+              return f"{s // 60}m {s % 60}s" if s >= 60 else f"{s}s"
+          def _fmt_bpd(text, cost):
+              if cost <= 0: return 'N/A'
+              data = text.encode('utf-8') if isinstance(text, str) else text
+              bpd = (len(gzip.compress(data)) * 8) / cost  # bits per dollar
+              if bpd >= 1_000_000: return f"{bpd / 1_000_000:.1f} Mbit/$"
+              return f"{bpd / 1_000:.1f} Kbit/$"
+          if os.path.exists("/tmp/llm_usage.json"):
+              _d = json.load(open("/tmp/llm_usage.json"))
+              input_tokens = _d.get('input_tokens', 0)
+              output_tokens = _d.get('output_tokens', 0)
+              cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
+          else:
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("MAX_ITER", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
+          try:
+              _st = int(open('/tmp/start_time').read().strip())
+          except Exception:
+              _st = int(time.time())
+          elapsed = int(time.time()) - _st
+          import subprocess as _sp, re as _re
+          # SHA written by reconcile.py/setup_branch() after branching — reflects
+          # the true diff base regardless of what the workflow checked out.
+          _base = open('/tmp/agent_start_sha').read().strip() if os.path.exists('/tmp/agent_start_sha') else None
+          _base_ref = _base or '$(git merge-base HEAD origin/main)'
+          _dp = _sp.run(f'git diff {_base_ref} HEAD 2>/dev/null || echo ""', shell=True, capture_output=True, text=True)
+          diff_text = _dp.stdout or ''
+          _ss = _sp.run(f'git diff --shortstat {_base_ref} HEAD 2>/dev/null || echo ""', shell=True, capture_output=True, text=True)
+          shortstat = _ss.stdout.strip()
+          loc_changed = 0
+          _m = _re.search(r"(\d+) insertion", shortstat)
+          if _m: loc_changed += int(_m.group(1))
+          _m = _re.search(r"(\d+) deletion", shortstat)
+          if _m: loc_changed += int(_m.group(1))
+          bits_text = diff_text
+          rounded = math.ceil(cost * 100) / 100
+          def _fmt_loc(n):
+              if n >= 1_000_000: return f"{n/1_000_000:.1f}M"
+              if n >= 1_000: return f"{n/1_000:.1f}k"
+              return str(n)
+          alias = os.environ.get("ALIAS", "")
+          model = os.environ.get("MODEL", "")
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('Diff', shortstat if shortstat else 'N/A'),
+              ('LOC/$', f'{_fmt_loc(int(loc_changed / cost))} loc/$' if cost > 0 and loc_changed > 0 else 'N/A'),
+              ('Info/$', _fmt_bpd(bits_text, cost)),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
+          lines = [
+              f'🤖 **Model:** `{alias}` (`{model}`)',
+              '',
+              '---',
+              '',
+              '### 💰 Cost',
+              '',
+              '| Metric | Value |',
+              '|--------|-------|',
+          ]
+          lines += [f'| {k} | {v} |' for k, v in rows]
+          open('/tmp/cost_comment.md', 'w').write('\n'.join(lines) + '\n')
+          PYEOF
+
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --body-file /tmp/cost_comment.md

--- a/lib/reconcile.py
+++ b/lib/reconcile.py
@@ -488,6 +488,7 @@ At that point only {remaining} iteration(s) remain. If the rebase is not complet
 def main():
     print(f"Setting up branch for PR #{PR_NUMBER}...")
     branch, head_sha = setup_branch()
+    open('/tmp/agent_start_sha', 'w').write(head_sha)
     print(f"Working on branch: {branch} (HEAD: {head_sha[:8]})")
 
     # Gather repository context


### PR DESCRIPTION
## Summary

- `lib/reconcile.py`: write `head_sha` from `setup_branch()` to `/tmp/agent_start_sha` immediately after the call at line 490, so the workflow step has a correct diff base
- `.github/workflows/remote-dev-bot.yml`: replace the shell-based "Post cost comment" step in the reconcile job with a Python block matching the resolve job's approach — reads `/tmp/agent_start_sha`, computes `git diff --shortstat`, and adds Diff, LOC/$, and Info/$ rows to the cost table

## Test plan

- [ ] All 344 existing tests pass (`python3 -m pytest tests/ -x -q`)
- [ ] Trigger a reconcile run and verify the cost comment includes Diff, LOC/$, and Info/$ rows
- [ ] Verify the comment still posts correctly when `/tmp/agent_start_sha` does not exist (falls back to `git merge-base HEAD origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)