### PR TITLE
Unify cumulative cost reporting into shared lib

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -563,6 +563,9 @@ jobs:
             exit 0
           fi
 
+          # Export PR number for cumulative cost scanning
+          export COST_TARGET_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
           # Generate cost table
           python3 << 'PYEOF'
           import json, math, os, gzip, time
@@ -634,161 +637,25 @@ jobs:
           ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
-          # --- Cumulative cost tracking ---
-          # Fetch prior cost tables from linked issue comments and sum up costs.
-          import subprocess as _sp2, re as _re2, json as _json2, os as _os2
-
-          def _extract_costs_from_text(text):
-              """Extract (cost, loc_ins, loc_del, input_tokens, output_tokens) from cost table text."""
-              total_cost = 0.0
-              total_ins = 0; total_del = 0
-              total_in_tok = 0; total_out_tok = 0
-              # Find all cost entries: **$X.XX**
-              # IMPORTANT: This regex matches the bold-dollar pattern used ONLY in the per-step
-              # "### 💰 Cost" table (e.g. "| **Cost** | **$0.52** |"). The "### 📊 Feature total"
-              # cumulative table intentionally uses bare "$X.XX" (no ** bold markers) and the row
-              # label "Cumulative cost" (not "Cost") so that future runs do NOT double-count it here.
-              # Do NOT reformat the cumulative table to use **bold** values or rename the row to "Cost".
-              for m in _re2.finditer(r'\*\*\$([0-9]+\.[0-9]+)\*\*', text):
-                  total_cost += float(m.group(1))
-              # Find LOC from Diff rows: "N insertions(+), M deletions(-)"
-              for m in _re2.finditer(r'\| Diff \|[^|]*\|', text):
-                  diff_cell = m.group(0)
-                  ins = _re2.search(r'(\d+) insertion', diff_cell)
-                  if ins: total_ins += int(ins.group(1))
-                  dl = _re2.search(r'(\d+) deletion', diff_cell)
-                  if dl: total_del += int(dl.group(1))
-              # Find token counts from Input/Output rows
-              for m in _re2.finditer(r'\| Input \| ([0-9.]+)([KM]?) tokens \|', text):
-                  v = float(m.group(1))
-                  sfx = m.group(2)
-                  if sfx == 'K': v *= 1000
-                  elif sfx == 'M': v *= 1_000_000
-                  total_in_tok += int(v)
-              for m in _re2.finditer(r'\| Output \| ([0-9.]+)([KM]?) tokens \|', text):
-                  v = float(m.group(1))
-                  sfx = m.group(2)
-                  if sfx == 'K': v *= 1000
-                  elif sfx == 'M': v *= 1_000_000
-                  total_out_tok += int(v)
-              # Find Info bits from per-step | Info | X.X Kbit | rows
-              # IMPORTANT: Only matches "| Info |" (not "| Cumulative info |") to avoid
-              # double-counting the cumulative section.
-              total_info_bits = 0.0
-              for m in _re2.finditer(r'\| Info \| ([0-9.]+) (Kbit|Mbit) \|', text):
-                  v = float(m.group(1))
-                  if m.group(2) == 'Mbit': v *= 1_000_000
-                  else: v *= 1_000
-                  total_info_bits += v
-              return total_cost, total_ins, total_del, total_in_tok, total_out_tok, total_info_bits
-
-          # Try to get the linked issue number from the PR body (Fixes/Closes/Resolves #N)
-          _repo = _os2.environ.get('GITHUB_REPOSITORY', '')
-          _pr_url_file = '/tmp/spr_output.log'
-          _pr_body = ''
-          _linked_issue_num = None
-
-          try:
-              _pr_url_raw = ''
-              if _os2.path.exists(_pr_url_file):
-                  _pr_url_raw = open(_pr_url_file).read()
-              _pr_url_m = _re2.search(r'https://github\.com/[^/]+/[^/]+/pull/([0-9]+)', _pr_url_raw)
-              if _pr_url_m:
-                  _pr_num = _pr_url_m.group(1)
-                  _pr_body_r = _sp2.run(
-                      ['gh', 'pr', 'view', _pr_num, '--repo', _repo, '--json', 'body', '--jq', '.body'],
-                      capture_output=True, text=True
-                  )
-                  if _pr_body_r.returncode == 0:
-                      _pr_body = _pr_body_r.stdout.strip()
-              # Extract linked issue from PR body
-              _fix_m = _re2.search(r'(?:Fixes|Closes|Resolves)\s+#([0-9]+)', _pr_body, _re2.IGNORECASE)
-              if _fix_m:
-                  _linked_issue_num = _fix_m.group(1)
-          except Exception as _e2:
-              pass
-
-          # Fetch prior cost tables from linked issue comments and PR body
-          _prior_costs = []
-          _prior_total_cost = 0.0
-          _prior_total_ins = 0; _prior_total_del = 0
-          _prior_total_in_tok = 0; _prior_total_out_tok = 0
-          _prior_total_info_bits = 0.0
-          _all_prior_text = _pr_body  # start with current PR body (prior runs appended there)
-
-          if _linked_issue_num and _repo:
-              try:
-                  _comments_r = _sp2.run(
-                      ['gh', 'api', f'repos/{_repo}/issues/{_linked_issue_num}/comments', '--jq', '.[].body'],
-                      capture_output=True, text=True
-                  )
-                  if _comments_r.returncode == 0:
-                      _all_prior_text += '\n' + _comments_r.stdout
-                      # Also include the issue body itself
-                      _issue_r = _sp2.run(
-                          ['gh', 'api', f'repos/{_repo}/issues/{_linked_issue_num}', '--jq', '.body'],
-                          capture_output=True, text=True
-                      )
-                      if _issue_r.returncode == 0:
-                          _all_prior_text += '\n' + _issue_r.stdout
-              except Exception:
-                  pass
-
-          # Count cost tables across all prior text (skip Feature total sections)
-          _num_prior = len(_re2.findall(r'### 💰 Cost', _all_prior_text))
-          if _num_prior > 0:
-              _pc, _pi, _pd, _pit, _pot, _pib = _extract_costs_from_text(_all_prior_text)
-              _prior_total_cost = _pc
-              _prior_total_ins = _pi
-              _prior_total_del = _pd
-              _prior_total_in_tok = _pit
-              _prior_total_out_tok = _pot
-              _prior_total_info_bits = _pib
-              _prior_costs = list(range(_num_prior))  # just count
-
-          # Compute cumulative totals (prior + current step)
-          _cum_steps = len(_prior_costs) + 1
-          _cum_cost = _prior_total_cost + cost
-          _cum_ins = _prior_total_ins + loc_changed  # loc_changed is insertions+deletions this step
-          _cum_in_tok = _prior_total_in_tok + input_tokens
-          _cum_out_tok = _prior_total_out_tok + output_tokens
+          # --- Cumulative cost tracking (via shared lib) ---
           _cur_info_bits = len(gzip.compress(bits_text.encode('utf-8') if isinstance(bits_text, str) else bits_text)) * 8 if bits_text else 0
-          _cum_info_bits = _prior_total_info_bits + _cur_info_bits
-
-          # Only append cumulative section if there are prior steps
-          if len(_prior_costs) > 0 and _cum_cost > 0:
-              def _fmt_loc_c(n):
-                  if n >= 1_000_000: return f"{n/1_000_000:.1f}M"
-                  if n >= 1_000: return f"{n/1_000:.1f}k"
-                  return str(n)
-              _cum_loc_per_dollar = int(_cum_ins / _cum_cost) if _cum_cost > 0 and _cum_ins > 0 else 0
-              # FORMATTING NOTE: The cumulative table uses bare "$X.XX" (no ** bold markers)
-              # and the row label "Cumulative cost" (not "Cost"). This is intentional:
-              #   - _extract_costs_from_text() only picks up **$X.XX** (bold) patterns, which
-              #     appear exclusively in the per-step "### 💰 Cost" table.
-              #   - If you change the cost value here to **bold** or rename the row to "Cost",
-              #     future runs will double-count this cumulative figure when summing prior steps.
-              _ctbl = [
-                  '',
-                  f'### 📊 Feature total ({_cum_steps} steps)',
-                  '',
-                  '| Metric | Value |',
-                  '|--------|-------|',
-                  f'| Cumulative cost | ${_cum_cost:.2f} |',
-              ]
-              if _cum_ins > 0:
-                  _ctbl.append(f'| LOC | ~{_fmt_loc_c(_cum_ins)} (estimate) |')
-              if _cum_loc_per_dollar > 0:
-                  _ctbl.append(f'| LOC/$ | ~{_fmt_loc_c(_cum_loc_per_dollar)} loc/$ |')
-              if _cum_info_bits > 0:
-                  _ctbl.append(f'| Cumulative info | {f"{_cum_info_bits/1_000_000:.1f} Mbit" if _cum_info_bits >= 1_000_000 else f"{_cum_info_bits/1_000:.1f} Kbit"} |')
-              if _cum_cost > 0 and _cum_info_bits > 0:
-                  _ctbl.append(f'| Cumulative info/$ | {f"{_cum_info_bits/1_000_000:.1f} Mbit/$" if _cum_info_bits/_cum_cost >= 1_000_000 else f"{_cum_info_bits/_cum_cost/1_000:.1f} Kbit/$"} |')
-              if _cum_in_tok > 0:
-                  _ctbl.append(f'| Input | {_fmt_tok(_cum_in_tok)} tokens |')
-              if _cum_out_tok > 0:
-                  _ctbl.append(f'| Output | {_fmt_tok(_cum_out_tok)} tokens |')
-              _tbl += _ctbl
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+                  current_loc=loc_changed,
+                  current_info_bits=_cur_info_bits,
+              )
+              if _cum:
+                  _tbl.append('')
+                  _tbl.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
           PYEOF
 
@@ -1412,6 +1279,9 @@ jobs:
             exit 0
           fi
 
+          # Export PR number for cumulative cost scanning
+          export COST_TARGET_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
           # Generate cost table
           python3 << 'PYEOF'
           import json, math, os, gzip, time
@@ -1483,161 +1353,25 @@ jobs:
           ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
-          # --- Cumulative cost tracking ---
-          # Fetch prior cost tables from linked issue comments and sum up costs.
-          import subprocess as _sp2, re as _re2, json as _json2, os as _os2
-
-          def _extract_costs_from_text(text):
-              """Extract (cost, loc_ins, loc_del, input_tokens, output_tokens) from cost table text."""
-              total_cost = 0.0
-              total_ins = 0; total_del = 0
-              total_in_tok = 0; total_out_tok = 0
-              # Find all cost entries: **$X.XX**
-              # IMPORTANT: This regex matches the bold-dollar pattern used ONLY in the per-step
-              # "### 💰 Cost" table (e.g. "| **Cost** | **$0.52** |"). The "### 📊 Feature total"
-              # cumulative table intentionally uses bare "$X.XX" (no ** bold markers) and the row
-              # label "Cumulative cost" (not "Cost") so that future runs do NOT double-count it here.
-              # Do NOT reformat the cumulative table to use **bold** values or rename the row to "Cost".
-              for m in _re2.finditer(r'\*\*\$([0-9]+\.[0-9]+)\*\*', text):
-                  total_cost += float(m.group(1))
-              # Find LOC from Diff rows: "N insertions(+), M deletions(-)"
-              for m in _re2.finditer(r'\| Diff \|[^|]*\|', text):
-                  diff_cell = m.group(0)
-                  ins = _re2.search(r'(\d+) insertion', diff_cell)
-                  if ins: total_ins += int(ins.group(1))
-                  dl = _re2.search(r'(\d+) deletion', diff_cell)
-                  if dl: total_del += int(dl.group(1))
-              # Find token counts from Input/Output rows
-              for m in _re2.finditer(r'\| Input \| ([0-9.]+)([KM]?) tokens \|', text):
-                  v = float(m.group(1))
-                  sfx = m.group(2)
-                  if sfx == 'K': v *= 1000
-                  elif sfx == 'M': v *= 1_000_000
-                  total_in_tok += int(v)
-              for m in _re2.finditer(r'\| Output \| ([0-9.]+)([KM]?) tokens \|', text):
-                  v = float(m.group(1))
-                  sfx = m.group(2)
-                  if sfx == 'K': v *= 1000
-                  elif sfx == 'M': v *= 1_000_000
-                  total_out_tok += int(v)
-              # Find Info bits from per-step | Info | X.X Kbit | rows
-              # IMPORTANT: Only matches "| Info |" (not "| Cumulative info |") to avoid
-              # double-counting the cumulative section.
-              total_info_bits = 0.0
-              for m in _re2.finditer(r'\| Info \| ([0-9.]+) (Kbit|Mbit) \|', text):
-                  v = float(m.group(1))
-                  if m.group(2) == 'Mbit': v *= 1_000_000
-                  else: v *= 1_000
-                  total_info_bits += v
-              return total_cost, total_ins, total_del, total_in_tok, total_out_tok, total_info_bits
-
-          # Try to get the linked issue number from the PR body (Fixes/Closes/Resolves #N)
-          _repo = _os2.environ.get('GITHUB_REPOSITORY', '')
-          _pr_url_file = '/tmp/spr_output.log'
-          _pr_body = ''
-          _linked_issue_num = None
-
-          try:
-              _pr_url_raw = ''
-              if _os2.path.exists(_pr_url_file):
-                  _pr_url_raw = open(_pr_url_file).read()
-              _pr_url_m = _re2.search(r'https://github\.com/[^/]+/[^/]+/pull/([0-9]+)', _pr_url_raw)
-              if _pr_url_m:
-                  _pr_num = _pr_url_m.group(1)
-                  _pr_body_r = _sp2.run(
-                      ['gh', 'pr', 'view', _pr_num, '--repo', _repo, '--json', 'body', '--jq', '.body'],
-                      capture_output=True, text=True
-                  )
-                  if _pr_body_r.returncode == 0:
-                      _pr_body = _pr_body_r.stdout.strip()
-              # Extract linked issue from PR body
-              _fix_m = _re2.search(r'(?:Fixes|Closes|Resolves)\s+#([0-9]+)', _pr_body, _re2.IGNORECASE)
-              if _fix_m:
-                  _linked_issue_num = _fix_m.group(1)
-          except Exception as _e2:
-              pass
-
-          # Fetch prior cost tables from linked issue comments and PR body
-          _prior_costs = []
-          _prior_total_cost = 0.0
-          _prior_total_ins = 0; _prior_total_del = 0
-          _prior_total_in_tok = 0; _prior_total_out_tok = 0
-          _prior_total_info_bits = 0.0
-          _all_prior_text = _pr_body  # start with current PR body (prior runs appended there)
-
-          if _linked_issue_num and _repo:
-              try:
-                  _comments_r = _sp2.run(
-                      ['gh', 'api', f'repos/{_repo}/issues/{_linked_issue_num}/comments', '--jq', '.[].body'],
-                      capture_output=True, text=True
-                  )
-                  if _comments_r.returncode == 0:
-                      _all_prior_text += '\n' + _comments_r.stdout
-                      # Also include the issue body itself
-                      _issue_r = _sp2.run(
-                          ['gh', 'api', f'repos/{_repo}/issues/{_linked_issue_num}', '--jq', '.body'],
-                          capture_output=True, text=True
-                      )
-                      if _issue_r.returncode == 0:
-                          _all_prior_text += '\n' + _issue_r.stdout
-              except Exception:
-                  pass
-
-          # Count cost tables across all prior text (skip Feature total sections)
-          _num_prior = len(_re2.findall(r'### 💰 Cost', _all_prior_text))
-          if _num_prior > 0:
-              _pc, _pi, _pd, _pit, _pot, _pib = _extract_costs_from_text(_all_prior_text)
-              _prior_total_cost = _pc
-              _prior_total_ins = _pi
-              _prior_total_del = _pd
-              _prior_total_in_tok = _pit
-              _prior_total_out_tok = _pot
-              _prior_total_info_bits = _pib
-              _prior_costs = list(range(_num_prior))  # just count
-
-          # Compute cumulative totals (prior + current step)
-          _cum_steps = len(_prior_costs) + 1
-          _cum_cost = _prior_total_cost + cost
-          _cum_ins = _prior_total_ins + loc_changed  # loc_changed is insertions+deletions this step
-          _cum_in_tok = _prior_total_in_tok + input_tokens
-          _cum_out_tok = _prior_total_out_tok + output_tokens
+          # --- Cumulative cost tracking (via shared lib) ---
           _cur_info_bits = len(gzip.compress(bits_text.encode('utf-8') if isinstance(bits_text, str) else bits_text)) * 8 if bits_text else 0
-          _cum_info_bits = _prior_total_info_bits + _cur_info_bits
-
-          # Only append cumulative section if there are prior steps
-          if len(_prior_costs) > 0 and _cum_cost > 0:
-              def _fmt_loc_c(n):
-                  if n >= 1_000_000: return f"{n/1_000_000:.1f}M"
-                  if n >= 1_000: return f"{n/1_000:.1f}k"
-                  return str(n)
-              _cum_loc_per_dollar = int(_cum_ins / _cum_cost) if _cum_cost > 0 and _cum_ins > 0 else 0
-              # FORMATTING NOTE: The cumulative table uses bare "$X.XX" (no ** bold markers)
-              # and the row label "Cumulative cost" (not "Cost"). This is intentional:
-              #   - _extract_costs_from_text() only picks up **$X.XX** (bold) patterns, which
-              #     appear exclusively in the per-step "### 💰 Cost" table.
-              #   - If you change the cost value here to **bold** or rename the row to "Cost",
-              #     future runs will double-count this cumulative figure when summing prior steps.
-              _ctbl = [
-                  '',
-                  f'### 📊 Feature total ({_cum_steps} steps)',
-                  '',
-                  '| Metric | Value |',
-                  '|--------|-------|',
-                  f'| Cumulative cost | ${_cum_cost:.2f} |',
-              ]
-              if _cum_ins > 0:
-                  _ctbl.append(f'| LOC | ~{_fmt_loc_c(_cum_ins)} (estimate) |')
-              if _cum_loc_per_dollar > 0:
-                  _ctbl.append(f'| LOC/$ | ~{_fmt_loc_c(_cum_loc_per_dollar)} loc/$ |')
-              if _cum_info_bits > 0:
-                  _ctbl.append(f'| Cumulative info | {f"{_cum_info_bits/1_000_000:.1f} Mbit" if _cum_info_bits >= 1_000_000 else f"{_cum_info_bits/1_000:.1f} Kbit"} |')
-              if _cum_cost > 0 and _cum_info_bits > 0:
-                  _ctbl.append(f'| Cumulative info/$ | {f"{_cum_info_bits/1_000_000:.1f} Mbit/$" if _cum_info_bits/_cum_cost >= 1_000_000 else f"{_cum_info_bits/_cum_cost/1_000:.1f} Kbit/$"} |')
-              if _cum_in_tok > 0:
-                  _ctbl.append(f'| Input | {_fmt_tok(_cum_in_tok)} tokens |')
-              if _cum_out_tok > 0:
-                  _ctbl.append(f'| Output | {_fmt_tok(_cum_out_tok)} tokens |')
-              _tbl += _ctbl
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+                  current_loc=loc_changed,
+                  current_info_bits=_cur_info_bits,
+              )
+              if _cum:
+                  _tbl.append('')
+                  _tbl.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
           PYEOF
 
@@ -2296,6 +2030,7 @@ jobs:
           ALIAS="${{ needs.parse.outputs.alias }}"
           MODEL="${{ needs.parse.outputs.model }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          export COST_TARGET_NUMBER="$PR_NUMBER"
 
           # Generate cost table (writes /tmp/cost_table.txt)
           python3 << 'PYEOF'
@@ -2348,6 +2083,24 @@ jobs:
           ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
+          # --- Cumulative cost tracking (via shared lib) ---
+          _cur_info_bits = len(gzip.compress(bits_text.encode('utf-8') if isinstance(bits_text, str) else bits_text)) * 8 if bits_text else 0
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+                  current_info_bits=_cur_info_bits,
+              )
+              if _cum:
+                  _tbl.append('')
+                  _tbl.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
           PYEOF
 
@@ -2686,6 +2439,7 @@ jobs:
           MODEL="${{ needs.parse.outputs.model }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
           MAX_ITER="${{ needs.parse.outputs.max_iterations }}"
+          export COST_TARGET_NUMBER="$PR_NUMBER"
 
           python3 << 'PYEOF'
           import json, math, os, gzip, time
@@ -2767,6 +2521,25 @@ jobs:
               '|--------|-------|',
           ]
           lines += [f'| {k} | {v} |' for k, v in rows]
+          # --- Cumulative cost tracking (via shared lib) ---
+          _cur_info_bits = len(gzip.compress(bits_text.encode('utf-8') if isinstance(bits_text, str) else bits_text)) * 8 if bits_text else 0
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+                  current_loc=loc_changed,
+                  current_info_bits=_cur_info_bits,
+              )
+              if _cum:
+                  lines.append('')
+                  lines.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
           open('/tmp/cost_comment.md', 'w').write('\n'.join(lines) + '\n')
           PYEOF
 
@@ -3307,6 +3080,7 @@ jobs:
           BRANCH="${{ steps.checkout_info.outputs.branch }}"
           SHA="${{ steps.checkout_info.outputs.sha }}"
           MODEL_HEADER="🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`) · 📍 **Branch:** \`${BRANCH}\` (\`${SHA}\`)"
+          export COST_TARGET_NUMBER="$ISSUE_NUMBER"
 
           # Generate cost table (writes /tmp/cost_table.txt)
           python3 << 'PYEOF'
@@ -3359,6 +3133,24 @@ jobs:
           ]
           _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
           _tbl += [f'| {k} | {v} |' for k, v in rows]
+          # --- Cumulative cost tracking (via shared lib) ---
+          _cur_info_bits = len(gzip.compress(bits_text.encode('utf-8') if isinstance(bits_text, str) else bits_text)) * 8 if bits_text else 0
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+                  current_info_bits=_cur_info_bits,
+              )
+              if _cum:
+                  _tbl.append('')
+                  _tbl.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
           open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
           PYEOF
 
@@ -4554,6 +4346,7 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          DELEGATE_MAX_ITER: ${{ needs.parse.outputs.delegate_max_iterations }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
@@ -4561,39 +4354,10 @@ jobs:
           ALIAS="${{ needs.parse.outputs.alias }}"
           MODEL="${{ needs.parse.outputs.model }}"
 
-          ELAPSED=$(( $(date +%s) - $(cat /tmp/start_time 2>/dev/null || date +%s) ))
-          ELAPSED_FMT=$(python3 -c "s=${ELAPSED}; print(f'{s//60}m {s%60}s' if s >= 60 else f'{s}s')")
-          if [ -f /tmp/llm_usage.json ]; then
-            read INPUT_TOKENS OUTPUT_TOKENS COST ITERATIONS < <(python3 -c "
-          import json
-          d = json.load(open('/tmp/llm_usage.json'))
-          print(d.get('input_tokens', 0), d.get('output_tokens', 0), d.get('cost') or 0, d.get('iterations', 0))
-          ")
-          else
-            INPUT_TOKENS=0; OUTPUT_TOKENS=0; COST=0; ITERATIONS=0
-          fi
-          DELEGATE_MAX_ITER="${{ needs.parse.outputs.delegate_max_iterations }}"
-          ITERATIONS_FMT=$(python3 -c "
-          max_i = '${DELEGATE_MAX_ITER}'
-          iters = '${ITERATIONS}'
-          print(f'{iters} / {max_i}' if max_i.isdigit() and int(max_i) > 0 else iters)
-          ")
-          ROUNDED=$(python3 -c "import math; print(f'{math.ceil(float(\"${COST:-0}\") * 100) / 100:.2f}')")
-          IFS=$'\t' read INPUT_TOKENS_FMT OUTPUT_TOKENS_FMT < <(python3 -c "
-          def fmt(n):
-              if n >= 1_000_000:
-                  v = n / 1_000_000
-                  return f'{round(v)}M' if v >= 10 else f'{round(v, 1)}M'
-              elif n >= 1_000:
-                  v = n / 1_000
-                  return f'{round(v)}K' if v >= 10 else f'{round(v, 1)}K'
-              return str(n)
-          print(fmt(${INPUT_TOKENS}), fmt(${OUTPUT_TOKENS}), sep='\t')
-          ")
-
           # Check pipeline result
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
 
+          # Build header (varies by outcome)
           if [[ -f /tmp/delegate_abort.txt ]]; then
             ABORT_REASON=$(cat /tmp/delegate_abort.txt)
             {
@@ -4604,16 +4368,6 @@ jobs:
               echo "**Reason:** ${ABORT_REASON}"
               echo ""
               echo "See the [workflow run logs]($RUN_URL) for full details."
-              echo ""
-              echo "### 💰 Cost"
-              echo ""
-              echo "| Metric | Value |"
-              echo "|--------|-------|"
-              echo "| Time | ${ELAPSED_FMT} |"
-              echo "| Iterations | ${ITERATIONS_FMT} |"
-              echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
-              echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
-              printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
             } > /tmp/delegate_result_comment.md
           elif [[ -n "$PR_URL" ]]; then
             {
@@ -4632,16 +4386,6 @@ jobs:
               echo "6. ✅ Code revision plan"
               echo ""
               echo "See the [workflow run logs]($RUN_URL) for full details."
-              echo ""
-              echo "### 💰 Cost"
-              echo ""
-              echo "| Metric | Value |"
-              echo "|--------|-------|"
-              echo "| Time | ${ELAPSED_FMT} |"
-              echo "| Iterations | ${ITERATIONS_FMT} |"
-              echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
-              echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
-              printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
             } > /tmp/delegate_result_comment.md
           else
             {
@@ -4652,17 +4396,79 @@ jobs:
               echo "The implementation stage did not create a pull request."
               echo ""
               echo "See the [workflow run logs]($RUN_URL) for full details."
-              echo ""
-              echo "### 💰 Cost"
-              echo ""
-              echo "| Metric | Value |"
-              echo "|--------|-------|"
-              echo "| Time | ${ELAPSED_FMT} |"
-              echo "| Iterations | ${ITERATIONS_FMT} |"
-              echo "| Input | ${INPUT_TOKENS_FMT} tokens |"
-              echo "| Output | ${OUTPUT_TOKENS_FMT} tokens |"
-              printf "| **Cost** | **\$%s** |\n" "$ROUNDED"
             } > /tmp/delegate_result_comment.md
+          fi
+
+          # For cumulative scanning: use PR number if available, else issue number
+          if [[ -n "$PR_URL" ]]; then
+            export COST_TARGET_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          else
+            export COST_TARGET_NUMBER="$ISSUE_NUMBER"
+          fi
+
+          # Generate cost table + cumulative via Python
+          python3 << 'PYEOF'
+          import json, math, os, gzip, time
+          def _fmt_tok(n):
+              n = int(n)
+              if n >= 1_000_000:
+                  v = n / 1_000_000
+                  return f"{round(v)}M" if v >= 10 else f"{round(v, 1)}M"
+              elif n >= 1_000:
+                  v = n / 1_000
+                  return f"{round(v)}K" if v >= 10 else f"{round(v, 1)}K"
+              return str(n)
+          def _fmt_ela(s):
+              s = int(s)
+              return f"{s // 60}m {s % 60}s" if s >= 60 else f"{s}s"
+          if os.path.exists("/tmp/llm_usage.json"):
+              _d = json.load(open("/tmp/llm_usage.json"))
+              input_tokens = _d.get('input_tokens', 0)
+              output_tokens = _d.get('output_tokens', 0)
+              cost = float(_d.get('cost') or 0)
+              iterations = _d.get('iterations', 0)
+          else:
+              input_tokens = output_tokens = 0; cost = 0.0; iterations = 0
+          _max_iter_str = os.environ.get("DELEGATE_MAX_ITER", "") or ""
+          _max_iter = int(_max_iter_str) if _max_iter_str.isdigit() and int(_max_iter_str) > 0 else 0
+          iterations_fmt = f"{iterations} / {_max_iter}" if _max_iter > 0 else str(iterations)
+          try:
+              _st = int(open('/tmp/start_time').read().strip())
+          except Exception:
+              _st = int(time.time())
+          elapsed = int(time.time()) - _st
+          rounded = math.ceil(cost * 100) / 100
+          rows = [
+              ('Time', _fmt_ela(elapsed)),
+              ('Iterations', iterations_fmt),
+              ('Input', _fmt_tok(input_tokens) + ' tokens'),
+              ('Output', _fmt_tok(output_tokens) + ' tokens'),
+              ('**Cost**', f'**${rounded:.2f}**'),
+          ]
+          _tbl = ['', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
+          _tbl += [f'| {k} | {v} |' for k, v in rows]
+          # --- Cumulative cost tracking (via shared lib) ---
+          try:
+              import sys as _sys; _sys.path.insert(0, '.remote-dev-bot/lib')
+              from cumulative_cost import compute_cumulative_table
+              _cum = compute_cumulative_table(
+                  repo=os.environ.get('GITHUB_REPOSITORY', ''),
+                  number=os.environ.get('COST_TARGET_NUMBER', ''),
+                  current_cost=cost,
+                  current_input_tokens=input_tokens,
+                  current_output_tokens=output_tokens,
+              )
+              if _cum:
+                  _tbl.append('')
+                  _tbl.append(_cum)
+          except Exception as _e:
+              print(f"Cumulative cost computation failed (non-fatal): {_e}")
+          open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
+          PYEOF
+
+          # Append cost table to result comment
+          if [ -f /tmp/cost_table.txt ]; then
+            cat /tmp/cost_table.txt >> /tmp/delegate_result_comment.md
           fi
 
           gh issue comment "$ISSUE_NUMBER" \
@@ -4685,76 +4491,10 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --add-assignee "${{ github.event.comment.user.login }}"
 
-      - name: Append cost to PR
-        if: >-
-          always() &&
-          !(github.event.issue.pull_request || github.event.pull_request)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-        run: |
-          PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
-          if [ -z "$PR_URL" ]; then
-            echo "No PR URL found — skipping cost append"
-            exit 0
-          fi
-
-          ALIAS="${{ needs.parse.outputs.alias }}"
-          MODEL="${{ needs.parse.outputs.model }}"
-          ELAPSED=$(( $(date +%s) - $(cat /tmp/start_time 2>/dev/null || date +%s) ))
-
-          python3 << PYEOF
-          import json, math, os
-
-          elapsed = ${ELAPSED}
-          alias = "${ALIAS}"
-          model = "${MODEL}"
-
-          usage = {}
-          if os.path.exists("/tmp/llm_usage.json"):
-              with open("/tmp/llm_usage.json") as f:
-                  usage = json.load(f)
-
-          inp = usage.get("input_tokens", 0)
-          out = usage.get("output_tokens", 0)
-          cost = usage.get("cost") or 0.0
-          iters = usage.get("iterations", 0)
-
-          def _fmt(n):
-              if n >= 1_000_000:
-                  v = n / 1_000_000
-                  return f'{round(v)}M' if v >= 10 else f'{round(v, 1)}M'
-              elif n >= 1_000:
-                  v = n / 1_000
-                  return f'{round(v)}K' if v >= 10 else f'{round(v, 1)}K'
-              return str(n)
-
-          elapsed_fmt = f'{elapsed // 60}m {elapsed % 60}s' if elapsed >= 60 else f'{elapsed}s'
-          rounded = math.ceil(cost * 100) / 100
-
-          rows = [
-              ('Time', elapsed_fmt),
-              ('Iterations', str(iters)),
-              ('Input', f'{_fmt(inp)} tokens'),
-              ('Output', f'{_fmt(out)} tokens'),
-              ('**Cost**', f'**\${rounded:.2f}**'),
-          ]
-          _tbl = ['---', '', '### 💰 Cost', '', '| Metric | Value |', '|--------|-------|']
-          _tbl += [f'| {k} | {v} |' for k, v in rows]
-          open('/tmp/cost_table.txt', 'w').write('\n'.join(_tbl))
-          PYEOF
-
-          if [ ! -f /tmp/cost_table.txt ]; then
-            echo "Cost table generation failed — fallback step will handle it"
-            exit 0
-          fi
-
-          CURRENT_BODY=$(gh pr view "$PR_URL" --json body --jq '.body' 2>/dev/null || echo "")
-          COST_TABLE=$(cat /tmp/cost_table.txt)
-          printf '%s\n\n%s\n' "$CURRENT_BODY" "$COST_TABLE" > /tmp/pr_new_body.txt
-
-          gh pr edit "$PR_URL" --body-file /tmp/pr_new_body.txt
-          echo "cost embedded" > /tmp/cost_embedded
-          echo "Cost table appended to PR $PR_URL"
+      # NOTE: Delegate's "Append cost to PR" step was removed to prevent
+      # double-counting — delegate already posts cost as an issue comment
+      # (in "Post result comment" above), and the cumulative scanner would
+      # count both if the same cost table appeared on both the issue and PR.
 
       - name: Post cost comment (fallback)
         if: always()

--- a/lib/cumulative_cost.py
+++ b/lib/cumulative_cost.py
@@ -1,0 +1,266 @@
+"""Shared cumulative cost aggregation for remote-dev-bot.
+
+Scans prior issue/PR comments for per-step cost tables (### 💰 Cost),
+extracts metrics, and returns a cumulative summary table to append to
+the current step's cost comment.
+
+Usage from workflow Python heredoc:
+    import sys; sys.path.insert(0, 'lib')
+    from cumulative_cost import compute_cumulative_table
+    cum = compute_cumulative_table(repo, number, cost, input_tokens, ...)
+    if cum:
+        _tbl.append('')
+        _tbl.append(cum)
+"""
+
+import json
+import re
+import subprocess
+
+
+def _fmt_tok(n: int) -> str:
+    n = int(n)
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{round(v)}M" if v >= 10 else f"{round(v, 1)}M"
+    elif n >= 1_000:
+        v = n / 1_000
+        return f"{round(v)}K" if v >= 10 else f"{round(v, 1)}K"
+    return str(n)
+
+
+def _fmt_loc(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def extract_costs_from_text(text: str) -> tuple:
+    """Extract per-step cost metrics from text containing cost tables.
+
+    Returns (cost, loc_ins, loc_del, input_tokens, output_tokens, info_bits).
+
+    IMPORTANT: This function intentionally matches ONLY per-step format:
+      - Cost:   **$X.XX**  (bold)     — cumulative uses bare $X.XX
+      - Tokens: | Input |             — cumulative uses | Cumulative input |
+      - Info:   | Info |              — cumulative uses | Cumulative info |
+      - Diff:   | Diff |             — cumulative uses | Cumulative LOC |
+    Do NOT change the cumulative table labels to match per-step labels,
+    or future runs will double-count.
+    """
+    total_cost = 0.0
+    total_ins = 0
+    total_del = 0
+    total_in_tok = 0
+    total_out_tok = 0
+    total_info_bits = 0.0
+
+    # Bold cost values: **$X.XX** — only in per-step tables
+    for m in re.finditer(r'\*\*\$([0-9]+\.[0-9]+)\*\*', text):
+        total_cost += float(m.group(1))
+
+    # LOC from Diff rows: "N insertions(+), M deletions(-)"
+    for m in re.finditer(r'\| Diff \|[^|]*\|', text):
+        diff_cell = m.group(0)
+        ins = re.search(r'(\d+) insertion', diff_cell)
+        if ins:
+            total_ins += int(ins.group(1))
+        dl = re.search(r'(\d+) deletion', diff_cell)
+        if dl:
+            total_del += int(dl.group(1))
+
+    # Token counts: | Input | 42.5K tokens |  (NOT | Cumulative input |)
+    for m in re.finditer(r'\| Input \| ([0-9.]+)([KM]?) tokens \|', text):
+        v = float(m.group(1))
+        sfx = m.group(2)
+        if sfx == 'K':
+            v *= 1000
+        elif sfx == 'M':
+            v *= 1_000_000
+        total_in_tok += int(v)
+
+    for m in re.finditer(r'\| Output \| ([0-9.]+)([KM]?) tokens \|', text):
+        v = float(m.group(1))
+        sfx = m.group(2)
+        if sfx == 'K':
+            v *= 1000
+        elif sfx == 'M':
+            v *= 1_000_000
+        total_out_tok += int(v)
+
+    # Info bits: | Info | 1.2 Mbit |  (NOT | Cumulative info |)
+    for m in re.finditer(r'\| Info \| ([0-9.]+) (Kbit|Mbit) \|', text):
+        v = float(m.group(1))
+        if m.group(2) == 'Mbit':
+            v *= 1_000_000
+        else:
+            v *= 1_000
+        total_info_bits += v
+
+    return total_cost, total_ins, total_del, total_in_tok, total_out_tok, total_info_bits
+
+
+def _fetch_comments(repo: str, number: str) -> str:
+    """Fetch all comments + body for an issue/PR. Returns concatenated text."""
+    text_parts = []
+
+    # Fetch the issue/PR body
+    try:
+        r = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/{number}', '--jq', '.body // ""'],
+            capture_output=True, text=True, timeout=30,
+        )
+        if r.returncode == 0:
+            text_parts.append(r.stdout)
+    except Exception:
+        pass
+
+    # Fetch all comments (paginated)
+    try:
+        r = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/{number}/comments',
+             '--paginate', '--jq', '.[].body'],
+            capture_output=True, text=True, timeout=60,
+        )
+        if r.returncode == 0:
+            text_parts.append(r.stdout)
+    except Exception:
+        pass
+
+    return '\n'.join(text_parts)
+
+
+def _find_linked_issue(repo: str, number: str, text: str) -> str | None:
+    """If number is a PR, find the linked issue via Fixes/Closes/Resolves #N.
+
+    Also checks the PR title via API.
+    """
+    # Check if this is a PR (has pull_request key)
+    try:
+        r = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/{number}',
+             '--jq', '.pull_request // empty'],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode != 0 or not r.stdout.strip():
+            return None  # Not a PR
+    except Exception:
+        return None
+
+    # It's a PR — look for linked issue in body text
+    m = re.search(r'(?:Fixes|Closes|Resolves)\s+#([0-9]+)', text, re.IGNORECASE)
+    if m:
+        return m.group(1)
+
+    # Also check the PR title
+    try:
+        r = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/{number}', '--jq', '.title // ""'],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0:
+            m = re.search(r'(?:Fixes|Closes|Resolves)\s+#([0-9]+)',
+                           r.stdout, re.IGNORECASE)
+            if m:
+                return m.group(1)
+    except Exception:
+        pass
+
+    return None
+
+
+def compute_cumulative_table(
+    repo: str,
+    number: str,
+    current_cost: float,
+    current_input_tokens: int,
+    current_output_tokens: int,
+    current_loc: int = 0,
+    current_info_bits: float = 0,
+) -> str:
+    """Scan prior comments for cost tables, add current step, return cumulative markdown.
+
+    Returns the cumulative table as a markdown string, or '' if fewer than 2 total steps.
+    The returned string should be appended to the per-step cost table.
+
+    Args:
+        repo: GitHub repository (owner/name)
+        number: Issue or PR number to scan and post to
+        current_cost: This step's cost in dollars
+        current_input_tokens: This step's input token count
+        current_output_tokens: This step's output token count
+        current_loc: This step's LOC changed (insertions + deletions)
+        current_info_bits: This step's compressed diff size in bits
+    """
+    if not repo or not number:
+        return ''
+
+    # Collect all text to scan
+    all_text = _fetch_comments(repo, number)
+
+    # If this is a PR, also scan the linked issue
+    linked_issue = _find_linked_issue(repo, number, all_text)
+    if linked_issue:
+        issue_text = _fetch_comments(repo, linked_issue)
+        all_text += '\n' + issue_text
+
+    # Count prior cost tables
+    num_prior = len(re.findall(r'### 💰 Cost', all_text))
+    if num_prior == 0:
+        return ''  # This is the first step — no cumulative needed
+
+    # Extract prior costs
+    prior_cost, prior_ins, prior_del, prior_in_tok, prior_out_tok, prior_info = \
+        extract_costs_from_text(all_text)
+
+    # Compute cumulative (prior + current)
+    cum_steps = num_prior + 1
+    cum_cost = prior_cost + current_cost
+    cum_loc = (prior_ins + prior_del) + current_loc
+    cum_in_tok = prior_in_tok + current_input_tokens
+    cum_out_tok = prior_out_tok + current_output_tokens
+    cum_info = prior_info + current_info_bits
+
+    if cum_cost <= 0:
+        return ''
+
+    # Build cumulative table
+    # FORMATTING RULES (anti-double-counting):
+    #   - Use "Cumulative cost" (not "Cost" or "**Cost**")
+    #   - Use bare $X.XX (not **$X.XX**)
+    #   - Use "Cumulative input/output/info" (not "Input"/"Output"/"Info")
+    #   - Use "Cumulative LOC" (not "Diff")
+    lines = [
+        f'### \U0001f4ca Feature total ({cum_steps} steps)',
+        '',
+        '| Metric | Value |',
+        '|--------|-------|',
+        f'| Cumulative cost | ${cum_cost:.2f} |',
+    ]
+
+    if cum_loc > 0:
+        lines.append(f'| Cumulative LOC | ~{_fmt_loc(cum_loc)} (estimate) |')
+        cum_loc_per_dollar = int(cum_loc / cum_cost) if cum_cost > 0 else 0
+        if cum_loc_per_dollar > 0:
+            lines.append(f'| Cumulative LOC/$ | ~{_fmt_loc(cum_loc_per_dollar)} loc/$ |')
+
+    if cum_info > 0:
+        info_str = (f"{cum_info / 1_000_000:.1f} Mbit"
+                    if cum_info >= 1_000_000
+                    else f"{cum_info / 1_000:.1f} Kbit")
+        lines.append(f'| Cumulative info | {info_str} |')
+        if cum_cost > 0:
+            bpd = cum_info / cum_cost
+            bpd_str = (f"{bpd / 1_000_000:.1f} Mbit/$"
+                       if bpd >= 1_000_000
+                       else f"{bpd / 1_000:.1f} Kbit/$")
+            lines.append(f'| Cumulative info/$ | {bpd_str} |')
+
+    if cum_in_tok > 0:
+        lines.append(f'| Cumulative input | {_fmt_tok(cum_in_tok)} tokens |')
+    if cum_out_tok > 0:
+        lines.append(f'| Cumulative output | {_fmt_tok(cum_out_tok)} tokens |')
+
+    return '\n'.join(lines)


### PR DESCRIPTION
## Summary

- Extract duplicated cumulative cost logic from resolve/build into shared `lib/cumulative_cost.py`
- Add cumulative cost tracking to review, reconcile, design, and delegate (previously only resolve/build had it)
- Fix pre-existing token double-counting bug: cumulative table now uses `Cumulative input`/`Cumulative output` labels so the scanner won't match them on subsequent runs
- Remove delegate's redundant "Append cost to PR" step that caused double-counting
- Cumulative scanner traces PR → linked issue to aggregate costs across both threads
- Net reduction of ~260 lines of duplicated inline code

Fixes #532

## Test plan

- [ ] Trigger `/agent-resolve` on an issue → verify per-step cost table appears, no cumulative (first step)
- [ ] Trigger a second `/agent-resolve` or `/agent-reconcile` on the same issue's PR → verify cumulative "Feature total (2 steps)" section appears
- [ ] Verify cumulative rows use `Cumulative cost`, `Cumulative input`, etc. (not `Cost`, `Input`)
- [ ] Trigger `/agent-design` → verify cost table appears with cumulative if prior steps exist
- [ ] Trigger `/agent-review` on a PR → verify cumulative includes costs from linked issue
- [ ] Verify no `_extract_costs_from_text` remains inline in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)