### PR TITLE
Update gpt-small to GPT-5.3-Codex-Spark

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -106,8 +106,8 @@ models:
     description: "Most capable — for complex multi-file features"
 
   gpt-small:
-    id: openai/gpt-5.1-codex-mini
-    description: "OpenAI GPT-5.1 Codex Mini — good default"
+    id: openai/gpt-5.3-codex-spark
+    description: "OpenAI GPT-5.3 Codex Spark — fast, >1000 tok/s"
 
   gpt-large:
     id: openai/gpt-5.3-codex


### PR DESCRIPTION
## Summary
- Update `gpt-small` model from `openai/gpt-5.1-codex-mini` to `openai/gpt-5.3-codex-spark`
- GPT-5.3-Codex-Spark is the current fast/cheap OpenAI coding model (>1000 tok/s)

## Test plan
- [ ] Trigger `/agent-resolve-gpt-small` on a test issue and verify it uses the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)