### PR TITLE
experiment: disable tool dropping and bash truncation for baseline data

### DIFF
--- a/design-workspace.md
+++ b/design-workspace.md
@@ -1,0 +1,171 @@
+# Design Workspace: Context & Cost Optimization
+
+Working document for issue #496 — context trimming, tool call drops, caching.
+
+## Status
+
+**Phase: data gathering.** We're turning off existing token-saving measures to
+get clean baseline runs, then deciding what to implement based on real data.
+
+## Background
+
+The dominant cost in long resolve runs is the rolling conversation history being
+re-sent every iteration. With N iterations and ~m tokens per iteration:
+
+- Total input tokens ~ N * prefix + 0.5 * m * N^2 (without trimming)
+- Total input tokens ~ N * prefix + 20 * m * (N - 20) (with keep_n=20 trimming)
+
+The key insight: **trimming tool results defeats caching, and caching is the
+bigger lever.** If the message list is append-only, providers can cache the
+entire conversation prefix — each iteration only pays for the newest turn.
+Today, `trim_tool_results` rewrites assistant messages in the middle of history
+every iteration, invalidating any cache beyond the static system prompt.
+
+## Empirical data
+
+### Run 24283767463 (Apr 11, remote-dev-bot self-dev, 31 iters)
+
+- Model: claude-small (Sonnet 4.6), max_iterations=50, keep_n=20
+- **697K input tokens, 7.3K output tokens, $1.78, 3 min**
+- Trim fired 12 times (iterations 20-31), dropping 1 message per iter
+- Steady-state context: 15-22K tokens per request
+- Tool output sizes: mostly 80-8,100 chars (20-2,000 tokens)
+- No single huge output — cost is from quadratic re-posting of small results
+- Notable: 8 iterations were `sed -n` reads of files the agent already partially
+  read earlier. Truncation at 8K forced multiple follow-up reads.
+
+### Run 24174271003 (Apr 9, bridge-analysis, 63 iters)
+
+- Model: claude-small (Sonnet 4.6), max_iterations=75, keep_n=20
+- **993K input tokens, 12K output tokens, $2.05, 6 min**
+- Similar pattern: small tool outputs, quadratic re-send is the bottleneck
+- Estimated ~575 tokens per tool pair, steady-state ~17.5K per request
+
+## Current token-saving measures (and assessment)
+
+| # | Measure | Config key | Status | Assessment |
+|---|---------|-----------|--------|------------|
+| 1 | **Tool result trimming** | `context_keep_tool_results: 20` | Active | **Harmful.** Defeats caching by rewriting messages mid-history. Saves ~35% of tokens on a 63-iter run, but caching would save 70-80%. Also removes context the agent may need. |
+| 2 | **Bash output truncation** | `bash_output_limit: 8000` | Active | **Probably harmful.** Forces agents into multi-iteration `sed -n` dances to reconstruct files they could have read in one call. The extra iterations cost more than the saved tokens, especially with caching. |
+| 3 | **Context distillation** | `distill_enabled: true` | Active | **Helpful, keep.** One-time pre-pass, doesn't interact with caching. Reduces the static prefix by identifying relevant files. Saves ~$0.89 on a 63-iter run (312K tokens saved). |
+| 4 | **Context compaction** | `max_context_tokens: 0` | Disabled | **Keep disabled.** Each compaction is an LLM call that also invalidates the cache. More useful as a quality lever (summarizing to keep model on track) than a cost lever. |
+| 5 | **Smart drop ordering** | (in trim_tool_results) | Active | **Moot if we stop dropping.** Currently: drop read-only bash first, then file reads, then write results. |
+| 6 | **Cache marker** | (single, on initial user msg) | Active | **Insufficient.** Only caches ~6K of static prefix. Need to advance markers to cover the conversation. |
+
+## Plan: clean baseline runs
+
+**Goal:** See the true tool output size distribution and context growth with no
+artificial limits, so we can make data-driven decisions.
+
+### Config changes for baseline runs
+
+```yaml
+agent:
+  context_keep_tool_results: 0   # disable dropping entirely
+  bash_output_limit: 0           # disable truncation entirely
+  # distill_enabled: true        # keep — doesn't interact with caching
+```
+
+### What to measure
+
+From the baseline runs, we want to know:
+1. **Tool output size distribution.** Histogram of result sizes in chars/tokens.
+   Are there outliers? What's the 95th percentile?
+2. **Context growth curve.** How large does context get with no drops?
+   Does it hit model limits on long runs?
+3. **Iteration count delta.** Do agents need fewer iterations when they can
+   read whole files? (Compare to historical runs on similar tasks.)
+4. **Cache hit rate.** With append-only messages, what fraction of input is
+   cached? (Read from LiteLLM response headers / usage.)
+
+## Design ideas under consideration
+
+### A. No drops + cache markers (primary proposal)
+
+- Stop dropping tool results entirely. Append-only message list.
+- Place cache markers at the conversation tail so the full prefix is cached.
+- Safety valve: only drop if approaching model context limit (e.g., 80% of 200K).
+- When forced to drop, drop largest results first, oldest within each size tier.
+
+**Estimated savings:** 70-80% of input token cost on long runs.
+
+### B. Short-TTL drops for large results only
+
+- Keep small results forever (agent's working memory).
+- Drop large results (above X chars) after K iterations (e.g., 5).
+- Hypothesis: agent reads a big file dump, extracts what it needs in 1-2 iters,
+  then the dump is dead weight.
+
+**Status:** Interesting but possibly unnecessary if caching handles the re-send
+cost. Large results that are cached cost very little to keep. Revisit after
+baseline data.
+
+### C. Raise/remove bash_output_limit
+
+- Current: 8000 chars (first 4K + last 4K).
+- Proposal: raise to 30-50K, or disable entirely (0).
+- Removes the perverse incentive to do multiple `sed -n` reads.
+- With caching, the extra tokens per read are affordable.
+
+**Risk:** An accidental `cat` of a huge file could produce unbounded output.
+Keep some limit as a safety net, but make it generous enough that agents rarely
+hit it in normal use. 50K chars (~12.5K tokens) is probably right — large
+enough for any reasonable file read, small enough to bound pathological cases.
+
+### D. Line numbers in distillation and structural extract
+
+- Add line numbers to file content in `format_codebase()` and
+  `format_structural_extract()`.
+- Distillation output can then say "relevant function at resolve.py:656-710".
+- Agent can do `sed -n '656,710p'` on first iteration instead of exploratory
+  grep-then-read dance.
+
+**Status:** Orthogonal to caching. Reduces iteration count, which is the
+biggest cost lever. Should implement regardless of caching approach.
+
+### E. Line numbers in the file listing
+
+- Currently `git ls-files` dumps bare paths.
+- Adding line counts (e.g., `lib/resolve.py (1750 lines)`) could help agents
+  decide whether to `cat` vs `sed -n`.
+
+**Status:** Low effort, modest benefit. Nice to have.
+
+## Open questions
+
+1. **Anthropic cache markers vs automatic caching.** Does Anthropic's automatic
+   prefix caching work without explicit `cache_control` markers? If so, just
+   stopping drops might be sufficient with zero marker changes. Need to verify.
+
+2. **OpenAI automatic prefix caching.** OpenAI caches identical prefixes
+   automatically. With append-only messages this should just work. Verify with
+   a GPT model run.
+
+3. **Gemini caching behavior.** Gemini uses `cachedContent` API. Does LiteLLM
+   translate `cache_control` markers correctly? Does it benefit from append-only?
+
+4. **Context compaction as quality lever.** Even if we don't need it for cost,
+   does summarizing old context help the agent stay focused on long runs? The
+   63-iter bridge-analysis run had the agent re-reading the same files in the
+   40s-50s iterations — possibly because it lost track of what it had already done.
+
+## History
+
+- **#478**: Token spend deep dive. Found that ~$10-11 of a $13.65 run went to
+  uncached tool result re-sends.
+- **#496**: This issue. Captured approaches A-D from the deep dive.
+- **#498**: Added tool-result-size logging (`Tool: name(args) -> N chars`).
+- **Context distillation**: Added ~Apr 2026. One-time pre-pass that extracts
+  relevant files before the agent loop.
+- **Tool result trimming**: Added ~Mar 2026 (`context_keep_tool_results`).
+  Keeps last N tool pairs, drops oldest. Smart ordering: read-only bash first,
+  file reads second, writes last.
+- **Bash output truncation**: Added ~Mar 2026 (`bash_output_limit: 8000`).
+  First 4K + last 4K chars of any bash output exceeding the limit.
+- **Apr 12 analysis session**: Reviewed runs 24174271003 (63 iters, $2.05) and
+  24283767463 (31 iters, $1.78). Concluded that per-pair sizes are small
+  (~575 tokens), cost is dominated by quadratic re-posting, and caching is the
+  primary lever. Tool call dropping is counterproductive because it defeats
+  caching. Bash truncation is counterproductive because it forces extra
+  iterations. Plan: disable both, get clean baseline runs, then implement
+  caching properly.

--- a/design-workspace.md
+++ b/design-workspace.md
@@ -112,24 +112,113 @@ Keep some limit as a safety net, but make it generous enough that agents rarely
 hit it in normal use. 50K chars (~12.5K tokens) is probably right — large
 enough for any reasonable file read, small enough to bound pathological cases.
 
-### D. Line numbers in distillation and structural extract
+### D. Structural extract as agent context (with line numbers)
 
-- Add line numbers to file content in `format_codebase()` and
-  `format_structural_extract()`.
-- Distillation output can then say "relevant function at resolve.py:656-710".
-- Agent can do `sed -n '656,710p'` on first iteration instead of exploratory
-  grep-then-read dance.
+After distillation, also include the structural extract (AST-extracted function
+and class signatures with docstrings) in the agent's system prompt. Currently
+structural extract is only used as *input* to the Tier 2 distillation path
+(medium repos). Sending it to the agent as well gives it a complete index of
+every function/class in the codebase — even ones the distillation LLM didn't
+think were relevant.
 
-**Status:** Orthogonal to caching. Reduces iteration count, which is the
-biggest cost lever. Should implement regardless of caching approach.
+Add line numbers to signature entries so the agent can jump directly:
+```
+def resolve_config(base_path, override_path, command_string, ...):  # line 456
+    """Config parsing for resolve mode."""
+    ...
+```
 
-### E. Line numbers in the file listing
+The agent can then do `sed -n '456,520p' lib/config.py` on its first iteration
+instead of the exploratory grep → read → grep → read dance.
 
-- Currently `git ls-files` dumps bare paths.
-- Adding line counts (e.g., `lib/resolve.py (1750 lines)`) could help agents
-  decide whether to `cat` vs `sed -n`.
+**Status:** Decided — implement. Orthogonal to caching. Reduces iteration
+count, which is the biggest cost lever.
 
-**Status:** Low effort, modest benefit. Nice to have.
+### E. Remove git ls-files from system prompt
+
+Currently `main()` builds `repo_context` starting with the bare `git ls-files`
+output. When distillation is on (the usual case), the agent never sees this —
+it gets replaced by the distilled output. When distillation is off, it's a
+list of filenames with no structure info.
+
+With structural extract in the agent context (idea D), the file listing is
+fully redundant — the structural extract already lists every file with its
+signatures. Remove it.
+
+**Status:** Decided — implement. Separate PR or bundled with D.
+
+### F. Raise bash_output_limit
+
+- Current: 8000 chars (first 4K + last 4K).
+- Proposal: raise to 30-50K, or disable entirely (0).
+- Removes the perverse incentive to do multiple `sed -n` reads.
+- With caching, the extra tokens per read are affordable.
+
+**Risk:** An accidental `cat` of a huge file could produce unbounded output.
+Keep some limit as a safety net, but make it generous enough that agents rarely
+hit it in normal use. 50K chars (~12.5K tokens) is probably right — large
+enough for any reasonable file read, small enough to bound pathological cases.
+
+**Status:** Temporarily disabled (0) for baseline data. Will decide on a
+permanent value after reviewing baseline runs.
+
+## User-side improvements ("Getting the most out of RDB")
+
+Changes users can make to *their* code to get better results from RDB (and
+possibly other AI agents). These will eventually go into a README section.
+
+### Add type hints to Python functions
+
+Type hints in function signatures let agents understand the contract without
+reading the function body. This matters most for the structural extract path
+where agents see only signatures:
+
+```python
+# Without hints — agent must read the body to know what to pass
+def resolve_config(base_path, override_path, command_string, local_path=None):
+
+# With hints — signature alone tells the full contract
+def resolve_config(base_path: str, override_path: str, command_string: str,
+                   local_path: str | None = None, args: dict[str, Any] | None = None) -> dict:
+```
+
+Return types are especially valuable — knowing a function returns `dict` vs
+`list[str]` vs `Optional[Config]` saves the agent a read.
+
+Prioritize type hints on:
+- Public API functions (called from multiple files)
+- Functions with non-obvious return types
+- Functions that take complex arguments (dicts, callbacks, optional params)
+
+### Add AGENTS.md with project conventions
+
+RDB agents read AGENTS.md (and CLAUDE.md, GEMINI.md) at the start of every
+run. Include:
+- How to run tests
+- Key file locations
+- Architectural patterns and conventions
+- Common pitfalls
+
+### Keep modules focused and reasonably sized
+
+A 1750-line `resolve.py` means agents spend iterations navigating to the
+relevant section. Smaller, focused modules let agents `cat` a whole file and
+have full context immediately. This interacts with bash_output_limit — smaller
+files are less likely to be truncated.
+
+### Mirror test structure to source structure
+
+When `tests/test_config.py` tests `lib/config.py`, agents can find the test
+file by convention. When test organization doesn't mirror source, agents
+waste iterations searching.
+
+## Writeup plan
+
+Once the performance work stabilizes, write up findings as:
+1. **design-workspace.md** — keep as the living analysis document
+2. **ADR(s)** — for each significant decision (e.g., "ADR: remove tool result
+   dropping in favor of prompt caching", "ADR: raise bash_output_limit")
+3. **README section** — "Getting the most out of RDB" with user-facing tips
 
 ## Open questions
 

--- a/lib/distill.py
+++ b/lib/distill.py
@@ -194,7 +194,7 @@ def format_codebase(files):
     return "\n".join(parts)
 
 
-def _extract_python_signatures(content):
+def _extract_python_signatures(content, include_line_numbers=False):
     """Extract function/class signatures and docstrings from Python source."""
     try:
         tree = ast.parse(content)
@@ -209,13 +209,19 @@ def _extract_python_signatures(content):
             # Get the function signature from source lines
             sig = _format_function_sig(node, content)
             docstring = ast.get_docstring(node)
-            parts.append(sig)
+            if include_line_numbers:
+                parts.append(f"{sig}  # line {node.lineno}")
+            else:
+                parts.append(sig)
             if docstring:
                 parts.append(f'    """{docstring}"""')
             parts.append("    ...")
             parts.append("")
         elif isinstance(node, ast.ClassDef):
-            parts.append(f"class {node.name}:")
+            if include_line_numbers:
+                parts.append(f"class {node.name}:  # line {node.lineno}")
+            else:
+                parts.append(f"class {node.name}:")
             docstring = ast.get_docstring(node)
             if docstring:
                 parts.append(f'    """{docstring}"""')
@@ -223,7 +229,10 @@ def _extract_python_signatures(content):
             for item in ast.iter_child_nodes(node):
                 if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     sig = _format_function_sig(item, content)
-                    parts.append(f"    {sig}")
+                    if include_line_numbers:
+                        parts.append(f"    {sig}  # line {item.lineno}")
+                    else:
+                        parts.append(f"    {sig}")
                     method_doc = ast.get_docstring(item)
                     if method_doc:
                         parts.append(f'        """{method_doc}"""')
@@ -251,7 +260,7 @@ def _format_function_sig(node, source):
     return f"{prefix} {node.name}({', '.join(arg_names)}):"
 
 
-def format_structural_extract(files):
+def format_structural_extract(files, include_line_numbers=False):
     """Format a compact structural representation for medium repos.
 
     Python files: AST-extracted function/class signatures + docstrings.
@@ -261,7 +270,9 @@ def format_structural_extract(files):
     for f in files:
         parts.append(f'<file path="{f["path"]}">')
         if f["path"].endswith(".py"):
-            extract = _extract_python_signatures(f["content"])
+            extract = _extract_python_signatures(
+                f["content"], include_line_numbers=include_line_numbers
+            )
             if isinstance(extract, list):
                 parts.append("\n".join(extract))
             else:
@@ -404,10 +415,13 @@ def _identify_relevant_files(extract_text, task_context, model):
 def maybe_distill(repo_context, issue_context, model, root="."):
     """Run context distillation pre-step.
 
-    Returns (context_text, input_tokens, output_tokens, cost).
-    On failure or skip, returns (repo_context, 0, 0, 0.0).
+    Returns (context_text, input_tokens, output_tokens, cost, structural_extract).
+    On failure or skip, returns (repo_context, 0, 0, 0.0, "").
+    The structural_extract is a compact index of all functions/classes with line
+    numbers, intended to be included in the agent's system prompt alongside the
+    distilled context.
     """
-    fallback = (repo_context, 0, 0, 0.0)
+    fallback = (repo_context, 0, 0, 0.0, "")
 
     try:
         files = gather_repo_files(root=root)
@@ -417,6 +431,15 @@ def maybe_distill(repo_context, issue_context, model, root="."):
 
         total_tokens = estimate_tokens_for_files(files)
         print(f"  [Distill] Gathered {len(files)} files, ~{total_tokens:,} tokens estimated")
+
+        # Always build the agent-facing structural extract with line numbers.
+        # This is cheap (no LLM call) and gives the agent a complete index of
+        # every function/class so it can jump directly to definitions.
+        agent_structural_extract = format_structural_extract(
+            files, include_line_numbers=True
+        )
+        extract_tokens = len(agent_structural_extract) // 4
+        print(f"  [Distill] Structural extract: ~{extract_tokens:,} tokens")
 
         total_input = 0
         total_output = 0
@@ -434,6 +457,9 @@ def maybe_distill(repo_context, issue_context, model, root="."):
         elif total_tokens <= DISTILL_STRUCT_EXTRACT_LIMIT:
             # Tier 2: Medium repo — structural extract + second pass
             print("  [Distill] Tier 2 (medium repo): structural extract + targeted read")
+            # The distillation input uses the extract without line numbers
+            # (line numbers aren't useful for the distillation LLM's task of
+            # identifying relevant files).
             extract_text = format_structural_extract(files)
 
             # Pass 1: identify relevant files
@@ -472,7 +498,7 @@ def maybe_distill(repo_context, issue_context, model, root="."):
             return fallback
 
         print(f"  [Distill] Distillation complete: ~{len(result) // 4:,} tokens output")
-        return result, total_input, total_output, total_cost
+        return result, total_input, total_output, total_cost, agent_structural_extract
 
     except Exception as e:
         print(f"  [Distill] Distillation failed: {e} — proceeding with full repo context")

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1172,19 +1172,17 @@ def main():
     _branch_created = branch
     print(f"Working on branch: {branch}")
 
-    # Gather repository context
-    file_listing_result = subprocess.run(
-        ["git", "ls-files"], capture_output=True, text=True
-    )
-    file_listing = file_listing_result.stdout.strip()
-    repo_context = f"## Repository File Listing\n\n```\n{file_listing}\n```"
-
+    # Gather repository context (EXTRA_FILES only — the structural extract
+    # from distillation replaces the old git ls-files listing).
+    repo_context = ""
     for filepath in EXTRA_FILES:
         if os.path.exists(filepath):
             with open(filepath) as f:
                 content = f.read().strip()
             if content:
-                repo_context += f"\n\n## File: {filepath}\n\n{content}"
+                if repo_context:
+                    repo_context += "\n\n"
+                repo_context += f"## File: {filepath}\n\n{content}"
 
     # Gather issue/PR context
     if ISSUE_TYPE == "pr":
@@ -1258,11 +1256,16 @@ def main():
             print("Running context distillation pre-step...")
             # Estimate tokens before distillation so we can measure savings
             undistilled_tokens = estimate_tokens([{"content": repo_context}])
-            distilled, distill_input_tokens, distill_output_tokens, distill_cost = maybe_distill(
+            distilled, distill_input_tokens, distill_output_tokens, distill_cost, structural_extract = maybe_distill(
                 repo_context, issue_context, LLM_MODEL
             )
             if distilled != repo_context:
                 agent_context = f"## Distilled Context\n\n{distilled}"
+                # Append the structural extract (with line numbers) so the
+                # agent has a complete index of every function/class and can
+                # jump directly to definitions without exploratory reads.
+                if structural_extract:
+                    agent_context += f"\n\n## Codebase Index\n\n{structural_extract}"
                 distillation_ran = True
                 post_distill_tokens = len(distilled) // 4
                 print(f"Distillation complete: {distill_input_tokens} input tokens, {distill_output_tokens} output tokens, ${distill_cost:.4f}")
@@ -1408,6 +1411,29 @@ def main():
                             "2. Call finish() now — do not start any new work."
                         ),
                     })
+
+            # Place a cache marker at the conversation tail so the entire
+            # prefix (all prior turns) is cached on the next iteration.
+            # With append-only messages (no tool result dropping), this gives
+            # near-perfect cache hit rates — only the newest turn is uncached.
+            # Uses 2 of 4 Anthropic markers (one on initial user msg, one here).
+            if _should_cache(LLM_MODEL) and len(messages) > 2:
+                _tail_msg = messages[-1]
+                _tail_content = _tail_msg.get("content")
+                _cc: dict = {"type": "ephemeral"}
+                if LLM_MODEL.startswith(("gemini/", "vertex_ai/")):
+                    _cc["ttl"] = "3600s"
+                if isinstance(_tail_content, str):
+                    _tail_msg["content"] = [
+                        {"type": "text", "text": _tail_content, "cache_control": _cc}
+                    ]
+                elif isinstance(_tail_content, list) and _tail_content:
+                    # Remove any prior cache_control markers in this message
+                    for block in _tail_content:
+                        if isinstance(block, dict):
+                            block.pop("cache_control", None)
+                    if isinstance(_tail_content[-1], dict):
+                        _tail_content[-1]["cache_control"] = _cc
 
             try:
                 response = completion_with_retries(

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -173,14 +173,18 @@ agent:
   # Bash output truncation limit in characters. Long outputs are trimmed to
   # first half + last half of this length to prevent context bloat.
   # Set to 0 to disable truncation.
-  bash_output_limit: 8000
+  # NOTE: Temporarily disabled (was 8000) to gather baseline data on tool
+  # output sizes without truncation. See design-workspace.md.
+  bash_output_limit: 0
   # Rolling status log: post a one-sentence status update every N iterations
   # as an issue comment. Set to 0 to disable (default — enable per-repo).
   status_log_interval: 0
   # Number of recent tool call/result pairs to keep in context. Older pairs
   # are replaced with a placeholder to prevent O(N²) token growth on long runs.
-  # Set to 0 to keep all tool results (not recommended for runs > ~20 iterations).
-  context_keep_tool_results: 20
+  # Set to 0 to keep all tool results.
+  # NOTE: Temporarily disabled (was 20) to gather baseline data on context
+  # growth without dropping. See design-workspace.md.
+  context_keep_tool_results: 0
   # Context window compaction: when the context grows too large, the oldest
   # messages are summarized by the LLM and replaced with a compact summary.
   # Set max_context_tokens to 0 to disable compaction entirely.

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -439,10 +439,10 @@ class TestMaybeDistill:
         assert result[2] == 150   # 50 + 100
 
     def test_returns_tuple(self, tmp_path):
-        """maybe_distill returns (context, input_tokens, output_tokens, cost)."""
+        """maybe_distill returns (context, input_tokens, output_tokens, cost, structural_extract)."""
         files = {"main.py": "x"}
         make_git_repo(tmp_path, files)
-        
+
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "distilled"
@@ -450,14 +450,15 @@ class TestMaybeDistill:
         mock_response.usage.prompt_tokens = 10
         mock_response.usage.completion_tokens = 5
         mock_response._hidden_params = {"response_cost": 0.001}
-        
+
         with patch("lib.distill.completion", return_value=mock_response):
-            ctx, inp, out, cost = maybe_distill("repo", "task", "anthropic/claude-sonnet-4-5", root=str(tmp_path))
-        
+            ctx, inp, out, cost, struct_extract = maybe_distill("repo", "task", "anthropic/claude-sonnet-4-5", root=str(tmp_path))
+
         assert ctx == "distilled"
         assert inp == 10
         assert out == 5
         assert cost == 0.001
+        assert "<structural_extract>" in struct_extract
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Set `context_keep_tool_results: 0` (was 20) — stop dropping tool results
- Set `bash_output_limit: 0` (was 8000) — stop truncating bash output
- Add `design-workspace.md` capturing the #496 analysis and plan

## Why
We need clean baseline runs to see the true tool output size distribution and context growth pattern before implementing caching. The current measures (dropping + truncation) defeat prompt caching and may force agents into extra iterations, costing more than they save. Details in design-workspace.md.

## What to do after merge
Kick off a few agent runs (bridge-analysis, rdb-test) on real tasks and examine:
1. Tool output size distribution (the `Tool: name(args) -> N chars` log lines)
2. Total context growth (does it hit model limits?)
3. Iteration count (fewer iterations without truncation?)
4. Cost (higher per-request but possibly fewer requests?)

## Test plan
- [x] `pytest tests/` — 438 pass, 3 pre-existing failures on dev (delegate tests)
- Config-only change + new doc, no code changes