### PR TITLE
chore(lib): remove unused 'import json' from workshop.py (#557)

### DIFF
--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -15,7 +15,6 @@ follow-up.
 """
 
 import gzip
-import json
 import math
 import os
 import re


### PR DESCRIPTION
Closes #557 (workshop.py half).

## What

`lib/workshop.py` declared `import json` (line 18) but never used it.

```
$ grep -c "json\." lib/workshop.py
0
```

The only `json` match in the file is the import line itself.

## Note on `cumulative_cost.py`

The issue also mentions `lib/cumulative_cost.py`, but that file
does not exist in the current tree:

```
$ ls lib/cumulative_cost*
ls: lib/cumulative_cost*: No such file or directory
$ grep -r "cumulative_cost" .
(no matches)
```

Either the file was already removed in a prior cleanup or the
issue's path is stale. This PR addresses only the workshop.py
half; happy to follow up if the second file resurfaces under a
different name.

## Verification

- `python -c "import lib.workshop"` succeeds.
- `pytest tests/ -q` → 312 passed.