### PR TITLE
Make cross-repo app token scope opt-in; advertise gh CLI in bash tool

### DIFF
--- a/.github/actions/setup-rdb/action.yml
+++ b/.github/actions/setup-rdb/action.yml
@@ -31,6 +31,15 @@ inputs:
     description: 'Whether to include /remote-dev-bot.yaml in the sparse checkout'
     required: false
     default: 'true'
+  app_token_owner:
+    description: >-
+      Optional: scope the generated app token to all repos under this owner
+      that have the App installed. Empty (default) keeps the token scoped to
+      the current repo only. Used by the rdb-internal dogfood shim so
+      self-debugging agents can read other repos owned by the same user;
+      not set by the public agent.yml shim.
+    required: false
+    default: ''
 
 outputs:
   token:
@@ -47,7 +56,7 @@ runs:
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}
-        owner: ${{ github.repository_owner }}
+        owner: ${{ inputs.app_token_owner }}
 
     - name: Checkout target repository
       uses: actions/checkout@v5

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -35,6 +35,11 @@ jobs:
     with:
       rdb_ref: dev
       command_prefix: dogfood
+      # Broaden app token scope to all repos under this owner that have the App
+      # installed, so self-debugging dogfood runs in rdb can read issues/PRs/run
+      # logs from other repos (e.g. bridge-analysis) when fixing rdb itself.
+      # NOT set in agent.yml — public users get current-repo-only scope.
+      app_token_owner: ${{ github.repository_owner }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: 'agent'
         type: string
+      app_token_owner:
+        description: 'Optional: scope the generated GitHub App token to all repos under this owner instead of just the current repo. Empty (default) keeps current-repo-only scope. Set by the rdb-internal dogfood shim so self-debugging agents can read other repos owned by the same user; not set by the public agent.yml shim.'
+        required: false
+        default: ''
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -92,6 +97,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
 
       - name: Install PyYAML
         run: pip install PyYAML
@@ -143,6 +149,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           include_rdb_config: 'false'
 
       - name: Determine API key
@@ -675,6 +682,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           include_rdb_config: 'false'
 
       - name: Determine API key
@@ -1330,6 +1338,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           fetch_depth: '0'
 
       - name: Install dependencies
@@ -1986,6 +1995,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           fetch_depth: '0'
           include_rdb_config: 'false'
 
@@ -2312,6 +2322,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           target_ref: ${{ steps.resolve_ref.outputs.ref }}
 
       - name: Capture checkout info
@@ -2930,6 +2941,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           target_ref: ${{ steps.resolve_ref.outputs.ref }}
 
       - name: Install dependencies
@@ -3209,6 +3221,7 @@ jobs:
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
           pat_token: ${{ secrets.RDB_PAT_TOKEN }}
           rdb_ref: ${{ inputs.rdb_ref }}
+          app_token_owner: ${{ inputs.app_token_owner }}
           target_ref: ${{ needs.parse.outputs.target_branch }}
 
       - name: Install dependencies

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -635,6 +635,10 @@ TOOLS = [
             "description": (
                 "Execute a bash command in the repository root. "
                 "Use this to read files, make edits, run tests, git add/commit/push, etc. "
+                "The `gh` CLI is available with a working GH_TOKEN, so you can also run "
+                "`gh issue view N`, `gh pr view N`, `gh run view RUN_ID --log`, "
+                "`gh api repos/<owner>/<repo>/...`, etc. to inspect issues, PRs, "
+                "comments, and Actions run logs when that helps you debug. "
                 "Commands have a 30-second timeout."
             ),
             "parameters": {


### PR DESCRIPTION
Two changes to support self-debugging dogfood runs without giving the same broad scope to public users.

## 1. Make cross-repo app token scope opt-in

**Background:** the `setup-rdb` composite action (added in #596) hardcoded
`owner: ${{ github.repository_owner }}` on `create-github-app-token@v3`. That meant every App-using invocation got an account-wide token covering all repos under the owner that have the App installed. Broader than intended for routine /agent-resolve runs in non-rdb repos.

**Change:** add an opt-in `app_token_owner` input that threads through:

- `.github/actions/setup-rdb/action.yml`: new `app_token_owner` input (default `''`), passed to the action's `owner:` parameter. Empty falls back to current-repo scope (the action's documented behavior).
- `.github/workflows/remote-dev-bot.yml`: matching `workflow_call` input; threaded through all 8 setup-rdb call sites.
- `.github/workflows/dogfood.yml`: passes `app_token_owner: ${{ github.repository_owner }}` so dogfood-triggered runs in rdb get cross-repo scope.
- `.github/workflows/agent.yml`: **not modified** — public users continue with current-repo scope only.

**Effect:** only `/dogfood` invocations in this repo get cross-repo access. `/agent-*` invocations anywhere — including in other repos owned by the same user — get current-repo scope only. This matches the desired security/scope posture (broaden only where genuinely needed for self-debugging).

## 2. Advertise the gh CLI in resolve's bash tool description

The resolve agent's `bash` tool inherits `GH_TOKEN` from the workflow environment, so `gh issue view N`, `gh pr view N`, `gh run view RUN_ID --log`, `gh api repos/...`, etc. all work. But the tool description didn't mention this, so the model often introspected "I only have local file tools" when asked about GitHub access. Added an explicit hint.

**Note:** `lib/design_loop.py`'s tool set does **not** include `bash` (only `read_file`, `grep`, `submit_analysis`), so the gh hint doesn't apply there. Whether the design loop should gain bash, or narrower gh-only tools, is a separate scope decision and not part of this PR.

## Verification

- All YAML files parse: `python3 -c "import yaml; yaml.safe_load(open(f))"` for each.
- `lib/resolve.py` parses (`ast.parse`).
- `pytest tests/ -q` not run locally (no pytest available on the dev VPS); CI will run it on this PR.
- Functional smoke: this should be exercised by the next /dogfood run after merge — if cross-repo scope works, the agent will be able to `gh issue view N --repo gnovak/some-other-repo` from within an rdb run.

## Files changed

```
 .github/actions/setup-rdb/action.yml | 11 ++++++++++-
 .github/workflows/dogfood.yml        |  5 +++++
 .github/workflows/remote-dev-bot.yml | 13 +++++++++++++
 lib/resolve.py                       |  4 ++++
 4 files changed, 32 insertions(+), 1 deletion(-)
```
