### PR TITLE
Revert #488 to clear dev→main merge conflict

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1120,7 +1120,6 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.parse.outputs.target_branch }}
           fetch-depth: 0
 
       - name: Checkout remote-dev-bot config
@@ -1835,8 +1834,6 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5
@@ -2481,8 +2478,6 @@ jobs:
 
       - name: Checkout target repository
         uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Checkout remote-dev-bot config
         uses: actions/checkout@v5

--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -193,10 +193,7 @@ DEFAULT_SYSTEM_PROMPT = (
     "focus on architecture: components, data flow, key interfaces. Do NOT write implementation-level code.\n"
     "- If the issue is an **implementation spec** (e.g., specific function signatures, config schemas), "
     "go deeper: file-level changes, function signatures, edge cases, test strategy.\n"
-    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n"
-    "- If the issue is an **exploratory question** (e.g., feasibility assessment, data availability, "
-    "'is X possible?'), focus on answering the question directly. Explore the codebase and data as needed, "
-    "give a clear answer, and skip the implementation-plan scaffolding.\n\n"
+    "- If the issue is a **bug report**, focus on root-cause analysis and the minimal fix.\n\n"
     "Match the level of detail the issue author is asking for — don't over-specify when they want boxes-and-arrows, "
     "and don't under-specify when they want an implementation plan."
 )


### PR DESCRIPTION
## Summary

Reverts PR #488 (merge commit a894cdf). Purely a history-cleanup PR to make the eventual dev→main integration conflict-free.

## Why

#488 landed on main on 2026-04-10 but was never back-merged to dev. Meanwhile #503 landed on dev (2026-04-11) fixing the same design/workshop checkout bug via a slightly different route. The result: main and dev had divergent fixes in the same files, guaranteeing a messy conflict whenever dev→main next merged.

#488 made four changes. Audit of each:

1. \`ref: target_branch\` on **review** job's Checkout — **no-op.** Review calls \`gh pr checkout\` right after the initial checkout (line 1816 on dev), which overrides whatever ref was set.
2. \`ref: target_branch\` on **design** job's Checkout — **superseded** by #503 on dev.
3. \`ref: target_branch\` on **workshop** job's Checkout — **superseded** by #503 on dev.
4. \`lib/design_loop.py\` exploratory-question bullet in DEFAULT_SYSTEM_PROMPT — **substantive, worth keeping.** Ported to dev separately in #512 (now merged).

So none of #488's content is lost: (1) is a no-op, (2)(3) are already on dev via #503, and (4) is on dev via #512. Reverting on main returns main's state in these files to the pre-#488 baseline, and dev's #503+#512 stack will apply cleanly on the eventual dev→main merge.

## Test plan

- [x] \`pytest tests/test_yaml.py -q\` — 47 passed on the revert branch
- [x] Diff review: revert removes exactly the additions from #488, nothing more
- [ ] Post-merge: verify \`git merge-base origin/main origin/dev\` still points at the v0.8.0 release merge (no new divergence introduced)