### PR TITLE
Add .gemini/GEMINI.md pointer to AGENTS.md

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,0 +1,3 @@
+# GEMINI.md
+
+**Read AGENTS.md in the repository root now before doing anything else.** It contains project conventions, key files, PR policy, and code style guidelines that govern all work in this repo.


### PR DESCRIPTION
## Summary

- Repo already has AGENTS.md and CLAUDE.md (CLAUDE.md points at AGENTS.md). Gemini was missing the equivalent.
- Adds \`.gemini/GEMINI.md\` from \`brain/agents-template\` — same one-line pointer pattern as CLAUDE.md.

## Test plan

- [ ] Open a Gemini session in this repo, confirm AGENTS.md is read on startup
- [ ] No code changes; no test runs needed