### PR TITLE
Update GPT models to gpt-5.4-mini and gpt-5.4

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -133,12 +133,12 @@ models:
     description: "Most capable — for complex multi-file features"
 
   gpt-small:
-    id: openai/gpt-5.3-codex-spark
-    description: "OpenAI GPT-5.3 Codex Spark — fast, >1000 tok/s"
+    id: openai/gpt-5.4-mini
+    description: "OpenAI GPT-5.4 Mini — fast, cost-effective coding"
 
   gpt-large:
-    id: openai/gpt-5.3-codex
-    description: "OpenAI GPT-5.3 Codex — best coding model"
+    id: openai/gpt-5.4
+    description: "OpenAI GPT-5.4 — frontier coding + reasoning"
 
   gemini-small:
     id: gemini/gemini-2.5-flash


### PR DESCRIPTION
## Summary

- **gpt-small**: `openai/gpt-5.3-codex-spark` → `openai/gpt-5.4-mini`
- **gpt-large**: `openai/gpt-5.3-codex` → `openai/gpt-5.4`

gpt-5.3-codex-spark was not available via the OpenAI Chat Completions API (Codex/CLI only for ChatGPT Pro subscribers), causing `litellm.NotFoundError` on every council review that used gpt-small.

The GPT-5.4 family folds Codex coding capabilities into the mainline: gpt-5.4 matches or exceeds gpt-5.3-codex on SWE-Bench Pro, and gpt-5.4-mini beats gpt-5.2-codex (~54% vs ~48%) at ~1/3 the cost.

## Test plan

- [ ] Trigger a delegate or build run using gpt-small council and verify no NotFoundError
- [ ] Spot-check review quality from gpt-5.4-mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)