### PR TITLE
Fix Claude 4.6 assistant message prefill crash

### DIFF
--- a/lib/reconcile.py
+++ b/lib/reconcile.py
@@ -567,6 +567,18 @@ def main():
                     ),
                 })
 
+            # Guard: Claude 4.6+ rejects conversations ending with an
+            # assistant message ("does not support assistant message prefill").
+            # Normally messages end with a tool result, but edge cases in
+            # LiteLLM's Anthropic message translation can produce a trailing
+            # assistant turn. Append a nudge-user message to fix the sequence.
+            if messages and messages[-1].get("role") == "assistant":
+                print(f"  [Prefill guard] Messages end with assistant role — injecting user message")
+                messages.append({
+                    "role": "user",
+                    "content": "Continue with the reconcile task. Use the tools available to proceed.",
+                })
+
             try:
                 response = completion(
                     model=LLM_MODEL,
@@ -593,6 +605,17 @@ def main():
                     write_status(False, f"Model hit output token limit at iteration {iteration + 1} — context too large")
                 else:
                     write_status(False, f"API connection error at iteration {iteration + 1}: {exc}")
+                break
+            except litellm.exceptions.BadRequestError as exc:
+                err_msg = str(exc)
+                if "prefill" in err_msg.lower():
+                    # Claude 4.6+ doesn't support assistant prefill. The
+                    # prefill guard above should prevent this, but if it
+                    # slips through, log the message roles for debugging.
+                    roles = [m.get("role") for m in messages[-5:]]
+                    print(f"Prefill error at iteration {iteration + 1}. "
+                          f"Last 5 roles: {roles}. Error: {exc}")
+                write_status(False, f"Bad request at iteration {iteration + 1}: {exc}")
                 break
             except litellm.exceptions.APIError as exc:
                 err_msg = str(exc)

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1392,6 +1392,17 @@ def main():
                         ),
                     })
 
+            # Guard: Claude 4.6+ rejects conversations ending with an
+            # assistant message ("does not support assistant message prefill").
+            # Normally messages end with a tool result, but edge cases in
+            # LiteLLM's Anthropic message translation can produce a trailing
+            # assistant turn. Append a nudge-user message to fix the sequence.
+            if messages and messages[-1].get("role") == "assistant":
+                print(f"  [Prefill guard] Messages end with assistant role — injecting user message")
+                messages.append({
+                    "role": "user",
+                    "content": "Continue working on the task. Use the tools available to proceed.",
+                })
             try:
                 response = completion_with_retries(
                     completion,
@@ -1401,6 +1412,14 @@ def main():
                     max_tokens=16384,
                     transient_error_counter=transient_error_counter,
                 )
+            except litellm.exceptions.BadRequestError as exc:
+                err_msg = str(exc)
+                if "prefill" in err_msg.lower():
+                    roles = [m.get("role") for m in messages[-5:]]
+                    print(f"Prefill error at iteration {iteration + 1}. "
+                          f"Last 5 roles: {roles}. Error: {exc}")
+                write_status(False, f"Bad request at iteration {iteration + 1}: {exc}")
+                break
             except litellm.exceptions.RateLimitError as exc:
                 rate_limit_retries += 1
                 if rate_limit_retries <= MAX_RATE_LIMIT_RETRIES:


### PR DESCRIPTION
## Summary

Claude 4.6 [removed support for assistant message prefill](https://github.com/crewAIInc/crewAI/issues/4798) — any request where the messages array ends with `role: "assistant"` is rejected with `BadRequestError`. This crashed reconcile runs (observed at iteration 27 on bridge-analysis PR #336).

The root cause is not fully clear — our code appends tool results after each assistant message, so messages should end with `role: "tool"`. However, something in LiteLLM's Anthropic message translation appears to produce a trailing assistant turn in edge cases on longer conversations.

**Fixes:**
1. **Prefill guard** before each `completion()` call: if messages end with `role: "assistant"`, inject a user message to fix the sequence. Logs when triggered for debugging.
2. **Catch `BadRequestError`** (previously uncaught → unhandled crash). Logs last 5 message roles on prefill errors for root cause diagnosis.

Applied to both `reconcile.py` and `resolve.py`.

Fixes #541

## Test plan

- [x] All 440 tests pass (excluding 3 pre-existing failures from #533)
- [ ] Re-run reconcile on bridge-analysis PR #336 and verify it doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)