### PR TITLE
Block /agent-* inside rdb repo, redirect to /dogfood-* (#499)

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -32,7 +32,58 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Dogfood gate (rdb repo only; no-op elsewhere).
+  #
+  # Inside gnovak/remote-dev-bot itself, `/agent-*` runs against @main
+  # (released code), which is almost always a mistake during development —
+  # you meant /dogfood-* which runs @dev. This gate hard-blocks /agent-* in
+  # the rdb repo and posts a redirect comment.
+  #
+  # For all other repos the gate short-circuits to proceed=true and is
+  # invisible — it adds ~5s to the overall run but no functional change.
+  #
+  # Break-glass: if dev is broken and you need to run @main from inside
+  # the rdb repo, temporarily revert the gate commit on main, invoke
+  # /agent-*, then revert the revert.
+  gate:
+    if: >
+      (github.event.issue || github.event.pull_request) &&
+      (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
+      contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Check dogfood gate
+        id: check
+        run: |
+          if [[ "${{ github.repository }}" == "gnovak/remote-dev-bot" ]]; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post redirect comment
+        if: steps.check.outputs.proceed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RDB_PAT_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          # 👀 reaction on the triggering comment — signals "seen, not acting".
+          # The 🚀 reaction normally added by remote-dev-bot.yml's parse job
+          # won't run here because we never call the reusable workflow.
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST --field content=eyes || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "⚠️ **This is the rdb dev repo.** \`/agent-*\` commands target released \`@main\` code — almost always a mistake during active development.
+
+          Use \`/dogfood-resolve\` (or \`/dogfood-design\`, \`/dogfood-review\`, etc.) to run against \`@dev\` instead.
+
+          <sub>If \`@dev\` is genuinely broken and you need to run \`@main\`, temporarily revert the gate commit on \`main\`. No inline arg exists by design — \`/agent-*\` stays clean of developer-facing flags since users copy this file.</sub>"
+
   resolve:
+    needs: [gate]
     # Security gate: only allow trusted users to trigger agent runs.
     # OWNER = repo owner, COLLABORATOR = explicitly invited, MEMBER = org member.
     # This prevents arbitrary users from triggering runs that consume API credits.
@@ -40,6 +91,7 @@ jobs:
     # Supports both "/agent-resolve" (dash) and "/agent resolve" (space) syntax.
     # Available modes: resolve (fix issue + open PR), design (analysis comment), review (review a PR)
     if: >
+      needs.gate.outputs.proceed == 'true' &&
       (github.event.issue || github.event.pull_request) &&
       (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -285,6 +285,38 @@ def test_agent_yml_has_author_association_gate():
         assert 'github.event.comment.author_association' in content
 
 
+def test_agent_yml_has_dogfood_gate():
+    """agent.yml must hard-block /agent-* inside gnovak/remote-dev-bot.
+
+    Regression test for issue #499. Inside the rdb repo itself, `/agent-*`
+    runs against released `@main` code — almost always a mistake during
+    active development (you meant `/dogfood-*` which runs `@dev`). The gate
+    prevents wasting tokens investigating dev-only bugs on stale code.
+
+    For all other repos the gate short-circuits to proceed=true and is a no-op.
+    """
+    agent_yml_path = REPO_ROOT / ".github/workflows/agent.yml"
+    agent_yml = load_yaml(agent_yml_path)
+    jobs = agent_yml["jobs"]
+
+    assert "gate" in jobs, "agent.yml must have a 'gate' job (issue #499)"
+
+    content = agent_yml_path.read_text()
+    # Gate must key off the rdb repo specifically
+    assert "gnovak/remote-dev-bot" in content
+    assert "proceed=false" in content
+    assert "proceed=true" in content
+
+    # resolve job must depend on the gate and block on its output
+    needs = jobs["resolve"].get("needs")
+    assert needs == "gate" or (isinstance(needs, list) and "gate" in needs), (
+        "resolve job must have `needs: [gate]`"
+    )
+    assert "needs.gate.outputs.proceed" in str(jobs["resolve"].get("if", "")), (
+        "resolve job's `if` must check needs.gate.outputs.proceed"
+    )
+
+
 # --- Loop prevention checks ---
 
 


### PR DESCRIPTION
## Summary

Closes #499.

Inside `gnovak/remote-dev-bot` itself, `/agent-*` runs against released `@main` code — almost always a mistake during active development where you meant `/dogfood-*` which runs `@dev`. This adds a gate job to `agent.yml` that hard-blocks `/agent-*` in this repo and posts a redirect comment.

For all other repos the gate short-circuits to `proceed=true` and is a no-op (~5s overhead, no functional change).

## Design notes

- **No escape hatch / inline arg by design.** `/agent-*` stays clean of developer-facing flags since users copy this file into their repos. The decision rule: user-facing commands (`/agent-*`) get no args; developer-facing ones (`/dogfood-*`) can.
- **Break-glass recovery** if `@dev` is broken and you need `@main` from inside rdb: temporarily revert the gate commit on `main` (`git revert <sha> && git push`), invoke `/agent-*`, then revert the revert. Takes about a minute. This is explicitly cheaper than maintaining a parallel two-job `dogfood.yml` path for a case that shows up maybe once a year.
- The existing `resolve` job gains `needs: [gate]` + `if: needs.gate.outputs.proceed == 'true'`. Nothing downstream changes.

## Targeting main

`agent.yml` is the shim users copy, so this is a main-targeting change. Touches only `agent.yml` and a regression test. No changes to `remote-dev-bot.yml`, `lib/`, or any user-visible interface.

## Test plan

- [x] `pytest tests/test_yaml.py -q` — 48 passed
- [x] YAML parses (`yaml.safe_load`)
- [ ] After merge: comment `/agent-resolve` on any open rdb issue, confirm the gate fires and posts the redirect comment
- [ ] After merge: confirm `/dogfood-resolve` on the same issue still works normally (runs against `@dev` via `dogfood.yml`)