### PR TITLE
fix(config): reject design_rounds outside {1, 2} in delegate mode

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -586,8 +586,19 @@ def resolve_config(base_path, override_path, command_string, local_path=None, ti
         )
         # Design rounds for delegate: 1 = design only, 2 = design + implementation spec.
         # Inline arg takes precedence; otherwise fall back to mode config; otherwise 1.
+        # Only 1 and 2 are currently defined; reject anything else loudly rather
+        # than silently clamping to 2 (values >= 3 previously fell through the
+        # `if design_rounds >= 2` branch in run_delegate and behaved identically
+        # to 2, giving users no signal that their request was ignored).
         default_rounds = int(mode_config.get("design_rounds", 1))
-        result["design_rounds"] = int(args.get("design_rounds", default_rounds))
+        design_rounds = int(args.get("design_rounds", default_rounds))
+        if design_rounds not in (1, 2):
+            raise ValueError(
+                f"design_rounds must be 1 or 2, got: {design_rounds}. "
+                f"1 = design only; 2 = design + implementation spec round. "
+                f"Higher values (test plan, risk review, etc.) are not yet defined."
+            )
+        result["design_rounds"] = design_rounds
 
     if mode in ("workshop", "build", "delegate") or (mode == "review" and args.get("council", False)):
         # Council models: explicit list from mode config, or all configured models.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1818,6 +1818,57 @@ class TestDelegateConfig:
         result = resolve_config(base_path, "nonexistent.yaml", "resolve")
         assert "design_rounds" not in result
 
+    # --- design_rounds validation ---
+    #
+    # Only 1 and 2 are defined. Values outside that range must raise
+    # ValueError rather than silently getting clamped or ignored:
+    # run_delegate's branch is `if design_rounds >= 2`, so a user who
+    # types `design_rounds = 3` used to get the same behavior as 2 with
+    # no signal that the extra round they asked for doesn't exist.
+
+    def test_delegate_design_rounds_3_rejected(self, delegate_config_dir):
+        """design_rounds=3 raises ValueError — no third round is defined."""
+        tmp_path, base_path = delegate_config_dir
+        with pytest.raises(ValueError, match="design_rounds must be 1 or 2"):
+            resolve_config(
+                base_path, "nonexistent.yaml", "delegate",
+                args={"design_rounds": 3},
+            )
+
+    def test_delegate_design_rounds_0_rejected(self, delegate_config_dir):
+        """design_rounds=0 raises ValueError — not a valid round count."""
+        tmp_path, base_path = delegate_config_dir
+        with pytest.raises(ValueError, match="design_rounds must be 1 or 2"):
+            resolve_config(
+                base_path, "nonexistent.yaml", "delegate",
+                args={"design_rounds": 0},
+            )
+
+    def test_delegate_design_rounds_negative_rejected(self, delegate_config_dir):
+        """Negative design_rounds raises ValueError."""
+        tmp_path, base_path = delegate_config_dir
+        with pytest.raises(ValueError, match="design_rounds must be 1 or 2"):
+            resolve_config(
+                base_path, "nonexistent.yaml", "delegate",
+                args={"design_rounds": -1},
+            )
+
+    def test_delegate_design_rounds_invalid_mode_config_rejected(self, delegate_config_dir):
+        """An invalid mode-level design_rounds in YAML also raises ValueError.
+
+        Validation applies to the resolved value regardless of whether it
+        came from an inline arg or the merged config — otherwise users
+        could silently ship a bad default.
+        """
+        tmp_path, base_path = delegate_config_dir
+        with open(base_path) as f:
+            config = yaml.safe_load(f)
+        config["modes"]["delegate"]["design_rounds"] = 5
+        with open(base_path, "w") as f:
+            yaml.dump(config, f)
+        with pytest.raises(ValueError, match="design_rounds must be 1 or 2"):
+            resolve_config(base_path, "nonexistent.yaml", "delegate")
+
     def test_delegate_council_models(self, delegate_config_dir):
         """Delegate mode resolves council models from explicit list."""
         tmp_path, base_path = delegate_config_dir


### PR DESCRIPTION
## Summary
- Tighten validation so `design_rounds` outside `{1, 2}` raises `ValueError` at parse time instead of silently collapsing to the same behavior as `2`.
- Validation applies to both inline args and the mode config — a bad YAML default won't ship silently.
- Four new tests in `tests/test_config.py` cover `3`, `0`, negative, and an invalid mode-config value.

## Context
Follow-up to #521 / #518. In delegate mode, `run_delegate`'s branch is `if design_rounds >= 2`, so a user who typed `design_rounds = 3` used to get the same behavior as `2` with no signal that the extra round they asked for doesn't exist. Now the resolver rejects it loudly with a message explaining the current definitions (`1` = design only, `2` = design + implementation spec).

No issue filed for this — it's a small follow-up noticed during review of #521.

## Test plan
- [x] `pytest tests/test_config.py` — 186 config tests pass (4 new)
- [x] `pytest tests/` — 445 tests pass (was 441)