### PR TITLE
Don't misreport iteration exhaustion when an exception broke the loop

### DIFF
--- a/lib/context.py
+++ b/lib/context.py
@@ -9,6 +9,35 @@ import json
 import re
 
 
+def classify_provider_error(e):
+    """Surface provider-side error messages cleanly.
+
+    LiteLLM wraps provider errors and embeds the JSON response body in the
+    string. The actually-useful message (e.g. Anthropic's "You have reached
+    your specified API usage limits...") is buried inside that JSON. This
+    helper extracts it for human-readable reporting.
+
+    Returns a string in the form "{Provider} API error: {message}" when a
+    structured provider error can be parsed, or the unchanged str(e)
+    otherwise.
+
+    Examples:
+        >>> classify_provider_error("litellm.BadRequestError: AnthropicException - "
+        ...     '{"type":"error","error":{"type":"invalid_request_error",'
+        ...     '"message":"You have reached your specified API usage limits."}}')
+        'Anthropic API error: You have reached your specified API usage limits.'
+    """
+    msg = str(e)
+    m = re.search(
+        r'(\w+)Exception\b.*?"message":\s*"([^"]+)"',
+        msg,
+        re.DOTALL,
+    )
+    if m:
+        return f"{m.group(1)} API error: {m.group(2)}"
+    return msg
+
+
 # Patterns that indicate a bash command is a "write" operation.
 # Write operation results are protected from being dropped by trim_tool_results,
 # so context about what was actually changed is preserved longer.

--- a/lib/reconcile.py
+++ b/lib/reconcile.py
@@ -24,7 +24,11 @@ from litellm import completion
 # reconcile.py runs from a target repo's working directory.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from lib.context import compact_messages, estimate_tokens
+from lib.context import (
+    classify_provider_error,
+    compact_messages,
+    estimate_tokens,
+)
 from lib.tools import (
     validate_path,
     is_dangerous_command,
@@ -454,6 +458,12 @@ def main():
     rate_limit_retries = 0
     MAX_RATE_LIMIT_RETRIES = 3
 
+    # Tracks whether the for-loop ran to completion without `break`. Used by
+    # the post-loop code below to distinguish "agent truly exhausted iterations"
+    # from "the loop broke out early via an exception handler that already
+    # wrote a more specific status".
+    loop_completed_naturally = False
+
     try:
         for iteration in range(MAX_ITERATIONS):
             last_iteration = iteration
@@ -696,6 +706,9 @@ def main():
                         print(f"  [Status log iter {iteration + 1}]: {first_sentence[:100]}")
                 except Exception as e:
                     print(f"  [Status log] failed at iteration {iteration + 1}: {e}")
+        else:
+            # for-else: only runs if the for loop completed without `break`.
+            loop_completed_naturally = True
 
     finally:
         write_usage(total_input_tokens, total_output_tokens, total_cost, last_iteration + 1)
@@ -718,7 +731,9 @@ def main():
             print(f"Could not post status log comment: {e}")
 
     if finish_args is None:
-        write_status(False, "Agent exhausted all iterations without calling finish()")
+        if loop_completed_naturally:
+            write_status(False, "Agent exhausted all iterations without calling finish()")
+        # else: a more specific status was written by the exception handler that broke the loop
         print("Agent did not call finish() — treating as failure")
         # Safety: if a mid-rebase state was left, abort it
         try:
@@ -770,7 +785,7 @@ if __name__ == "__main__":
         import traceback
         print(f"Unhandled exception in reconcile.py: {e}")
         traceback.print_exc()
-        write_status(False, f"Agent crashed: {e}")
+        write_status(False, f"Agent crashed: {classify_provider_error(e)}")
         # Safety: abort any in-progress rebase
         try:
             if os.path.exists(".git/rebase-merge") or os.path.exists(".git/rebase-apply"):

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -26,7 +26,12 @@ from litellm import completion
 # resolve.py runs from a target repo's working directory.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from lib.context import compact_messages, completion_with_retries, estimate_tokens
+from lib.context import (
+    classify_provider_error,
+    compact_messages,
+    completion_with_retries,
+    estimate_tokens,
+)
 from lib.tools import (
     validate_path,
     is_dangerous_command,
@@ -1208,6 +1213,12 @@ def main():
     rate_limit_retries = 0
     MAX_RATE_LIMIT_RETRIES = 3
 
+    # Tracks whether the for-loop ran to completion without `break`. Used by
+    # the post-loop code below to distinguish "agent truly exhausted iterations"
+    # from "the loop broke out early via an exception handler that already
+    # wrote a more specific status" (e.g., BadRequestError on spend-limit).
+    loop_completed_naturally = False
+
     try:
         for iteration in range(MAX_ITERATIONS):
             last_iteration = iteration
@@ -1729,6 +1740,10 @@ def main():
                             print(f"  [Status log iter {iteration + 1}]: {first_sentence[:100]}")
                 except Exception as e:
                     print(f"  [Status log] failed at iteration {iteration + 1}: {e}")
+        else:
+            # for-else: only runs if the for loop completed without `break`.
+            # If we reach here, the agent truly exhausted MAX_ITERATIONS.
+            loop_completed_naturally = True
 
     # Write usage data (always, even on exception)
     finally:
@@ -1798,7 +1813,12 @@ def main():
 
     # Handle finish
     if finish_args is None:
-        write_status(False, "Agent exhausted all iterations without calling finish()")
+        # Only claim "exhausted" if the for-loop ran to completion. If it
+        # broke out early via an exception handler (BadRequestError, rate
+        # limit, etc.), that handler already wrote a more specific status
+        # — don't overwrite it with the generic exhaustion message.
+        if loop_completed_naturally:
+            write_status(False, "Agent exhausted all iterations without calling finish()")
         print("Agent did not call finish() — treating as failure")
         # Safety net: push any local commits the agent made but forgot to push.
         # Unpushed commits are lost when the runner shuts down, so we attempt a
@@ -1820,9 +1840,15 @@ def main():
         if ISSUE_TYPE == "issue" and remote_branch_exists and ON_FAILURE == "draft":
             try:
                 last_status = status_log[-1][1] if status_log else "No status recorded."
+                if loop_completed_naturally:
+                    headline = (
+                        f"agent exhausted all {MAX_ITERATIONS} iterations "
+                        "without completing the task."
+                    )
+                else:
+                    headline = "agent did not finish the task \u2014 see status below."
                 draft_body = (
-                    f"\u26a0\ufe0f **Partial work** \u2014 agent exhausted all {MAX_ITERATIONS} iterations "
-                    f"without completing the task.\n\n"
+                    f"\u26a0\ufe0f **Partial work** \u2014 {headline}\n\n"
                     f"This draft PR contains whatever was committed and pushed during the run. "
                     f"To continue, trigger `/agent-resolve` as a comment on this PR and the "
                     f"agent will pick up from this branch.\n\n"
@@ -1957,6 +1983,6 @@ if __name__ == "__main__":
         import traceback
         print(f"Unhandled exception in resolve.py: {e}")
         traceback.print_exc()
-        write_status(False, f"Agent crashed: {e}")
+        write_status(False, f"Agent crashed: {classify_provider_error(e)}")
     finally:
         _cleanup()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from lib.context import trim_tool_results, completion_with_retries
+from lib.context import classify_provider_error, trim_tool_results, completion_with_retries
 
 
 # ---------------------------------------------------------------------------
@@ -496,3 +496,49 @@ class TestCompletionWithRetries:
 
         assert result is expected
         assert fn.call_count == 6
+
+
+# ---------------------------------------------------------------------------
+# classify_provider_error
+# ---------------------------------------------------------------------------
+
+class TestClassifyProviderError:
+    def test_extracts_anthropic_message(self):
+        e = (
+            'litellm.BadRequestError: AnthropicException - '
+            '{"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"You have reached your specified API usage limits. '
+            'You will regain access on 2026-05-01 at 00:00 UTC."},"request_id":"req_X"}'
+        )
+        result = classify_provider_error(e)
+        assert result.startswith("Anthropic API error: ")
+        assert "You have reached your specified API usage limits" in result
+        assert "2026-05-01" in result
+        # The noisy LiteLLM/JSON wrapper should not appear in the cleaned form
+        assert "BadRequestError" not in result
+        assert "request_id" not in result
+
+    def test_extracts_openai_message(self):
+        e = (
+            'litellm.RateLimitError: OpenAIException - '
+            '{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}'
+        )
+        result = classify_provider_error(e)
+        assert result == "OpenAI API error: Rate limit exceeded"
+
+    def test_unstructured_string_returned_unchanged(self):
+        # Plain ConnectionError or similar with no embedded JSON
+        e = "ConnectionResetError: peer closed the connection"
+        assert classify_provider_error(e) == e
+
+    def test_exception_object_str_used(self):
+        # Should accept exception objects (calling str()) as well as strings
+        try:
+            raise ValueError("plain message")
+        except ValueError as exc:
+            assert classify_provider_error(exc) == "plain message"
+
+    def test_no_message_field_falls_back(self):
+        # An "Exception" pattern but no JSON message → fallback to original
+        e = "Some weird AnthropicException happened with no JSON"
+        assert classify_provider_error(e) == e


### PR DESCRIPTION
Fixes #595.

## What was happening

When `completion_with_retries` raised a `BadRequestError` (or `RateLimitError`, `APIConnectionError`, etc.) inside the agent loop, the matching `except` handler correctly wrote a specific status — e.g. `"Bad request at iteration 41: ...invalid_request_error...usage limits..."` — and broke out of the loop. But the post-loop code at `if finish_args is None:` then unconditionally wrote `"Agent exhausted all iterations without calling finish()"`, overwriting the meaningful status with a misleading generic one.

Verified from #570's logs (run `25078505015`):

```
21:31:40  === Iteration 40/100 ===            (last successful iteration)
21:31:42  === Iteration 41/100 ===
21:31:47  AnthropicException — You have reached your specified API usage limits...
          Agent did not call finish() — treating as failure
```

The user saw "exhausted all iterations" even though only 41/100 actually ran. That's the question this PR answers definitively.

## The fix

Track whether the for-loop completed normally via Python's for-else pattern. Only emit the "exhausted" status when the loop ran to completion; when it broke out early, leave the exception handler's specific status in place.

Also surface common provider-error messages cleanly via a new `classify_provider_error(e)` helper in `lib/context.py`. It extracts the inner `"message"` field from LiteLLM-wrapped provider errors:

| Before | After |
|---|---|
| `Agent crashed: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC."},"request_id":"req_X"}` | `Agent crashed: Anthropic API error: You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC.` |

## Files

- `lib/resolve.py` — for-else with `loop_completed_naturally` flag; guarded `write_status` call; updated draft-PR body language to drop "exhausted all N iterations" when the loop broke early; broad-except uses `classify_provider_error`.
- `lib/reconcile.py` — same for-else fix; broad-except uses `classify_provider_error`.
- `lib/context.py` — new `classify_provider_error(e)`. Also includes a doctest example.
- `tests/test_context.py` — `TestClassifyProviderError` covering Anthropic, OpenAI, unstructured strings, exception objects, and no-message-field fallback.

## Maps to #595

- **Part A** ("API error swallowed as iteration exhaustion") — fixed directly via the for-else pattern. The misleading message no longer overwrites a more-specific one written by an exception handler.
- **Part B** ("classify common API errors") — `classify_provider_error` covers the LiteLLM-wrapped provider-error case (Anthropic/OpenAI), the most common variant in practice.

The "loop hammers the API after a persistent 4xx" suspicion in #595 turned out to be wrong: at iter 41 the BadRequestError handler broke the loop immediately. The user just saw "exhausted" because of the overwrite. After this PR, they'd see "Bad request at iteration 41: ..." instead.

## Verification

- Smoke imports all 4 modified files; `classify_provider_error` produces expected output for the actual Anthropic spend-limit string format.
- All Python files parse cleanly.
- `pytest tests/test_context.py::TestClassifyProviderError -v` not run locally (still no pytest on the dev VPS); CI will run on this PR.
- For-else correctness: verified by reading the resulting code; Python's for-else only takes the `else:` branch when the loop completes without `break`, which is exactly the semantic we want.
