### PR TITLE
Fix YAML parse error breaking all agent triggers

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -341,12 +341,7 @@ jobs:
             PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
             if [[ -z "$PR_URL" ]]; then
               TARGET_BRANCH="${{ needs.parse.outputs.target_branch }}"
-              DRAFT_BODY="⚠️ **Partial work** — agent terminated unexpectedly before completing the task.
-
-This draft PR contains whatever was committed and pushed during the run. To continue, trigger \`/agent-resolve\` as a comment on this PR and the agent will pick up from this branch.
-
-Fixes #${ISSUE_NUMBER}"
-              echo "$DRAFT_BODY" > /tmp/safety_net_pr_body.txt
+              printf '⚠️ **Partial work** — agent terminated unexpectedly before completing the task.\n\nThis draft PR contains whatever was committed and pushed during the run. To continue, trigger `/agent-resolve` as a comment on this PR and the agent will pick up from this branch.\n\nFixes #%s\n' "$ISSUE_NUMBER" > /tmp/safety_net_pr_body.txt
               gh pr create \
                 --draft \
                 --repo "${{ github.repository }}" \
@@ -962,12 +957,7 @@ Fixes #${ISSUE_NUMBER}"
             PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log 2>/dev/null | head -1)
             if [[ -z "$PR_URL" ]]; then
               TARGET_BRANCH="${{ needs.parse.outputs.target_branch }}"
-              DRAFT_BODY="⚠️ **Partial work** — agent terminated unexpectedly before completing the task.
-
-This draft PR contains whatever was committed and pushed during the run. To continue, trigger \`/agent-resolve\` as a comment on this PR and the agent will pick up from this branch.
-
-Fixes #${ISSUE_NUMBER}"
-              echo "$DRAFT_BODY" > /tmp/safety_net_pr_body.txt
+              printf '⚠️ **Partial work** — agent terminated unexpectedly before completing the task.\n\nThis draft PR contains whatever was committed and pushed during the run. To continue, trigger `/agent-resolve` as a comment on this PR and the agent will pick up from this branch.\n\nFixes #%s\n' "$ISSUE_NUMBER" > /tmp/safety_net_pr_body.txt
               gh pr create \
                 --draft \
                 --repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary

- Fix YAML syntax error introduced in commit 188496c ("Add draft PR creation to Safety-net push step")
- The `DRAFT_BODY` bash multiline string had continuation lines at column 1, which the YAML parser interpreted as the end of the `run: |` block
- This broke the **entire workflow file** — no agent triggers worked in any repo since that commit landed on dev
- Replace with `printf` to keep the string on one logical line

## Test plan

- [ ] Trigger `/agent-resolve` on bridge-analysis and verify the workflow starts
- [ ] Verify YAML validates: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/remote-dev-bot.yml'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)