### PR TITLE
Add no_op() tool so agents can signal intentional no-change

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -380,7 +380,40 @@ jobs:
           fi
 
           SUCCESS=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('true' if d.get('success') else 'false')")
+          NO_OP=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('true' if d.get('no_op') else 'false')")
           EXPLANATION=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print(d.get('explanation',''))")
+
+          if [[ "$NO_OP" == "true" ]]; then
+            {
+              echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
+              echo ""
+              echo "### ℹ️ No change needed"
+              echo ""
+              echo "The agent investigated this issue and determined that no code change is required."
+              echo ""
+              if [[ -n "$EXPLANATION" ]]; then
+                echo "**Agent's findings:**"
+                echo ""
+                echo "$EXPLANATION"
+                echo ""
+              fi
+              echo "### 💰 Cost"
+              echo ""
+              echo "| Metric | Value |"
+              echo "|--------|-------|"
+              echo "| Time | ${ELAPSED_FMT} |"
+              echo "| Iterations | ${ITERATIONS_FMT} |"
+              echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
+              echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
+              printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
+            } > /tmp/noop_comment.md
+
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/noop_comment.md
+            echo "cost embedded" > /tmp/cost_embedded
+            exit 0
+          fi
 
           if [[ "$SUCCESS" == "false" ]]; then
             DRAFT_PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
@@ -433,7 +466,7 @@ jobs:
             iters="unknown"
           fi
           if [ -f /tmp/resolve_status.json ]; then
-            success=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('✅' if d.get('success') else '❌')")
+            success=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('✅ (no change needed)' if d.get('no_op') else ('✅' if d.get('success') else '❌'))")
             explanation=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print(d.get('explanation','')[:200])")
           else
             success="❓"
@@ -876,7 +909,40 @@ jobs:
           fi
 
           SUCCESS=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('true' if d.get('success') else 'false')")
+          NO_OP=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('true' if d.get('no_op') else 'false')")
           EXPLANATION=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print(d.get('explanation',''))")
+
+          if [[ "$NO_OP" == "true" ]]; then
+            {
+              echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
+              echo ""
+              echo "### ℹ️ No change needed"
+              echo ""
+              echo "The agent investigated this issue and determined that no code change is required."
+              echo ""
+              if [[ -n "$EXPLANATION" ]]; then
+                echo "**Agent's findings:**"
+                echo ""
+                echo "$EXPLANATION"
+                echo ""
+              fi
+              echo "### 💰 Cost"
+              echo ""
+              echo "| Metric | Value |"
+              echo "|--------|-------|"
+              echo "| Time | ${ELAPSED_FMT} |"
+              echo "| Iterations | ${ITERATIONS_FMT} |"
+              echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
+              echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
+              printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
+            } > /tmp/noop_comment.md
+
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/noop_comment.md
+            echo "cost embedded" > /tmp/cost_embedded
+            exit 0
+          fi
 
           if [[ "$SUCCESS" == "false" ]]; then
             DRAFT_PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
@@ -930,6 +996,12 @@ jobs:
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
 
           if [[ -z "$PR_URL" ]]; then
+            # Check if this was an intentional no-op — if so, skip silently
+            NO_OP=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')) if __import__('os').path.exists('/tmp/resolve_status.json') else {}; print('true' if d.get('no_op') else 'false')")
+            if [[ "$NO_OP" == "true" ]]; then
+              echo "Agent signaled no_op — no PR to review. Skipping council review."
+              exit 0
+            fi
             echo "No PR URL found — resolve may have failed. Posting notice and skipping council review."
             gh issue comment "$ISSUE_NUMBER" \
               --repo "$GITHUB_REPO" \
@@ -1045,7 +1117,7 @@ jobs:
             iters="unknown"
           fi
           if [ -f /tmp/resolve_status.json ]; then
-            success=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('✅' if d.get('success') else '❌')")
+            success=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print('✅ (no change needed)' if d.get('no_op') else ('✅' if d.get('success') else '❌'))")
             explanation=$(python3 -c "import json; d=json.load(open('/tmp/resolve_status.json')); print(d.get('explanation','')[:200])")
           else
             success="❓"

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -524,6 +524,7 @@ Each commit message should describe what that unit of work does — treat them a
   - For issue triggers: the workflow creates a PR from your branch to the target branch
   - For PR triggers: the workflow records the PR URL; no new PR is created
 - If you cannot complete: call `finish(success=False, explanation="...")` describing what you tried and why it failed
+- **If investigation shows no change is needed**: call `no_op(reason="...")` instead of finish(). Use this when the code is already correct, the reported bug does not exist, or the requested change should deliberately not be made. The workflow will post your explanation as a comment and mark the run as success without creating a PR. Do NOT call finish(success=True) with empty commits in this case.
 - Before calling finish: verify your changes work (run tests if they exist, check the code compiles)
 
 **PR title**: Use imperative mood describing the change, not the issue number.
@@ -750,6 +751,33 @@ TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "no_op",
+            "description": (
+                "Signal that the investigation is complete and no code change is needed. "
+                "Use this when you have investigated the issue and determined that the code "
+                "is already correct, the reported problem does not exist, or the requested "
+                "change should not be made. "
+                "The workflow will post an explanatory comment on the issue and mark the "
+                "run as success without creating a PR."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Clear explanation of what was investigated and why no change "
+                            "is needed. This will be posted as a comment on the issue."
+                        ),
+                    },
+                },
+                "required": ["reason"],
+            },
+        },
+    },
 ]
 
 
@@ -940,10 +968,13 @@ def build_cost_table():
     return "\n".join(lines)
 
 
-def write_status(success, explanation):
+def write_status(success, explanation, no_op=False):
     """Write resolve status to /tmp/resolve_status.json."""
+    payload = {"success": success, "explanation": explanation}
+    if no_op:
+        payload["no_op"] = True
     with open("/tmp/resolve_status.json", "w") as f:
-        json.dump({"success": success, "explanation": explanation}, f)
+        json.dump(payload, f)
 
 
 def write_usage(input_tokens, output_tokens, cost, iterations,
@@ -1260,6 +1291,10 @@ def main():
                     finish_args = arguments
                     done = True
                     tool_result = "finish() received. Task loop ending."
+                elif tool_name == "no_op":
+                    finish_args = {"_no_op": True, "reason": arguments.get("reason", "")}
+                    done = True
+                    tool_result = "no_op() received. Task loop ending."
                 else:
                     tool_result = execute_tool(tool_name, arguments)
 
@@ -1533,6 +1568,13 @@ def main():
                 _pr_created = True
             except Exception as e:
                 print(f"Could not create draft PR: {e}")
+        return
+
+    # Handle no_op: agent investigated and determined no change is needed
+    if finish_args.get("_no_op"):
+        reason = finish_args.get("reason", "")
+        write_status(True, reason, no_op=True)
+        print(f"Agent signaled no_op: {reason}")
         return
 
     success = finish_args.get("success", False)

--- a/tests/test_no_op.py
+++ b/tests/test_no_op.py
@@ -1,0 +1,175 @@
+"""Tests for the no_op() tool behavior in lib/resolve.py.
+
+resolve.py reads ISSUE_NUMBER from os.environ at import time, so we must
+patch the environment before the module is imported. We do this once at
+module level using importlib so each test shares the already-imported module.
+"""
+
+import importlib
+import io
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, mock_open
+
+import pytest
+
+# Ensure the repo root is on sys.path
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Import resolve.py with the required env vars set so module-level code succeeds.
+_ENV_PATCH = patch.dict(
+    os.environ,
+    {
+        "ISSUE_NUMBER": "456",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "LLM_MODEL": "anthropic/claude-3-5-sonnet-20241022",
+    },
+)
+_ENV_PATCH.start()
+import lib.resolve as resolve_mod  # noqa: E402  (after env patch)
+_ENV_PATCH.stop()
+
+
+def _call_write_status_to_temp(tmp_path, *args, **kwargs):
+    """Call write_status but redirect /tmp/resolve_status.json to tmp_path."""
+    real_status = tmp_path / "resolve_status.json"
+    _real_open = io.open  # capture un-patched open
+
+    def _redirect_open(path, mode="r", **kw):
+        if path == "/tmp/resolve_status.json":
+            return _real_open(str(real_status), mode, **kw)
+        return _real_open(path, mode, **kw)
+
+    with patch("builtins.open", side_effect=_redirect_open):
+        resolve_mod.write_status(*args, **kwargs)
+
+    return real_status
+
+
+# ---------------------------------------------------------------------------
+# write_status with no_op flag
+# ---------------------------------------------------------------------------
+
+def test_write_status_no_op_sets_flag(tmp_path):
+    """write_status with no_op=True writes no_op: true to the status file."""
+    status_path = _call_write_status_to_temp(tmp_path, True, "no change needed", no_op=True)
+    data = json.loads(status_path.read_text())
+    assert data["success"] is True
+    assert data["no_op"] is True
+    assert data["explanation"] == "no change needed"
+
+
+def test_write_status_no_op_false_omits_flag(tmp_path):
+    """write_status without no_op does not include no_op key in output."""
+    status_path = _call_write_status_to_temp(tmp_path, True, "task complete")
+    data = json.loads(status_path.read_text())
+    assert "no_op" not in data
+
+
+def test_write_status_no_op_default_is_false(tmp_path):
+    """write_status no_op parameter defaults to False (key absent from JSON)."""
+    status_path = _call_write_status_to_temp(tmp_path, False, "failed")
+    data = json.loads(status_path.read_text())
+    assert "no_op" not in data
+
+
+def test_write_status_no_op_json_structure(tmp_path):
+    """write_status with no_op=True produces the expected exact JSON structure."""
+    status_path = _call_write_status_to_temp(
+        tmp_path, True, "The code is already correct", no_op=True
+    )
+    data = json.loads(status_path.read_text())
+    assert data == {
+        "success": True,
+        "explanation": "The code is already correct",
+        "no_op": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# no_op tool in TOOLS list
+# ---------------------------------------------------------------------------
+
+def test_no_op_tool_in_tools_list():
+    """The TOOLS list must include a no_op tool definition."""
+    tool_names = [t["function"]["name"] for t in resolve_mod.TOOLS]
+    assert "no_op" in tool_names
+
+
+def test_no_op_tool_has_reason_parameter():
+    """The no_op tool must accept a 'reason' parameter that is required."""
+    no_op_tool = next(
+        t for t in resolve_mod.TOOLS if t["function"]["name"] == "no_op"
+    )
+    params = no_op_tool["function"]["parameters"]
+    assert "reason" in params["properties"]
+    assert "reason" in params["required"]
+
+
+def test_finish_tool_still_present():
+    """The finish tool must still be present alongside no_op."""
+    tool_names = [t["function"]["name"] for t in resolve_mod.TOOLS]
+    assert "finish" in tool_names
+
+
+# ---------------------------------------------------------------------------
+# System prompt mentions no_op
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_mentions_no_op():
+    """The GIT_INSTRUCTIONS constant must mention no_op."""
+    assert "no_op" in resolve_mod.GIT_INSTRUCTIONS
+
+
+def test_system_prompt_no_op_explains_when_to_use():
+    """GIT_INSTRUCTIONS must explain when to use no_op vs finish."""
+    assert "no change is needed" in resolve_mod.GIT_INSTRUCTIONS or \
+           "no change needed" in resolve_mod.GIT_INSTRUCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Workflow YAML — no_op detection in Post result comment
+# ---------------------------------------------------------------------------
+
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "remote-dev-bot.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow_content():
+    return WORKFLOW_PATH.read_text()
+
+
+def test_workflow_detects_no_op_flag(workflow_content):
+    """The workflow YAML must extract NO_OP from resolve_status.json."""
+    # There should be at least two occurrences (two resolve job variants)
+    assert workflow_content.count("no_op") >= 2, (
+        "Expected at least 2 occurrences of 'no_op' in workflow YAML"
+    )
+
+
+def test_workflow_no_op_comment_text(workflow_content):
+    """The workflow must post a 'No change needed' comment for no_op runs."""
+    assert "No change needed" in workflow_content
+
+
+def test_workflow_no_op_skips_council_review(workflow_content):
+    """The workflow council review step must silently skip when no_op=true."""
+    # Verify the no_op check appears before the council review error message
+    no_op_idx = workflow_content.index("Agent signaled no_op")
+    council_error_idx = workflow_content.index("did not produce a pull request")
+    assert no_op_idx < council_error_idx, (
+        "no_op silent-skip should appear before the council error message"
+    )
+
+
+def test_workflow_no_op_exits_zero(workflow_content):
+    """The no_op branch in Post result comment must exit 0 (success)."""
+    # Find the no_op block and verify it has 'exit 0'.
+    # The block spans ~1200 chars (includes the gh comment call before exit 0).
+    noop_section_start = workflow_content.index('if [[ "$NO_OP" == "true" ]]')
+    block = workflow_content[noop_section_start:noop_section_start + 1400]
+    assert "exit 0" in block, "no_op block must exit with code 0"


### PR DESCRIPTION
## Summary

- Adds a `no_op(reason)` tool to `lib/resolve.py` that agents can call when investigation shows no code change is needed
- Updates both resolve job variants in the workflow to detect `no_op: true` in `resolve_status.json`, post an explanatory "No change needed" comment, skip PR creation, and exit success
- Silently skips the council code review step when `no_op` is set (avoiding spurious "no PR produced" notices)
- Adds 13 tests in `tests/test_no_op.py` covering the write_status flag, TOOLS list, system prompt, and workflow YAML behavior

## Test plan

- [x] `python -m pytest tests/` — 357 tests pass (344 existing + 13 new)
- [ ] Trigger a resolve run on an issue where no change is needed; verify the agent calls `no_op()`, the run shows success, and the issue gets a "No change needed" comment with the agent's explanation
- [ ] Verify no PR is created and no "no commits" error appears in the logs

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)