### PR TITLE
Fix test_distill.py collection crash on ISSUE_NUMBER import

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -30,7 +30,7 @@ from lib.context import compact_messages, completion_with_retries, estimate_toke
 
 # --- Environment ---
 
-ISSUE_NUMBER = os.environ["ISSUE_NUMBER"]
+ISSUE_NUMBER = os.environ.get("ISSUE_NUMBER", "")
 ISSUE_TYPE = os.environ.get("ISSUE_TYPE", "issue")   # "issue" | "pr"
 TARGET_BRANCH = os.environ.get("TARGET_BRANCH", "main")
 PR_TYPE = os.environ.get("PR_TYPE", "ready")          # "ready" | "draft"


### PR DESCRIPTION
## Summary
- Change `ISSUE_NUMBER = os.environ["ISSUE_NUMBER"]` to `os.environ.get("ISSUE_NUMBER", "")` in `lib/resolve.py`
- Fixes `KeyError: 'ISSUE_NUMBER'` during `pytest` collection of `test_distill.py`

## Root cause
PR #469 added `from lib.resolve import parse_linked_issues` to `test_distill.py`. Since `resolve.py` reads `ISSUE_NUMBER` with `os.environ[]` at module level, importing the module crashes unless the env var is set — which it isn't during local test runs.

## Test plan
- [x] `pytest tests/test_distill.py` — 56 passed (was failing to collect before)
- [x] `pytest tests/` — all 391 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)