### PR TITLE
Add narrow gh tool to design loop for read-only GitHub inspection

### DIFF
--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -13,6 +13,7 @@ import sys
 from lib.tools import (
     validate_path as _tools_validate_path,
     execute_read_file as _tools_execute_read_file,
+    execute_gh as _tools_execute_gh,
 )
 
 
@@ -64,6 +65,34 @@ TOOLS = [
                     },
                 },
                 "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "gh",
+            "description": (
+                "Run a `gh` CLI command to inspect GitHub state — issues, PRs, "
+                "comments, Actions run logs, etc. Read-only inspection only; do "
+                "not use this for write operations (no commenting, no editing, "
+                "no merging). Provide the subcommand and arguments without the "
+                "leading 'gh'. Examples: `issue view 584`, "
+                "`pr view 597 --json title,body,comments`, "
+                "`run view 25084646693 --log`, "
+                "`api repos/owner/repo/issues/N/comments`. "
+                "Token scope is current-repo by default; cross-repo when the "
+                "workflow was invoked via /dogfood. 30-second timeout."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "args": {
+                        "type": "string",
+                        "description": "gh subcommand and arguments, without the leading 'gh'.",
+                    }
+                },
+                "required": ["args"],
             },
         },
     },
@@ -137,12 +166,19 @@ def execute_grep(pattern, path=None):
         return f"Error executing grep: {e}"
 
 
+def execute_gh(args):
+    """Execute the gh tool (delegates to lib.tools.execute_gh)."""
+    return _tools_execute_gh(args)
+
+
 def execute_tool(tool_name, arguments):
     """Execute a tool and return the result."""
     if tool_name == "read_file":
         return execute_read_file(arguments.get("path", ""))
     elif tool_name == "grep":
         return execute_grep(arguments.get("pattern", ""), arguments.get("path"))
+    elif tool_name == "gh":
+        return execute_gh(arguments.get("args", ""))
     elif tool_name == "submit_analysis":
         return arguments.get("analysis", "")
     else:
@@ -155,9 +191,13 @@ def execute_tool(tool_name, arguments):
 
 DEFAULT_SYSTEM_PROMPT = (
     "You are analyzing a GitHub issue for design discussion using an agentic exploration loop. "
-    "You have access to tools to read files and search the codebase.\n\n"
+    "You have access to tools to read files, search the codebase, and inspect GitHub state.\n\n"
     "Your goal is to understand the issue, explore the relevant code, and produce a thorough "
-    "design analysis. Use the read_file and grep tools to explore the repository.\n\n"
+    "design analysis. Use the read_file and grep tools to explore the repository. "
+    "Use the gh tool when you need to look at GitHub state — past issues, PRs, comments, "
+    "or Actions run logs — for example when the question is 'why did run X fail' or "
+    "'what was discussed on issue Y'. The gh tool is for read-only inspection only; "
+    "do not use it to comment, edit, or merge.\n\n"
     "When you have gathered enough information, call the submit_analysis tool with your "
     "complete analysis in Markdown format.\n\n"
     "Your analysis should include:\n"

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -8,6 +8,7 @@ implementations with flags for the minor behavioral variants each caller needs.
 
 import os
 import re
+import shlex
 import subprocess
 
 
@@ -165,3 +166,54 @@ def execute_grep(pattern, path=None):
         return "Error: Search timed out"
     except Exception as e:
         return f"Error executing grep: {e}"
+
+
+def execute_gh(args, *, timeout=30):
+    """Run a `gh` CLI command for read-only GitHub-state inspection.
+
+    Arguments are parsed with shlex and passed to subprocess as a list, so
+    `gh` is invoked directly without a shell — shell metacharacters in the
+    input have no effect. The agent supplies arguments without the leading
+    "gh"; a leading "gh" is tolerated and stripped.
+
+    Authentication relies on GH_TOKEN being set in the process environment
+    (the workflow does this). Token scope (current-repo vs cross-repo) is
+    determined by the workflow's app-token configuration, not by this
+    function.
+
+    Parameters
+    ----------
+    args : str
+        The gh subcommand and arguments (e.g. "issue view 584",
+        "run view 25084646693 --log", "api repos/owner/repo/issues/N/comments").
+    timeout : int
+        Seconds before the command is killed. Default 30.
+    """
+    args = (args or "").strip()
+    if args.startswith("gh "):
+        args = args[3:].strip()
+    elif args == "gh":
+        args = ""
+    if not args:
+        return "Error: provide a gh subcommand (e.g. 'issue view 123')"
+    try:
+        parsed = shlex.split(args)
+    except ValueError as e:
+        return f"Error parsing gh arguments: {e}"
+    try:
+        result = subprocess.run(
+            ["gh"] + parsed,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        output = (result.stdout or "") + (result.stderr or "")
+        if result.returncode != 0:
+            output = f"(exit code {result.returncode})\n" + output
+        return output or "(no output)"
+    except subprocess.TimeoutExpired:
+        return f"Error: gh command timed out after {timeout} seconds"
+    except FileNotFoundError:
+        return "Error: gh CLI not found in PATH"
+    except Exception as e:
+        return f"Error executing gh: {e}"

--- a/tests/test_design_loop.py
+++ b/tests/test_design_loop.py
@@ -92,6 +92,22 @@ class TestExecuteTool:
         result = execute_tool("unknown_tool", {})
         assert "Unknown tool" in result
 
+    def test_gh_dispatches_to_gh(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            class R:
+                returncode = 0
+                stdout = "issue body"
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        result = execute_tool("gh", {"args": "issue view 584"})
+        assert result == "issue body"
+        assert captured["cmd"] == ["gh", "issue", "view", "584"]
+
 
 # ---------------------------------------------------------------------------
 # has_agent_command
@@ -123,16 +139,21 @@ class TestHasAgentCommand:
 # ---------------------------------------------------------------------------
 
 class TestToolDefinitions:
-    def test_has_three_tools(self):
-        assert len(TOOLS) == 3
+    def test_has_four_tools(self):
+        assert len(TOOLS) == 4
 
     def test_tool_names(self):
         names = {t["function"]["name"] for t in TOOLS}
-        assert names == {"read_file", "grep", "submit_analysis"}
+        assert names == {"read_file", "grep", "gh", "submit_analysis"}
 
     def test_all_tools_have_descriptions(self):
         for tool in TOOLS:
             assert tool["function"]["description"]
+
+    def test_gh_tool_takes_args(self):
+        gh_tool = next(t for t in TOOLS if t["function"]["name"] == "gh")
+        assert "args" in gh_tool["function"]["parameters"]["properties"]
+        assert gh_tool["function"]["parameters"]["required"] == ["args"]
 
 
 # ---------------------------------------------------------------------------
@@ -148,3 +169,6 @@ class TestSystemPrompt:
 
     def test_prompt_mentions_submit_analysis(self):
         assert "submit_analysis" in DEFAULT_SYSTEM_PROMPT
+
+    def test_prompt_mentions_gh_tool(self):
+        assert "gh" in DEFAULT_SYSTEM_PROMPT

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,111 @@
+"""Tests for lib/tools.py shared tool implementations.
+
+Currently covers execute_gh; other helpers are tested via the consuming
+modules' test files (test_design_loop, test_resolve, test_reconcile).
+"""
+
+import os
+import sys
+
+# Ensure lib/ is importable as a top-level package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib.tools import execute_gh
+
+
+class _FakeRun:
+    """Minimal stand-in for subprocess.run's CompletedProcess result."""
+
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+class TestExecuteGh:
+    def test_runs_subcommand_without_leading_gh(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            return _FakeRun(stdout="issue body")
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        result = execute_gh("issue view 584")
+        assert result == "issue body"
+        assert captured["cmd"] == ["gh", "issue", "view", "584"]
+
+    def test_strips_leading_gh(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            return _FakeRun(stdout="ok")
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        execute_gh("gh issue view 584")
+        assert captured["cmd"] == ["gh", "issue", "view", "584"]
+
+    def test_empty_input_returns_error(self):
+        assert "Error" in execute_gh("")
+        assert "Error" in execute_gh("   ")
+        assert "Error" in execute_gh("gh")
+        assert "Error" in execute_gh("gh ")
+
+    def test_handles_quoted_arguments(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            return _FakeRun(stdout="ok")
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        execute_gh('issue list --search "hello world"')
+        assert captured["cmd"] == ["gh", "issue", "list", "--search", "hello world"]
+
+    def test_unbalanced_quotes_returns_error(self):
+        result = execute_gh('issue list --search "unclosed')
+        assert "Error parsing" in result
+
+    def test_nonzero_exit_prefixes_output(self, monkeypatch):
+        def fake_run(cmd, *args, **kwargs):
+            return _FakeRun(stdout="", stderr="not found", returncode=1)
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        result = execute_gh("issue view 99999")
+        assert "exit code 1" in result
+        assert "not found" in result
+
+    def test_no_shell_interpolation(self, monkeypatch):
+        # Shell metacharacters should be passed as literal arguments to gh,
+        # not interpreted by a shell. This is enforced by passing a list to
+        # subprocess.run instead of shell=True.
+        captured = {}
+
+        def fake_run(cmd, *args, shell=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["shell"] = shell
+            return _FakeRun(stdout="ok")
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        execute_gh("issue view 1; rm -rf /")
+        # Whether shlex parses this in one shot or barfs, we never invoke a shell
+        assert captured.get("shell") in (None, False)
+
+    def test_gh_missing_returns_error(self, monkeypatch):
+        def fake_run(cmd, *args, **kwargs):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        result = execute_gh("issue view 1")
+        assert "gh CLI not found" in result
+
+    def test_timeout_returns_error(self, monkeypatch):
+        import subprocess as _subprocess
+
+        def fake_run(cmd, *args, **kwargs):
+            raise _subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+        monkeypatch.setattr("lib.tools.subprocess.run", fake_run)
+        result = execute_gh("api repos/owner/repo")
+        assert "timed out" in result


### PR DESCRIPTION
## What

Adds a narrow `gh` tool to the design loop for read-only GitHub state inspection — issues, PRs, comments, Actions run logs. The design loop deliberately has no `bash` tool (it's analysis-only), but that means it currently can't answer questions like "what happened on issue #584" or "why did run X fail" without me feeding it the data manually. This unblocks self-debugging dogfood runs without expanding into general-purpose bash.

## Why narrow `gh` instead of full `bash`

Full `bash` would be one line of wiring but quietly grants design the ability to run tests, modify files, exec arbitrary processes, etc. — none of which fit its analysis-only role. A narrow `gh` tool gives exactly the GitHub-state inspection capability needed for the user's stated use case (debugging via fetching issues/runs) without the scope creep.

## Implementation

- **`lib/tools.py`** — new `execute_gh(args, *, timeout=30)` helper. Tolerates a leading `gh`, parses with `shlex`, runs `gh` directly via `subprocess.run([...])` (list form, no shell — shell metacharacters in the input are passed as literal arguments to `gh`). Returns stdout+stderr; prefixes non-zero exit codes; handles `FileNotFoundError` and `TimeoutExpired`.
- **`lib/design_loop.py`** — imports `execute_gh`, adds the tool definition with examples, dispatches in `execute_tool`. `DEFAULT_SYSTEM_PROMPT` now mentions when to use it (and that it's read-only).
- **`tests/test_tools.py`** — new file with 9 focused `execute_gh` tests: argument parsing, leading-`gh` stripping, empty input, quoted args, unbalanced quotes, non-zero exit, no-shell-interpolation, `gh`-missing, timeout. All mock `subprocess.run`.
- **`tests/test_design_loop.py`** — update `test_has_three_tools` → `test_has_four_tools`; update tool-name set; add dispatch test that monkeypatches `lib.tools.subprocess.run` and verifies `execute_tool("gh", {"args": "issue view 584"})` builds `["gh", "issue", "view", "584"]`; add prompt assertion.

## Token scope

The token scope mechanism from #597 (`app_token_owner`) handles whether `gh` calls reach other repos. By default the workflow scopes the App token to the current repo only; `/dogfood` invocations in this repo opt into owner-wide scope. The tool description mentions both cases so the model knows what it can reach.

## Use cases this unblocks

The user's recent `/dogfood design` runs on issues #584, #585, #593, #594 were all asking "what happened in run X / on issue Y" — questions that needed `gh issue view`, `gh run view --log`, or `gh api repos/.../comments`. With this PR, those calls will work directly.

## Verification

- All four files parse cleanly (`ast.parse` for Python, structural smoke).
- Smoke imports verify `len(TOOLS) == 4`, names include `gh`, empty input returns the expected error.
- `pytest` not available on the dev VPS (still — see #559); CI will run the full suite on this PR.

## Files changed

```
 lib/design_loop.py            |  37 +++++++++++--
 lib/tools.py                  |  53 ++++++++++++++++++
 tests/test_design_loop.py     |  29 +++++++++-
 tests/test_tools.py           | 118 ++++++++++++++++++++++++++++++++++++++++ (new)
 4 files changed, 232 insertions(+), 5 deletions(-)
```
