### PR TITLE
Port exploratory-question bullet from #488 to dev

### DIFF
--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -193,7 +193,10 @@ DEFAULT_SYSTEM_PROMPT = (
     "focus on architecture: components, data flow, key interfaces. Do NOT write implementation-level code.\n"
     "- If the issue is an **implementation spec** (e.g., specific function signatures, config schemas), "
     "go deeper: file-level changes, function signatures, edge cases, test strategy.\n"
-    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n\n"
+    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n"
+    "- If the issue is an **exploratory question** (e.g., feasibility assessment, data availability, "
+    "'is X possible?'), focus on answering the question directly. Explore the codebase and data as needed, "
+    "give a clear answer, and skip the implementation-plan scaffolding.\n\n"
     "Match the level of detail the issue author is asking for — don't over-specify when they want boxes-and-arrows, "
     "and don't under-specify when they want an implementation plan."
 )


### PR DESCRIPTION
## Summary

Ports the one substantive piece of PR #488 that never made it to dev: an "exploratory question" calibration bullet in `lib/design_loop.py`'s `DEFAULT_SYSTEM_PROMPT`. This teaches the design agent to answer feasibility/availability questions directly instead of forcing an implementation-plan scaffold.

## Why this PR exists

PR #488 landed on `main` (2026-04-10). It had four changes:

1. Add `ref: target_branch` to `review` job checkout — **no-op**, `review` calls `gh pr checkout` immediately after
2. Add `ref: target_branch` to `design` job checkout — **superseded by #503 on dev**
3. Add `ref: target_branch` to `workshop` job checkout — **superseded by #503 on dev**
4. Add "exploratory question" bullet to `DEFAULT_SYSTEM_PROMPT` — **unique, not on dev**

So (4) is the only thing worth preserving. This PR ports it to dev ahead of the upcoming revert of #488 on main, so the eventual dev→main integration is clean.

## Test plan

- [x] `pytest tests/ -q --ignore=tests/test_workshop.py` — 396 passed (workshop tests are broken on dev, unrelated)
- [ ] Next /agent-design invocation that answers a feasibility question should show the new calibration in the agent's reasoning