### PR TITLE
Retire bug-fix-to-main exception in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,12 +136,12 @@ config layer, but there is no documented use case for this —
 | `dev`      | Long-lived integration branch, accumulates work ahead of `main`   | `dogfood.yml@dev` (rdb self-dev)         |
 | `e2e-test` | Ephemeral test pointer, reset by e2e scripts before each test run | `remote-dev-bot-test` shim               |
 
-**Pre-1.0 (current):** Two branches — `dev` and `main`. Small stable changes
-can PR directly to `main`; after merging, do a `git merge origin/main` on `dev`
-(trivial fast-forward since `dev` is a superset of `main`). Larger or
-experimental changes PR to `dev` and promote to `main` when baked. Accept
-occasional breakage on `main` — the cost of a broken main is low before there
-are real users, and the cost of extra process is paid every day.
+**Pre-1.0 (current):** Two branches — `dev` and `main`. **All PRs target `dev`**,
+regardless of size or risk. The earlier "small stable changes can PR directly to
+`main`" exception was retired after a classification failure produced overlapping
+fixes (PRs #488 / #503 / #512 / #513) that required real cleanup work. The
+single-target rule eliminates the classification step entirely. When `dev` is
+ready to release, merge `dev` → `main` and tag.
 
 **Post-1.0:** Graduate to three branches:
 
@@ -156,9 +156,8 @@ free-flowing; `staging` → `main` is the deliberate go/no-go moment. For this
 project "QA" means running `e2e.sh` and spot-checking a couple live triggers —
 roughly 20 minutes per release.
 
-Until then: **PRs go to `dev`** (or directly to `main` for small, ready
-changes). When `dev` is ready to release: run the full test suite, then merge
-`dev` → `main` and tag.
+Until then: **all PRs target `dev`**. When `dev` is ready to release, run the
+full test suite, then merge `dev` → `main` and tag.
 
 ### Dogfood shim (`dogfood.yml`)
 


### PR DESCRIPTION
## Summary

- AGENTS.md already documents the dev-only branch model (all PRs target \`dev\`, no bug-fix exception) with the PRs #488 / #503 / #512 / #513 cleanup as the rationale.
- CONTRIBUTING.md still said "small stable changes can PR directly to \`main\`" and "(or directly to \`main\` for small, ready changes)" — directly contradicted AGENTS.md and recreated the classification step that AGENTS.md explicitly retired.
- This PR aligns CONTRIBUTING.md to match: all PRs target \`dev\`, regardless of size or risk.

## Test plan

- [ ] Read CONTRIBUTING.md "Branch Model" section — confirm wording is consistent with AGENTS.md
- [ ] No code changes; no test runs needed