### PR TITLE
Fix: pass app token to checkout so agents can push workflow files

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -23,6 +23,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  workflows: write
 
 jobs:
   resolve:

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -158,6 +158,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Checkout remote-dev-bot lib
         uses: actions/checkout@v5
@@ -706,6 +708,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Checkout remote-dev-bot lib
         uses: actions/checkout@v5
@@ -1377,6 +1381,7 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v5
         with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           fetch-depth: 0
 
       - name: Checkout remote-dev-bot config
@@ -2096,6 +2101,7 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v5
         with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           fetch-depth: 0
 
       - name: Checkout remote-dev-bot lib
@@ -2426,6 +2432,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5
@@ -3075,6 +3083,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -85,6 +85,50 @@ def test_agent_has_max_iterations(bot_config):
     assert isinstance(bot_config["agent"]["max_iterations"], int)
 
 
+# --- Checkout token checks ---
+
+
+@pytest.fixture
+def workflow_jobs():
+    return load_yaml(REPO_ROOT / ".github/workflows/remote-dev-bot.yml")["jobs"]
+
+
+APP_TOKEN_EXPR = "steps.app-token.outputs.token"
+
+
+def test_all_checkout_target_steps_use_app_token(workflow_jobs):
+    """Every job's 'Checkout target repository' step must pass the app token.
+
+    Without this, actions/checkout configures the git credential with the
+    default github.token, which lacks workflows:write permission. Pushes
+    that touch .github/workflows/ will be rejected by GitHub.
+
+    Regression test for issue #463.
+    """
+    for job_name, job in workflow_jobs.items():
+        for step in job.get("steps", []):
+            if step.get("name") == "Checkout target repository":
+                token = step.get("with", {}).get("token", "")
+                assert APP_TOKEN_EXPR in token, (
+                    f"Job '{job_name}': Checkout target repository must use "
+                    f"the app token (got: {token!r}). Without this, git push "
+                    f"cannot update workflow files."
+                )
+
+
+def test_dogfood_has_workflows_write_permission():
+    """dogfood.yml must include workflows:write so the fallback github.token
+    can push workflow file changes when no app token is configured.
+
+    Regression test for issue #463.
+    """
+    dogfood = load_yaml(REPO_ROOT / ".github/workflows/dogfood.yml")
+    permissions = dogfood.get("permissions", {})
+    assert permissions.get("workflows") == "write", (
+        "dogfood.yml must have 'workflows: write' in permissions"
+    )
+
+
 # --- Security checks ---
 
 


### PR DESCRIPTION
## Summary
- Pass the app token to every job's "Checkout target repository" step in `remote-dev-bot.yml`
- Add `workflows: write` to `dogfood.yml` permissions
- Add regression tests in `test_yaml.py`

## Root cause
The parse job passed the app token to `actions/checkout`, but resolve, build, review, reconcile, design, and workshop jobs did not. Without the token, `actions/checkout` configures the git credential with the default `github.token`, which lacks `workflows:write` permission. Any `git push` touching `.github/workflows/` files was rejected by GitHub.

This is the bug behind #463 — agents could write workflow file changes but couldn't push them.

## Test plan
- [x] `test_all_checkout_target_steps_use_app_token` — verifies every job's checkout passes the app token (structural YAML test, catches regressions if a new job is added without the token)
- [x] `test_dogfood_has_workflows_write_permission` — verifies dogfood.yml includes `workflows: write`
- [x] All 335 tests pass (`test_distill.py` has a pre-existing collection error from #469, unrelated)

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)