### PR TITLE
Fix design/workshop/delegate to check out configured branch (#491)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -2435,6 +2435,16 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ needs.parse.outputs.target_branch }}
+
+      - name: Capture checkout info
+        id: checkout_info
+        run: |
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          SHA=$(git rev-parse --short HEAD)
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Checked out branch=$BRANCH sha=$SHA"
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5
@@ -2916,7 +2926,9 @@ jobs:
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ALIAS="${{ needs.parse.outputs.alias }}"
           MODEL="${{ needs.parse.outputs.model }}"
-          MODEL_HEADER="🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
+          BRANCH="${{ steps.checkout_info.outputs.branch }}"
+          SHA="${{ steps.checkout_info.outputs.sha }}"
+          MODEL_HEADER="🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`) · 📍 **Branch:** \`${BRANCH}\` (\`${SHA}\`)"
 
           # Generate cost table (writes /tmp/cost_table.txt)
           python3 << 'PYEOF'
@@ -3086,6 +3098,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5
@@ -3433,6 +3446,9 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -116,6 +116,37 @@ def test_all_checkout_target_steps_use_app_token(workflow_jobs):
                 )
 
 
+def test_branch_aware_jobs_use_target_branch_ref(workflow_jobs):
+    """design, workshop, and delegate jobs must check out the configured branch.
+
+    Unlike resolve/build/reconcile (which override TARGET_BRANCH and do their own
+    git checkout in setup_branch()), and unlike review (which uses gh pr checkout),
+    these analysis-mode jobs rely entirely on actions/checkout to land on the
+    right branch. Without `ref:`, checkout falls back to the repo default branch
+    (typically main), so an inline arg like `branch=dev` is silently ignored and
+    the agent reads the wrong code.
+
+    Regression test for issue #491.
+    """
+    BRANCH_AWARE_JOBS = {"design", "workshop", "delegate"}
+    EXPECTED_REF = "needs.parse.outputs.target_branch"
+    for job_name in BRANCH_AWARE_JOBS:
+        job = workflow_jobs.get(job_name)
+        assert job, f"Expected job '{job_name}' in workflow"
+        found = False
+        for step in job.get("steps", []):
+            if step.get("name") == "Checkout target repository":
+                found = True
+                ref = step.get("with", {}).get("ref", "")
+                assert EXPECTED_REF in ref, (
+                    f"Job '{job_name}': Checkout target repository must set "
+                    f"ref to '{{{{ {EXPECTED_REF} }}}}' (got: {ref!r}). "
+                    f"Without this, the agent reads from the default branch "
+                    f"instead of the configured/inline branch."
+                )
+        assert found, f"Job '{job_name}' has no 'Checkout target repository' step"
+
+
 def test_dogfood_has_workflows_write_permission():
     """dogfood.yml must include workflows:write so the fallback github.token
     can push workflow file changes when no app token is configured.


### PR DESCRIPTION
## Summary

- The `design`, `workshop`, and `delegate` jobs' "Checkout target repository" step had no `ref:`, so they always checked out the repo's default branch (typically `main`). Inline args like `branch=dev` were silently ignored — agents read code from `main` while the user expected `dev`.
- Adds `ref: \${{ needs.parse.outputs.target_branch }}` to all three jobs.
- Adds a `Capture checkout info` step to the design job and surfaces the actual branch + sha in the analysis comment header so users can verify what the agent saw.
- Regression test in `tests/test_yaml.py` covers all three jobs.

## Why this only affected design/workshop/delegate

`resolve`, `build`, and `reconcile` override `TARGET_BRANCH` and re-checkout via `setup_branch()` in `resolve.py`, so the initial workflow checkout doesn't matter. `review` uses `gh pr checkout`. The analysis-mode jobs have no such fallback — they trust the workflow checkout entirely.

## Test plan

- [x] `pytest tests/test_yaml.py -q` — 51 passed (incl. new regression test)
- [x] `pytest tests/ -q` — 414 passed; 2 pre-existing failures in `test_workshop.py` unrelated
- [ ] Dogfood `/agent-design` on issue #491 with `branch = dev` to verify the fix end-to-end and that the new branch header appears

Fixes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)