### PR TITLE
Add safety-net push step after agent exits to prevent lost work

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -307,6 +307,25 @@ jobs:
 
           exit $RESOLVE_EXIT_CODE
 
+      - name: Safety-net push
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+        run: |
+          # If the agent made commits but forgot to push, or exhausted iterations without
+          # calling finish(), save the work now. Skipped for no_op runs (nothing to push).
+          NO_OP=$(python3 -c "import json,os; d=json.load(open('/tmp/resolve_status.json')) if os.path.exists('/tmp/resolve_status.json') else {}; print('true' if d.get('no_op') else 'false')" 2>/dev/null || echo "false")
+          if [[ "$NO_OP" == "true" ]]; then
+            echo "no_op run — skipping safety-net push"
+            exit 0
+          fi
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "WIP: auto-saved by workflow (agent did not commit before exiting)"
+            echo "Committed uncommitted changes"
+          fi
+          git push origin HEAD 2>/dev/null || echo "Push failed or nothing to push"
+
       - name: Post result comment
         if: always()
         env:
@@ -835,6 +854,25 @@ jobs:
           fi
 
           exit $RESOLVE_EXIT_CODE
+
+      - name: Safety-net push
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+        run: |
+          # If the agent made commits but forgot to push, or exhausted iterations without
+          # calling finish(), save the work now. Skipped for no_op runs (nothing to push).
+          NO_OP=$(python3 -c "import json,os; d=json.load(open('/tmp/resolve_status.json')) if os.path.exists('/tmp/resolve_status.json') else {}; print('true' if d.get('no_op') else 'false')" 2>/dev/null || echo "false")
+          if [[ "$NO_OP" == "true" ]]; then
+            echo "no_op run — skipping safety-net push"
+            exit 0
+          fi
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "WIP: auto-saved by workflow (agent did not commit before exiting)"
+            echo "Committed uncommitted changes"
+          fi
+          git push origin HEAD 2>/dev/null || echo "Push failed or nothing to push"
 
       - name: Post result comment
         if: always()


### PR DESCRIPTION
If the agent exhausts all iterations without calling `finish()`, or commits locally but forgets to push, all work is permanently lost when the runner shuts down. This adds a `Safety-net push` step (with `if: always()`) that runs after the agent exits in both resolve job variants:

1. Checks if it's a `no_op` run — skips if so (nothing to push by design)
2. `git add -A` + commits any uncommitted changes with a WIP message
3. Pushes to the branch

If there's nothing new to push the step is effectively a no-op. Complements PR #459 (final-iteration wrapup escalation): that nudges the agent to call `finish()` properly; this saves work unconditionally as a fallback.