### PR TITLE
fix: design/review/workshop respect agent branch config

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1120,6 +1120,7 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v5
         with:
+          ref: ${{ needs.parse.outputs.target_branch }}
           fetch-depth: 0
 
       - name: Checkout remote-dev-bot config
@@ -1834,6 +1835,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5
@@ -2478,6 +2481,8 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5

--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -193,7 +193,10 @@ DEFAULT_SYSTEM_PROMPT = (
     "focus on architecture: components, data flow, key interfaces. Do NOT write implementation-level code.\n"
     "- If the issue is an **implementation spec** (e.g., specific function signatures, config schemas), "
     "go deeper: file-level changes, function signatures, edge cases, test strategy.\n"
-    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n\n"
+    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n"
+    "- If the issue is an **exploratory question** (e.g., feasibility assessment, data availability, "
+    "'is X possible?'), focus on answering the question directly. Explore the codebase and data as needed, "
+    "give a clear answer, and skip the implementation-plan scaffolding.\n\n"
     "Match the level of detail the issue author is asking for — don't over-specify when they want boxes-and-arrows, "
     "and don't under-specify when they want an implementation plan."
 )


### PR DESCRIPTION
## Summary
- Add `ref: target_branch` to the checkout step in the **review**, **design**, and **workshop** jobs so they respect `agent: branch:` config and `branch=` inline args (previously they always checked out the default branch)
- Add an "exploratory question" bullet to the design system prompt so the agent recognizes when an issue asks a question rather than requesting a design plan

## Test plan
- [x] All 312 tests pass
- [ ] Trigger a design invocation with `branch = dev` and verify the agent sees dev branch code
- [ ] Trigger a design invocation with an exploratory question and verify it answers directly without unnecessary design scaffolding

Fixes #475
Ref #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)