### PR TITLE
delegate: agentic Stage 6 + split max_iterations knobs

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -70,6 +70,8 @@ jobs:
       review_context_keep_tool_results: ${{ steps.parse.outputs.review_context_keep_tool_results }}
       workshop_max_iterations: ${{ steps.parse.outputs.workshop_max_iterations }}
       delegate_max_iterations: ${{ steps.parse.outputs.delegate_max_iterations }}
+      delegate_max_design_iterations: ${{ steps.parse.outputs.delegate_max_design_iterations }}
+      design_rounds: ${{ steps.parse.outputs.design_rounds }}
       council_models: ${{ steps.parse.outputs.council_models }}
       extra_instructions: ${{ steps.parse.outputs.extra_instructions }}
       model_extra_instructions: ${{ steps.parse.outputs.model_extra_instructions }}
@@ -3938,6 +3940,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           MAX_ITERATIONS: ${{ needs.parse.outputs.delegate_max_iterations }}
+          MAX_DESIGN_ITERATIONS: ${{ needs.parse.outputs.delegate_max_design_iterations }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
           EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
@@ -3962,6 +3965,9 @@ jobs:
           github_token = os.environ["GITHUB_TOKEN"]
 
           max_iterations = int(os.environ.get("MAX_ITERATIONS", "15") or "15")
+          max_design_iterations = int(
+              os.environ.get("MAX_DESIGN_ITERATIONS", "") or max_iterations
+          )
           wrapup_enabled = os.environ.get("WRAPUP_ENABLED", "true").lower() == "true"
           wrapup_iteration = int(os.environ.get("WRAPUP_ITERATION", "0") or "0")
           design_rounds = int(os.environ.get("DESIGN_ROUNDS", "1") or "1")
@@ -4018,6 +4024,7 @@ jobs:
               council_extra_instructions=council_extra_instructions,
               extra_context=extra_context,
               max_iterations=max_iterations,
+              max_design_iterations=max_design_iterations,
               wrapup_enabled=wrapup_enabled,
               wrapup_iteration=wrapup_iteration,
               post_comment_fn=post_comment,
@@ -4095,7 +4102,7 @@ jobs:
           TARGET_BRANCH_EXPLICIT: ${{ needs.parse.outputs.target_branch_explicit }}
           PR_TYPE: ${{ needs.parse.outputs.pr_type }}
           ON_FAILURE: ${{ needs.parse.outputs.on_failure }}
-          MAX_ITERATIONS: ${{ needs.parse.outputs.max_iterations }}
+          MAX_ITERATIONS: ${{ needs.parse.outputs.delegate_max_iterations }}
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
           STATUS_LOG_INTERVAL: ${{ needs.parse.outputs.status_log_interval }}
@@ -4341,9 +4348,16 @@ jobs:
           PYEOF
 
       # ===================================================================
-      # Stage 6: Code Revision Plan
+      # Stage 6: Agentic Code Revision
+      #
+      # Re-invokes resolve.py against the existing PR branch from Stage 4,
+      # with the Stage 5 council code reviews injected via EXTRA_FILES. The
+      # agent reads the reviews, decides what's worth applying, edits the
+      # code, and commits to the same branch. This replaces the earlier
+      # one-shot "revision plan" LLM call — now the agent actually applies
+      # the revisions instead of just describing them.
       # ===================================================================
-      - name: Run code revision plan (Stage 6)
+      - name: Run agentic code revision (Stage 6)
         if: steps.check_abort.outputs.abort != 'true'
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
@@ -4351,9 +4365,26 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_USERNAME: ${{ github.repository_owner }}
+          GIT_USERNAME: ${{ github.repository_owner }}
+          E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
+          TARGET_BRANCH: ${{ needs.parse.outputs.target_branch }}
+          TARGET_BRANCH_EXPLICIT: ${{ needs.parse.outputs.target_branch_explicit }}
+          PR_TYPE: ${{ needs.parse.outputs.pr_type }}
+          ON_FAILURE: ${{ needs.parse.outputs.on_failure }}
+          MAX_ITERATIONS: ${{ needs.parse.outputs.delegate_max_iterations }}
+          WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
+          WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
+          STATUS_LOG_INTERVAL: ${{ needs.parse.outputs.status_log_interval }}
+          ALIAS: ${{ needs.parse.outputs.alias }}
+          EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
+          EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.extra_instructions }}
+          MODEL_EXTRA_INSTRUCTIONS: ${{ needs.parse.outputs.model_extra_instructions }}
+          DEBUG_LOGGING: ${{ needs.parse.outputs.debug_logging }}
+          DISTILL_ENABLED: ${{ needs.parse.outputs.distill_enabled }}
           GITHUB_REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
 
@@ -4362,113 +4393,123 @@ jobs:
             exit 0
           fi
 
-          export PR_URL
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "Could not extract PR number from $PR_URL — skipping Stage 6"
+            exit 0
+          fi
+
+          # Format the Stage 5 council reviews as a markdown file so the
+          # revision agent can read them via EXTRA_FILES (resolve.py concatenates
+          # every file in EXTRA_FILES into repo_context).
           python3 << 'PYEOF'
           import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-          sys.path.insert(0, ".remote-dev-bot/lib")
-          from workshop import _run_revision_call, CODE_REVISION_SYSTEM_PROMPT
-
-          model = os.environ["LLM_MODEL"]
-          alias = "${{ needs.parse.outputs.alias }}"
-          github_repo = os.environ["GITHUB_REPO"]
-          github_token = os.environ["GH_TOKEN"]
-          issue_number = os.environ["ISSUE_NUMBER"]
-          pr_url = os.environ.get("PR_URL", "")
-
-          pr_number_match = re.search(r'/pull/(\d+)$', pr_url)
-          if not pr_number_match:
-              print("No PR number found, exiting")
-              sys.exit(0)
-          pr_number = pr_number_match.group(1)
-
-          env = {**os.environ, "GH_TOKEN": github_token}
-
-          # Fetch PR diff
-          diff_result = subprocess.run(
-              ["gh", "api", f"repos/{github_repo}/pulls/{pr_number}",
-               "--header", "Accept: application/vnd.github.diff"],
-              capture_output=True, text=True, env=env,
-          )
-          pr_diff = diff_result.stdout[:40000]
-
-          # Load code reviews from Stage 5
           with open("/tmp/delegate_code_reviews.json") as f:
               reviews = json.load(f)
+          lines = [
+              "# Council Code Reviews",
+              "",
+              "The pull request you just checked out was reviewed by multiple models.",
+              "Read each review, use judgement to decide what's worth acting on, and",
+              "apply the fixes. You may disagree with a reviewer — don't mechanically",
+              "apply every suggestion; weigh them against the original design and spec.",
+              "When done, commit and call finish().",
+              "",
+          ]
+          for r in reviews:
+              alias = r.get("model_alias", "(unknown)")
+              lines.append(f"## Review by {alias}")
+              lines.append("")
+              lines.append(r.get("review", ""))
+              lines.append("")
+              lines.append("---")
+              lines.append("")
+          with open("/tmp/delegate_code_reviews.md", "w") as f:
+              f.write("\n".join(lines))
+          PYEOF
 
-          critiques_text = "\n\n---\n\n".join(
-              f"### Code Review by {r['model_alias']}\n\n{r['review']}"
-              for r in reviews
-          )
+          # Save Stages 1-5 cost totals before resolve.py overwrites
+          # /tmp/llm_usage.json with the Stage 6 numbers.
+          if [[ -f /tmp/llm_usage.json ]]; then
+            cp /tmp/llm_usage.json /tmp/delegate_stages_1_5_usage.json
+          fi
 
-          user_content = (
-              f"## PR Diff\n\n```diff\n{pr_diff}\n```\n\n"
-              f"## Code Reviews\n\n{critiques_text}\n\n"
-              f"---\n\n"
-              f"Please produce a concrete revision plan addressing the code review feedback."
-          )
+          # Append the code reviews (and earlier design/spec artifacts) to
+          # EXTRA_FILES so resolve.py surfaces them as extra context for the
+          # revision agent.
+          EXTRA_FILES=$(python3 -c "
+          import json, os, sys
+          raw = os.environ.get('EXTRA_FILES', '[]') or '[]'
+          files = json.loads(raw)
+          for path in ('/tmp/delegate_revised_design.txt',
+                       '/tmp/delegate_revised_spec.txt',
+                       '/tmp/delegate_code_reviews.md'):
+              if os.path.exists(path):
+                  files.append(path)
+                  print(f'Appended {path}', file=sys.stderr)
+          print(json.dumps(files))
+          ")
+          export EXTRA_FILES
+          echo "Stage 6 EXTRA_FILES: $EXTRA_FILES"
 
-          extra_instructions = "${{ needs.parse.outputs.extra_instructions }}"
-          model_extra_instructions = "${{ needs.parse.outputs.model_extra_instructions }}"
-          combined_instructions = "\n\n".join(p for p in [extra_instructions, model_extra_instructions] if p)
+          # Redirect resolve.py at the existing PR branch: when ISSUE_TYPE=pr,
+          # resolve.py does `gh pr checkout $ISSUE_NUMBER`, commits on that
+          # branch, and (on finish) posts a success comment on the PR.
+          export ISSUE_NUMBER="$PR_NUMBER"
+          export ISSUE_TYPE=pr
 
-          revision_result = _run_revision_call(
-              model_id=model,
-              system_prompt=CODE_REVISION_SYSTEM_PROMPT,
-              user_content=user_content,
-              extra_instructions=combined_instructions,
-              max_tokens=8192,
-          )
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "## 🔄 Delegate Stage 6/6 — Agentic Code Revision
 
-          revision_text = revision_result["text"]
+          Running resolve agent with \`${{ needs.parse.outputs.alias }}\` (\`${{ needs.parse.outputs.model }}\`) to apply council code review feedback to this PR..."
 
-          # Post revision plan as a PR comment
-          def post_pr_comment(body):
-              proc = subprocess.run(
-                  ["gh", "pr", "comment", pr_number,
-                   "--repo", github_repo,
-                   "--body", body],
-                  env=env,
-                  capture_output=True, text=True,
-              )
-              if proc.returncode != 0:
-                  print(f"Warning: failed to post PR comment: {proc.stderr}", file=sys.stderr)
+          TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
+          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          echo "Stage 6 resolver timeout: ${TIMEOUT_MINUTES} minutes"
 
-          post_pr_comment(
-              f"## 🔄 Delegate Stage 6/6 — Code Revision Plan\n\n"
-              f"🤖 **Model:** `{alias}` (`{model}`)\n\n"
-              f"{revision_text}\n\n"
-              f"---\n"
-              f"_Code revision plan by `/agent-delegate` Stage 6 (`{alias}`)_"
-          )
+          timeout --kill-after=60 "$TIMEOUT_SECONDS" \
+            python3 -u .remote-dev-bot/lib/resolve.py
+          STAGE6_EXIT_CODE=$?
 
-          # Also post on the issue for visibility
-          proc = subprocess.run(
-              ["gh", "issue", "comment", issue_number,
-               "--repo", github_repo,
-               "--body", f"## 🔄 Delegate Stage 6/6 — Code Revision Plan\n\nPosted as a comment on {pr_url}"],
-              env=env,
-              capture_output=True, text=True,
-          )
+          if [[ $STAGE6_EXIT_CODE -eq 124 ]]; then
+            echo "::warning::Stage 6 resolver timed out after ${TIMEOUT_MINUTES} minutes. Cleanup steps will still run."
+          fi
 
-          # Merge Stage 6 usage into aggregate
-          existing = {}
+          exit $STAGE6_EXIT_CODE
+
+      - name: Merge Stage 6 costs
+        if: steps.check_abort.outputs.abort != 'true'
+        run: |
+          # resolve.py overwrites /tmp/llm_usage.json with Stage 6 numbers.
+          # Stages 1-5 totals were saved to delegate_stages_1_5_usage.json
+          # just before Stage 6 ran. Combine them into the final cost.
+          python3 << 'PYEOF'
+          import json, os
+
+          stage6 = {}
           if os.path.exists("/tmp/llm_usage.json"):
               with open("/tmp/llm_usage.json") as f:
-                  existing = json.load(f)
+                  stage6 = json.load(f)
+
+          prior = {}
+          if os.path.exists("/tmp/delegate_stages_1_5_usage.json"):
+              with open("/tmp/delegate_stages_1_5_usage.json") as f:
+                  prior = json.load(f)
 
           combined = {
-              "input_tokens": existing.get("input_tokens", 0) + revision_result["input_tokens"],
-              "output_tokens": existing.get("output_tokens", 0) + revision_result["output_tokens"],
-              "cost": (existing.get("cost") or 0.0) + revision_result["cost"],
-              "iterations": existing.get("iterations", 0),
+              "input_tokens": prior.get("input_tokens", 0) + stage6.get("input_tokens", 0),
+              "output_tokens": prior.get("output_tokens", 0) + stage6.get("output_tokens", 0),
+              "cost": (prior.get("cost") or 0.0) + (stage6.get("cost") or 0.0),
+              # Sum Stage 4 + Stage 6 code-writing iterations for the final
+              # display. Both loops share the same delegate_max_iterations cap,
+              # so the raw sum isn't meant to be compared against that cap —
+              # it's a "total code-writing iterations across the pipeline".
+              "iterations": prior.get("iterations", 0) + stage6.get("iterations", 0),
           }
           with open("/tmp/llm_usage.json", "w") as f:
               json.dump(combined, f)
+          print(f"Merged costs: prior ${prior.get('cost', 0):.2f} + Stage 6 ${stage6.get('cost', 0):.2f} = ${combined['cost']:.2f}")
           PYEOF
 
       # ===================================================================

--- a/lib/config.py
+++ b/lib/config.py
@@ -89,7 +89,8 @@ DEFAULT_TIMEOUT_MINUTES = 120
 
 # Arguments that can be overridden via inline args (lines after the command)
 ALLOWED_ARGS = {
-    "max_iterations": int,       # agent.max_iterations
+    "max_iterations": int,       # agent.max_iterations (code-writing stages)
+    "max_design_iterations": int,  # delegate: budget for design/exploration stages
     "timeout_minutes": int,      # agent.timeout_minutes
     "extra_files": list,         # mode's extra_files
     "branch": str,               # agent.branch (target branch for PRs)
@@ -564,7 +565,25 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
     if mode == "reconcile":
         result["reconcile_max_iterations"] = max_iter
     if mode == "delegate":
+        # Delegate has two independent iteration budgets:
+        #   delegate_max_iterations        — code-writing stages (Stage 4 resolve,
+        #                                    Stage 6 agentic code revision)
+        #   delegate_max_design_iterations — design/exploration stages (Stage 1
+        #                                    design, Stage 3a implementation spec)
+        # `delegate_max_iterations` is identical to the already-resolved `max_iter`
+        # (mode.max_iterations with inline arg override). The design budget is a
+        # second independent knob whose fallback chain is:
+        #   inline arg (max_design_iterations) → mode.max_design_iterations
+        #   → agent.max_iterations
+        # Naming rationale: `max_iterations` stays the common/easy name because
+        # users who say "give it more iterations" almost always mean the coding
+        # parts; the design budget gets the explicit name.
         result["delegate_max_iterations"] = max_iter
+        agent_max_iter = oh.get("max_iterations", 50)
+        result["delegate_max_design_iterations"] = args.get(
+            "max_design_iterations",
+            mode_config.get("max_design_iterations", agent_max_iter),
+        )
         # Design rounds for delegate: 1 = design only, 2 = design + implementation spec.
         # Inline arg takes precedence; otherwise fall back to mode config; otherwise 1.
         default_rounds = int(mode_config.get("design_rounds", 1))
@@ -707,6 +726,8 @@ def main():
                 f.write(f"reconcile_max_iterations={result['reconcile_max_iterations']}\n")
             if "delegate_max_iterations" in result:
                 f.write(f"delegate_max_iterations={result['delegate_max_iterations']}\n")
+            if "delegate_max_design_iterations" in result:
+                f.write(f"delegate_max_design_iterations={result['delegate_max_design_iterations']}\n")
             if "design_rounds" in result:
                 f.write(f"design_rounds={result['design_rounds']}\n")
             if "council_models" in result:

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -947,21 +947,6 @@ SPEC_REVISION_SYSTEM_PROMPT = (
     "Output a complete, revised implementation spec (not just a diff from the original)."
 )
 
-CODE_REVISION_SYSTEM_PROMPT = (
-    "You are a senior software engineer. You previously implemented a solution "
-    "for a GitHub issue, and your peers on a code review council have reviewed "
-    "the resulting pull request. Your task is to describe what changes should be "
-    "made to address the code review feedback.\n\n"
-    "Read the original PR diff and each code review carefully. Then produce "
-    "a revision plan that:\n"
-    "- Addresses valid concerns raised by reviewers\n"
-    "- Explains why you rejected any concerns you disagree with\n"
-    "- Incorporates useful suggestions\n"
-    "- Lists specific files and changes to make\n\n"
-    "Be concrete and actionable — the implementation agent will use your plan."
-)
-
-
 def _run_revision_call(
     *,
     model_id,
@@ -1019,6 +1004,7 @@ def run_delegate(
     council_extra_instructions="",
     extra_context="",
     max_iterations=15,
+    max_design_iterations=None,
     wrapup_enabled=True,
     wrapup_iteration=0,
     context_keep_tool_results=0,
@@ -1055,7 +1041,14 @@ def run_delegate(
     extra_context : str
         Additional context for agentic loops.
     max_iterations : int
-        Max iterations for agentic loops (design + resolve).
+        Max iterations for code-writing agentic loops. In delegate mode
+        run_delegate itself never runs a code-writing loop — the
+        Stage 4 resolve step is invoked by the workflow — but callers
+        pass this through for completeness / cost-model symmetry.
+    max_design_iterations : int or None
+        Max iterations for design/exploration agentic loops (Stage 1
+        design loop and Stage 3a implementation spec loop). Falls back
+        to max_iterations when None.
     wrapup_enabled : bool
         Whether graceful wrapup is enabled.
     wrapup_iteration : int
@@ -1090,6 +1083,13 @@ def run_delegate(
         else:
             print(body)
 
+    # Design/exploration budget falls back to the code-writing budget
+    # when the caller doesn't differentiate. Stages 1 and 3a (both
+    # agentic exploration loops) use this; Stages 4 and 6 (code-writing)
+    # are driven by the workflow with max_iterations.
+    if max_design_iterations is None:
+        max_design_iterations = max_iterations
+
     all_input_tokens = 0
     all_output_tokens = 0
     all_cost = 0.0
@@ -1110,7 +1110,7 @@ def run_delegate(
         issue_comments=issue_comments,
         extra_instructions=extra_instructions,
         extra_context=extra_context,
-        max_iterations=max_iterations,
+        max_iterations=max_design_iterations,
         wrapup_enabled=wrapup_enabled,
         wrapup_iteration=wrapup_iteration,
         context_keep_tool_results=context_keep_tool_results,
@@ -1359,7 +1359,7 @@ def run_delegate(
             issue_comments=issue_comments,
             extra_instructions=extra_instructions,
             extra_context=spec_extra_context,
-            max_iterations=max_iterations,
+            max_iterations=max_design_iterations,
             wrapup_enabled=wrapup_enabled,
             wrapup_iteration=wrapup_iteration,
             context_keep_tool_results=context_keep_tool_results,

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -99,7 +99,18 @@ modes:
 
   delegate:
     default_model: claude-small
-    max_iterations: 15       # Iteration limit for the design loop (Stage 1)
+    # Delegate has two independent iteration budgets:
+    #   max_iterations        — code-writing stages (Stage 4 resolve, Stage 6
+    #                           agentic code revision). Same name as elsewhere
+    #                           since it's the knob users typically adjust.
+    #   max_design_iterations — design/exploration stages (Stage 1 design loop,
+    #                           Stage 3a implementation spec loop). Design loops
+    #                           are usually satisfied with fewer iterations than
+    #                           coding loops, so they get a separate default.
+    # Each falls back independently to agent.max_iterations if unset.
+    # Both are settable as inline args in the /agent-delegate comment.
+    max_iterations: 50
+    max_design_iterations: 15
     extra_files:
       - README.md
       - CONTRIBUTING.md

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1860,3 +1860,75 @@ class TestDelegateConfig:
         tmp_path, base_path = delegate_config_dir
         result = resolve_config(base_path, "nonexistent.yaml", "delegate")
         assert "workshop_max_iterations" not in result
+
+    # --- delegate max_design_iterations (design/exploration budget) ---
+    #
+    # Delegate mode has two independent iteration budgets:
+    #   - delegate_max_iterations        — code-writing stages (Stage 4, 6)
+    #   - delegate_max_design_iterations — design/exploration stages (1, 3a)
+    # The design budget falls back to agent.max_iterations when not set
+    # at the mode level. Inline arg `max_design_iterations` overrides both.
+
+    def test_delegate_max_design_iterations_falls_back_to_agent(self, delegate_config_dir):
+        """Without a mode-level default, design budget falls back to agent.max_iterations."""
+        tmp_path, base_path = delegate_config_dir
+        # Fixture has agent.max_iterations = 50 and no
+        # modes.delegate.max_design_iterations — so the design budget
+        # should inherit 50 from the agent section.
+        result = resolve_config(base_path, "nonexistent.yaml", "delegate")
+        assert result["delegate_max_design_iterations"] == 50
+
+    def test_delegate_max_design_iterations_from_mode_config(self, delegate_config_dir):
+        """Mode-level max_design_iterations wins over agent.max_iterations."""
+        tmp_path, base_path = delegate_config_dir
+        with open(base_path) as f:
+            config = yaml.safe_load(f)
+        config["modes"]["delegate"]["max_design_iterations"] = 12
+        with open(base_path, "w") as f:
+            yaml.dump(config, f)
+        result = resolve_config(base_path, "nonexistent.yaml", "delegate")
+        assert result["delegate_max_design_iterations"] == 12
+
+    def test_delegate_max_design_iterations_inline_arg_override(self, delegate_config_dir):
+        """Inline arg max_design_iterations overrides both mode and agent config."""
+        tmp_path, base_path = delegate_config_dir
+        with open(base_path) as f:
+            config = yaml.safe_load(f)
+        config["modes"]["delegate"]["max_design_iterations"] = 12
+        with open(base_path, "w") as f:
+            yaml.dump(config, f)
+        result = resolve_config(
+            base_path, "nonexistent.yaml", "delegate",
+            args={"max_design_iterations": 30},
+        )
+        assert result["delegate_max_design_iterations"] == 30
+
+    def test_delegate_max_iterations_and_design_iterations_are_independent(self, delegate_config_dir):
+        """Bumping max_iterations via inline arg does NOT change max_design_iterations."""
+        tmp_path, base_path = delegate_config_dir
+        with open(base_path) as f:
+            config = yaml.safe_load(f)
+        config["modes"]["delegate"]["max_design_iterations"] = 12
+        with open(base_path, "w") as f:
+            yaml.dump(config, f)
+        # User says "give it more iterations" — the common expectation is
+        # that this bumps the coding loops, not the design loops.
+        result = resolve_config(
+            base_path, "nonexistent.yaml", "delegate",
+            args={"max_iterations": 100},
+        )
+        assert result["delegate_max_iterations"] == 100
+        assert result["delegate_max_design_iterations"] == 12
+
+    def test_delegate_max_design_iterations_not_emitted_for_non_delegate(self, delegate_config_dir):
+        """delegate_max_design_iterations is only emitted in delegate mode."""
+        tmp_path, base_path = delegate_config_dir
+        result = resolve_config(base_path, "nonexistent.yaml", "resolve")
+        assert "delegate_max_design_iterations" not in result
+
+
+def test_parse_args_max_design_iterations():
+    """max_design_iterations should be parsed as int and normalize dashes/spaces."""
+    assert parse_args(["max_design_iterations = 20"]) == {"max_design_iterations": 20}
+    assert parse_args(["max design iterations = 15"]) == {"max_design_iterations": 15}
+    assert parse_args(["max-design-iterations=8"]) == {"max_design_iterations": 8}

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -180,7 +180,6 @@ from unittest.mock import patch, MagicMock
 
 from workshop import (
     DESIGN_REVISION_SYSTEM_PROMPT,
-    CODE_REVISION_SYSTEM_PROMPT,
     _run_revision_call,
     run_delegate,
 )
@@ -199,17 +198,6 @@ class TestRevisionSystemPrompts:
     def test_design_revision_prompt_mentions_council(self):
         lower = DESIGN_REVISION_SYSTEM_PROMPT.lower()
         assert "council" in lower or "critiq" in lower or "feedback" in lower
-
-    def test_code_revision_prompt_nonempty(self):
-        assert len(CODE_REVISION_SYSTEM_PROMPT) > 100
-
-    def test_code_revision_prompt_mentions_code_review(self):
-        lower = CODE_REVISION_SYSTEM_PROMPT.lower()
-        assert "code review" in lower or "code-review" in lower
-
-    def test_code_revision_prompt_mentions_revision(self):
-        lower = CODE_REVISION_SYSTEM_PROMPT.lower()
-        assert "revision" in lower or "changes" in lower
 
 
 class TestRunRevisionCall:
@@ -589,6 +577,75 @@ class TestRunDelegate:
         # Should use the spec system prompt override
         assert "system_prompt" in stage3a_kwargs
         assert stage3a_kwargs["system_prompt"] is not None
+
+    @patch("workshop._run_revision_call")
+    @patch("workshop.run_council_review")
+    @patch("design_loop.run_design_loop")
+    def test_max_design_iterations_threads_into_design_loops(
+        self, mock_design, mock_council, mock_revision
+    ):
+        """run_delegate passes max_design_iterations to design loops, not max_iterations.
+
+        The design budget (Stage 1 design, Stage 3a implementation spec) is
+        independent from the code-writing budget (Stages 4, 6). When a
+        caller differentiates the two, both agentic exploration loops must
+        use the design budget.
+        """
+        mock_design.side_effect = [
+            self._mock_design_result(analysis="## Design\n\nDo X."),
+            self._mock_design_result(analysis="## Spec\n\nFile details."),
+        ]
+        mock_council.return_value = self._mock_council_review()
+        mock_revision.side_effect = [
+            self._mock_revision_result(text="## Revised Design\n\nApproved."),
+            self._mock_revision_result(text="## Revised Spec"),
+        ]
+
+        run_delegate(
+            model="anthropic/test-model",
+            model_alias="test-model",
+            council_models=[{"alias": "claude-small", "id": "anthropic/test"}],
+            issue_title="Test Issue",
+            issue_body="Test body.",
+            max_iterations=80,
+            max_design_iterations=12,
+            design_rounds=2,
+        )
+
+        # Stage 1 design loop
+        _, stage1_kwargs = mock_design.call_args_list[0]
+        assert stage1_kwargs["max_iterations"] == 12
+        # Stage 3a implementation spec loop
+        _, stage3a_kwargs = mock_design.call_args_list[1]
+        assert stage3a_kwargs["max_iterations"] == 12
+
+    @patch("workshop._run_revision_call")
+    @patch("workshop.run_council_review")
+    @patch("design_loop.run_design_loop")
+    def test_max_design_iterations_falls_back_to_max_iterations(
+        self, mock_design, mock_council, mock_revision
+    ):
+        """When max_design_iterations is omitted, design loops inherit max_iterations.
+
+        Callers that don't differentiate (older/simpler entry points) should
+        get uniform behavior — the design loop still gets a sensible budget.
+        """
+        mock_design.return_value = self._mock_design_result()
+        mock_council.return_value = self._mock_council_review()
+        mock_revision.return_value = self._mock_revision_result()
+
+        run_delegate(
+            model="anthropic/test-model",
+            model_alias="test-model",
+            council_models=[{"alias": "claude-small", "id": "anthropic/test"}],
+            issue_title="Test Issue",
+            issue_body="Test body.",
+            max_iterations=25,
+            # max_design_iterations intentionally omitted
+        )
+
+        _, stage1_kwargs = mock_design.call_args_list[0]
+        assert stage1_kwargs["max_iterations"] == 25
 
     @patch("workshop._run_revision_call")
     @patch("workshop.run_council_review")


### PR DESCRIPTION
## Summary

- **Stage 6 is now agentic.** Replaces the one-shot "code revision plan" LLM call with a re-invocation of `resolve.py` against the existing Stage 4 PR branch, with Stage 5 council code reviews injected via `EXTRA_FILES`. The revision agent reads the reviews, decides what to act on, edits code, commits, and pushes — a real second coding pass instead of a dangling document. Closes #518.
- **`max_iterations` splits into two independent knobs** in delegate mode:
  - `max_iterations` — code-writing stages (Stage 4 resolve, Stage 6 agentic revision)
  - `max_design_iterations` — design/exploration stages (Stage 1 design, Stage 3a implementation spec)
  - Both settable as inline args, both fall back independently to `agent.max_iterations` when the mode config omits them. Naming keeps `max_iterations` as the common/easy knob since "give it more iterations" almost always means coding.
- **Status logs inherit for free.** Stage 6 goes through `resolve.py`, which already honors `STATUS_LOG_INTERVAL`. Code-writing stages get rolling progress comments; design/exploration stages still don't (per prior guidance).
- **Dead code removed.** \`CODE_REVISION_SYSTEM_PROMPT\` and its 3 tests — no longer used now that Stage 6 is agentic.
- **Latent fix.** \`design_rounds\` was referenced as \`needs.parse.outputs.design_rounds\` in #520 but never declared as a parse-job output — it silently resolved to an empty string at runtime and only worked due to the \`"1"\` default in the consuming Python. Now properly declared.

## Mechanics

**Stage 6 step:**
1. Extract PR number from \`/tmp/spr_output.log\`
2. Format saved \`delegate_code_reviews.json\` as markdown to \`/tmp/delegate_code_reviews.md\`
3. Save Stages 1-5 \`/tmp/llm_usage.json\` to \`delegate_stages_1_5_usage.json\` (resolve.py will overwrite)
4. Append code reviews + revised design + revised spec to \`EXTRA_FILES\`
5. Export \`ISSUE_TYPE=pr\`, \`ISSUE_NUMBER=<pr number>\`
6. Invoke \`timeout ... python3 resolve.py\` — resolve.py does \`gh pr checkout\`, commits, pushes, posts success comment
7. Follow-up step merges Stages 1-5 + Stage 6 costs back into \`/tmp/llm_usage.json\`

**Iteration budget config:**

\`\`\`yaml
delegate:
  max_iterations: 50          # Stage 4 resolve, Stage 6 agentic revision
  max_design_iterations: 15   # Stage 1 design, Stage 3a spec
\`\`\`

\`run_delegate\` grows a \`max_design_iterations\` kwarg that Stages 1 and 3a use; when omitted it falls back to \`max_iterations\` so \`run_workshop\` and other callers are unaffected.

## Test plan

- [x] \`pytest tests/ -q\` — 441 passing (8 new: 6 config-plumbing, 2 for \`run_delegate\` threading \`max_design_iterations\` into design loops)
- [x] YAML parses, delegate job step ordering correct (Stages 1-3 → abort check → Stage 4 → merge costs → safety push → Stage 5 → Stage 6 → merge Stage 6 costs → post result)
- [ ] E2E: trigger \`/agent-delegate\` on \`remote-dev-bot-test\`; verify Stage 6 applies revisions to the PR branch and the final PR reflects both Stage 4 and Stage 6 commits
- [ ] E2E: \`/agent-delegate\` with \`max_iterations = 80\` inline arg — verify Stage 4 and Stage 6 use 80, Stages 1/3a still use the mode default 15
- [ ] E2E: \`/agent-delegate\` with \`max_design_iterations = 25\` — verify Stages 1/3a use 25, Stages 4/6 use mode default 50
- [ ] E2E: \`/agent-delegate\` with \`design_rounds = 2\` — verify Stage 3a runs (was silently broken due to missing parse output declaration; now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)