### PR TITLE
Fix unterminated f-strings in resolve.py cost summary (#497)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,13 +31,12 @@ Remote Dev Bot — a GitHub Action that runs an AI coding agent to resolve issue
 - `lib/context.py` — shared context management: `trim_tool_results` (drop old tool call pairs), `compact_messages` (LLM-summarize oldest messages), `estimate_tokens`
 - `lib/config.py` — config parsing: `parse_invocation`, `parse_args`, `resolve_config`, `normalize_config`, `ALLOWED_ARGS`; called by the workflow and unit tests
 - `lib/feedback.py` — install feedback collection: `InstallReport`, `InstallProblem`, `report_problems`; used during runbook execution
-- `scripts/compile.py` — compiles `remote-dev-bot.yml` → `dist/agent-resolve.yml`, `dist/agent-design.yml`, `dist/agent-review.yml`; finds steps by **name** not index
 
 **Tests** (`tests/`):
 - `test_config.py` — unit tests for all `lib/config.py` functions
 - `test_compaction.py` — unit tests for `lib/context.py` compaction functions
-- `test_compile.py` — tests that compiled outputs contain expected steps
 - `test_yaml.py` — structural/validity tests for YAML files (workflow and config)
+- `test_syntax.py` — `py_compile` check for every .py file under `lib/` and `scripts/`; catches SyntaxErrors that wouldn't be caught by import-based tests
 - `test_cost.py` — tests for cost parsing helpers (`parse_cost_from_comment` bash function in `e2e.sh`)
 - `test_feedback.py` — unit tests for `lib/feedback.py`
 - `e2e.sh` — full E2E test runner; creates issues in `remote-dev-bot-test`, triggers runs, checks results
@@ -58,7 +57,6 @@ pytest tests/ -q
 
 # Specific test file
 pytest tests/test_config.py -v
-pytest tests/test_compile.py -v    # Run after any workflow or compile.py changes
 
 # With doctests
 pytest --doctest-modules lib/config.py
@@ -126,9 +124,7 @@ Each iteration: call `completion(model, messages, tools, max_tokens=16384)` → 
 ### Adding or modifying a workflow step
 
 1. Edit the step in `.github/workflows/remote-dev-bot.yml`
-2. Update `scripts/compile.py` if the step needs to appear in compiled output (compile.py finds steps by name)
-3. Update expected step lists in `tests/test_compile.py` — the step-count tripwire tests will fail if the compiled output doesn't match
-4. Run `pytest tests/test_compile.py -v` to verify
+2. If the step affects branch-aware jobs (design/workshop/delegate) or token plumbing, the assertions in `tests/test_yaml.py` may need updating
 
 ### Adding a new mode
 
@@ -172,12 +168,6 @@ target branch = design/gemini
 - `ALLOWED_ARGS` in `lib/config.py` defines accepted names and types; unknown names are rejected with an error
 - `resolve_config(..., args=...)` applies parsed args on top of YAML config
 - `extra_files` **appends** to the mode's existing list (does not replace)
-
-## compile.py: Three-File Output
-
-`scripts/compile.py` inlines config parsing and selected steps from `remote-dev-bot.yml` into three standalone files: `dist/agent-resolve.yml`, `dist/agent-design.yml`, and `dist/agent-review.yml`. It finds steps by **name** (not index), so reordering steps is safe as long as step names don't change.
-
-**Rule: if you add, remove, or rename a step in remote-dev-bot.yml, update compile.py to match**, then run `pytest tests/test_compile.py -v`. The step-count tripwire tests will catch mismatches.
 
 ## Branch Model
 

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1018,12 +1018,12 @@ def build_cost_table():
         _base = open("/tmp/agent_start_sha").read().strip() if os.path.exists("/tmp/agent_start_sha") else None
         _base_ref = _base or "$(git merge-base HEAD origin/main)"
         _dp = _sp.run(
-            f"git diff {_base_ref} HEAD 2>/dev/null || echo \"\",
+            f"git diff {_base_ref} HEAD 2>/dev/null || echo \"\"",
             shell=True, capture_output=True, text=True, timeout=30,
         )
         diff_text = _dp.stdout or ""
         _ss = _sp.run(
-            f"git diff --shortstat {_base_ref} HEAD 2>/dev/null || echo \"\",
+            f"git diff --shortstat {_base_ref} HEAD 2>/dev/null || echo \"\"",
             shell=True, capture_output=True, text=True, timeout=30,
         )
         shortstat = _ss.stdout.strip()

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,40 @@
+"""Syntax-level checks for Python files in the repo.
+
+Most of `lib/` is invoked as scripts (`python3 lib/resolve.py`) rather than
+imported by tests, so a SyntaxError can ship to `dev` without any test
+catching it. The runtime symptom is a cryptic "agent process exited
+unexpectedly" with $0.00 cost — see issue #497 for the incident that
+motivated this test.
+
+This module compiles every .py file under `lib/` and `scripts/` to catch
+syntax errors at test time instead of in production.
+"""
+
+import py_compile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _python_files():
+    files = []
+    for sub in ("lib", "scripts"):
+        d = REPO_ROOT / sub
+        if d.exists():
+            files.extend(sorted(d.rglob("*.py")))
+    return files
+
+
+@pytest.mark.parametrize(
+    "py_file",
+    _python_files(),
+    ids=lambda p: str(p.relative_to(REPO_ROOT)),
+)
+def test_python_file_compiles(py_file):
+    """Every .py file in lib/ and scripts/ must parse without SyntaxError."""
+    try:
+        py_compile.compile(str(py_file), doraise=True)
+    except py_compile.PyCompileError as e:
+        pytest.fail(f"Syntax error in {py_file.relative_to(REPO_ROOT)}: {e}")


### PR DESCRIPTION
## Summary

- **dev is broken right now.** Two f-strings in `lib/resolve.py` (the git-diff metrics block in the cost summary) are missing their closing quote, so the file won't compile. Every resolve run since #495 merged at 16:21 UTC has been crashing at python startup with "agent process exited unexpectedly" — issue #497 is the dogfood that hit it.
- The fix is two added \`\"\` characters.
- Adds \`tests/test_syntax.py\` which py_compiles every .py under \`lib/\` and \`scripts/\`. Most of \`lib/\` runs as scripts (not imported by tests) so SyntaxErrors weren't surfaced by the existing test suite. Verified this test fails on the broken code and passes on the fix.
- Removes stale references in AGENTS.md to \`scripts/compile.py\` and \`tests/test_compile.py\` (both ripped out long ago).

Fixes #497

## Test plan

- [x] \`pytest tests/test_syntax.py -v\` — 9 passed
- [x] \`pytest tests/ -q\` — 423 passed (was 414, +9 from new test); same 2 pre-existing test_workshop failures, unrelated
- [x] Confirmed the new test catches the bug: \`git stash -- lib/resolve.py && pytest tests/test_syntax.py -k resolve\` fails with the exact SyntaxError from the dogfood log
- [ ] Dogfood any \`/agent-resolve\` to confirm the run actually starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)