### PR TITLE
Add distillation pre-pass to design / workshop / delegate

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -2449,6 +2449,7 @@ jobs:
           DESIGN_CONTEXT_KEEP_TOOL_RESULTS: ${{ needs.parse.outputs.design_context_keep_tool_results }}
           DESIGN_WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           DESIGN_WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
+          DISTILL_ENABLED: ${{ needs.parse.outputs.distill_enabled }}
         run: |
           date +%s > /tmp/start_time
           python3 << 'PYEOF'
@@ -2504,6 +2505,32 @@ jobs:
               body = f.read().strip()
           with open("/tmp/issue_comments.txt") as f:
               comments = f.read().strip()
+
+          # Distillation pre-pass: pre-select the parts of the codebase
+          # relevant to the issue, mirroring resolve.py's behavior.
+          distill_input_tokens = 0
+          distill_output_tokens = 0
+          distill_cost = 0.0
+          distill_enabled = os.environ.get("DISTILL_ENABLED", "true").lower() == "true"
+          if distill_enabled:
+              try:
+                  from distill import maybe_distill
+                  issue_context_text = (
+                      f"## Issue: {title}\n\n{body}"
+                      + (f"\n\n## Discussion so far:\n{comments}" if comments else "")
+                  )
+                  print("Running context distillation pre-step (design)...")
+                  distilled, distill_input_tokens, distill_output_tokens, distill_cost, structural_extract = maybe_distill(
+                      repo_context, issue_context_text, model
+                  )
+                  if distilled != repo_context:
+                      new_repo = f"## Distilled Context\n\n{distilled}"
+                      if structural_extract:
+                          new_repo += f"\n\n## Codebase Index\n\n{structural_extract}"
+                      repo_context = new_repo
+                      print(f"  Distillation: ~{distill_input_tokens} in, ~{distill_output_tokens} out, ${distill_cost:.4f}")
+              except Exception as e:
+                  print(f"Distillation failed: {e} — proceeding with full repo context")
 
           # Build the user content
           user_content = f"""## Issue: {title}
@@ -3064,6 +3091,7 @@ jobs:
           EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
+          DISTILL_ENABLED: ${{ needs.parse.outputs.distill_enabled }}
         run: |
           date +%s > /tmp/start_time
           python3 << 'PYEOF'
@@ -3085,6 +3113,7 @@ jobs:
           max_iterations = int(os.environ.get("MAX_ITERATIONS", "15") or "15")
           wrapup_enabled = os.environ.get("WRAPUP_ENABLED", "true").lower() == "true"
           wrapup_iteration = int(os.environ.get("WRAPUP_ITERATION", "0") or "0")
+          distill_enabled = os.environ.get("DISTILL_ENABLED", "true").lower() == "true"
 
           # Council models from parse job (JSON list of {alias, id} dicts)
           council_models = json.loads(os.environ.get("COUNCIL_MODELS", "[]") or "[]")
@@ -3148,6 +3177,7 @@ jobs:
               wrapup_enabled=wrapup_enabled,
               wrapup_iteration=wrapup_iteration,
               post_comment_fn=post_comment,
+              distill_enabled=distill_enabled,
           )
 
           # Save usage data for the cost fallback step
@@ -3340,6 +3370,7 @@ jobs:
           WRAPUP_ENABLED: ${{ needs.parse.outputs.graceful_wrapup_enabled }}
           WRAPUP_ITERATION: ${{ needs.parse.outputs.graceful_wrapup_iteration }}
           DESIGN_ROUNDS: ${{ needs.parse.outputs.design_rounds }}
+          DISTILL_ENABLED: ${{ needs.parse.outputs.distill_enabled }}
         run: |
           date +%s > /tmp/start_time
           python3 << 'PYEOF'
@@ -3365,6 +3396,7 @@ jobs:
           wrapup_enabled = os.environ.get("WRAPUP_ENABLED", "true").lower() == "true"
           wrapup_iteration = int(os.environ.get("WRAPUP_ITERATION", "0") or "0")
           design_rounds = int(os.environ.get("DESIGN_ROUNDS", "1") or "1")
+          distill_enabled = os.environ.get("DISTILL_ENABLED", "true").lower() == "true"
 
           council_models = json.loads(os.environ.get("COUNCIL_MODELS", "[]") or "[]")
 
@@ -3423,6 +3455,7 @@ jobs:
               wrapup_iteration=wrapup_iteration,
               post_comment_fn=post_comment,
               design_rounds=design_rounds,
+              distill_enabled=distill_enabled,
           )
 
           # Save usage data

--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -237,6 +237,7 @@ def run_design_loop(
     wrapup_iteration=0,
     context_keep_tool_results=0,
     system_prompt=None,
+    distill_enabled=True,
 ):
     """Run the agentic design exploration loop.
 
@@ -264,6 +265,11 @@ def run_design_loop(
         Number of recent tool results to keep (0 = keep all).
     system_prompt : str or None
         Override the default system prompt entirely.
+    distill_enabled : bool
+        If True (default), run a distillation pre-pass via
+        lib.distill.maybe_distill to focus extra_context on the parts
+        relevant to the issue. Set False to skip (e.g. for tests, or
+        when extra_context is already focused).
 
     Returns
     -------
@@ -273,6 +279,9 @@ def run_design_loop(
         - output_tokens: int
         - cost: float
         - iterations: int
+        - distill_input_tokens: int
+        - distill_output_tokens: int
+        - distill_cost: float
     """
     from litellm import completion as litellm_completion
 
@@ -289,6 +298,38 @@ def run_design_loop(
 
     if extra_instructions:
         system_prompt += f"\n\n## Additional Instructions\n\n{extra_instructions}"
+
+    # Distillation pre-pass: pre-select the parts of the codebase relevant
+    # to the issue, so the agent doesn't have to discover them via tool
+    # calls. Mirrors the pattern used in resolve.py.
+    distill_input_tokens = 0
+    distill_output_tokens = 0
+    distill_cost = 0.0
+    if distill_enabled and extra_context:
+        try:
+            try:
+                from distill import maybe_distill
+            except ImportError:
+                sys.path.insert(0, os.path.dirname(__file__))
+                from distill import maybe_distill
+            issue_context_text = (
+                f"## Issue: {issue_title}\n\n{issue_body}"
+                + (f"\n\n## Discussion so far:\n{issue_comments}" if issue_comments else "")
+            )
+            print("Running context distillation pre-step (design loop)...")
+            distilled, distill_input_tokens, distill_output_tokens, distill_cost, structural_extract = maybe_distill(
+                extra_context, issue_context_text, model
+            )
+            if distilled != extra_context:
+                # Replace extra_context with focused content + index of all
+                # function/class definitions for direct navigation.
+                new_extra = f"## Distilled Context\n\n{distilled}"
+                if structural_extract:
+                    new_extra += f"\n\n## Codebase Index\n\n{structural_extract}"
+                extra_context = new_extra
+                print(f"  Distillation: ~{distill_input_tokens} in, ~{distill_output_tokens} out, ${distill_cost:.4f}")
+        except Exception as e:
+            print(f"Distillation failed: {e} — proceeding with full extra_context")
 
     # Build user content
     user_content = f"## Issue: {issue_title}\n\n{issue_body}"
@@ -413,6 +454,9 @@ def run_design_loop(
         "iterations": (iteration + 1) if max_iterations > 0 else 0,
         "cache_read_tokens": total_cache_read_tokens,
         "cache_creation_tokens": total_cache_creation_tokens,
+        "distill_input_tokens": distill_input_tokens,
+        "distill_output_tokens": distill_output_tokens,
+        "distill_cost": distill_cost,
     }
 
 

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -551,6 +551,7 @@ def run_workshop(
     wrapup_iteration=0,
     context_keep_tool_results=0,
     post_comment_fn=None,
+    distill_enabled=True,
 ):
     """Run the full workshop MVP (Stages 1 and 2).
 
@@ -618,6 +619,7 @@ def run_workshop(
         wrapup_enabled=wrapup_enabled,
         wrapup_iteration=wrapup_iteration,
         context_keep_tool_results=context_keep_tool_results,
+        distill_enabled=distill_enabled,
     )
     design_elapsed = time.time() - design_start
 
@@ -972,6 +974,7 @@ def run_delegate(
     context_keep_tool_results=0,
     post_comment_fn=None,
     design_rounds=1,
+    distill_enabled=True,
 ):
     """Run the full delegate pipeline (6 stages, no human checkpoints).
 
@@ -1076,6 +1079,7 @@ def run_delegate(
         wrapup_enabled=wrapup_enabled,
         wrapup_iteration=wrapup_iteration,
         context_keep_tool_results=context_keep_tool_results,
+        distill_enabled=distill_enabled,
     )
     design_elapsed = time.time() - design_start
 
@@ -1317,6 +1321,7 @@ def run_delegate(
             wrapup_enabled=wrapup_enabled,
             wrapup_iteration=wrapup_iteration,
             context_keep_tool_results=context_keep_tool_results,
+            distill_enabled=distill_enabled,
             system_prompt=SPEC_DESIGN_SYSTEM_PROMPT,
         )
         spec_elapsed = time.time() - spec_start

--- a/tests/test_design_loop.py
+++ b/tests/test_design_loop.py
@@ -172,3 +172,42 @@ class TestSystemPrompt:
 
     def test_prompt_mentions_gh_tool(self):
         assert "gh" in DEFAULT_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Distillation flag
+# ---------------------------------------------------------------------------
+
+class TestDistillationFlag:
+    """Verify run_design_loop's distill_enabled parameter contract.
+
+    Full-loop behavior testing is infeasible without elaborate mocking of
+    litellm. These tests verify the public-API contract:
+      - the parameter exists, defaults to True
+      - workshop and delegate accept and thread it through
+      - the docstring documents the new return-dict keys
+
+    Behavioral verification happens via /dogfood runs after merge.
+    """
+
+    def test_run_design_loop_signature(self):
+        import inspect
+        from design_loop import run_design_loop
+        sig = inspect.signature(run_design_loop)
+        assert "distill_enabled" in sig.parameters
+        assert sig.parameters["distill_enabled"].default is True
+
+    def test_workshop_signatures_thread_distill_enabled(self):
+        import inspect
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+        from workshop import run_workshop, run_delegate
+        for fn in (run_workshop, run_delegate):
+            sig = inspect.signature(fn)
+            assert "distill_enabled" in sig.parameters, f"{fn.__name__} missing distill_enabled"
+            assert sig.parameters["distill_enabled"].default is True
+
+    def test_docstring_documents_return_keys(self):
+        from design_loop import run_design_loop
+        doc = run_design_loop.__doc__ or ""
+        for key in ("distill_input_tokens", "distill_output_tokens", "distill_cost"):
+            assert key in doc, f"return-dict key {key!r} not documented in run_design_loop docstring"


### PR DESCRIPTION
Fixes #601.

## What

Distillation (`lib/distill.py::maybe_distill`) was previously enabled only in resolve mode. This PR extends it to **design**, **workshop**, and **delegate** so their agentic exploration starts with a focused codebase view (relevant files + structural extract with line numbers) instead of just a raw repo listing.

## Skipped (deliberately)

| Mode | Reason |
|---|---|
| **review** | PR diff is already focused; whole-codebase distillation would be marginal. |
| **reconcile** | Relevant files = conflicting files, known via `git diff --name-only`. No LLM call needed. |

Already covered: **resolve** has it. **build** and **delegate Stage 4** call resolve.py internally and inherit it.

## Changes

- **`lib/design_loop.py`** — `run_design_loop` gains `distill_enabled: bool = True`. When enabled and `extra_context` is non-empty, calls `maybe_distill`, replaces `extra_context` with `## Distilled Context` block + `## Codebase Index` structural extract. Returns `distill_input_tokens` / `distill_output_tokens` / `distill_cost` in the result dict. `maybe_distill` failure is logged and falls back to the original extra_context (non-fatal).
- **`lib/workshop.py`** — `run_workshop` and `run_delegate` accept and thread `distill_enabled` through to all three internal `run_design_loop` calls (workshop Stage 1, delegate Stage 1 design, delegate Stage 3a spec).
- **`.github/workflows/remote-dev-bot.yml`** — `DISTILL_ENABLED` env var added to design, workshop, and delegate steps. Heredocs read it and pass through. The standalone `/agent-design` job has its own inline implementation that does NOT call `run_design_loop`; added the same `maybe_distill` call there so all three modes benefit.
- **`tests/test_design_loop.py`** — `TestDistillationFlag` verifies the parameter contract: signature, workshop/delegate threading, documented return-dict keys.

## Followup (not part of this PR)

The standalone `/agent-design` job duplicates a slimmer version of the design loop inline in YAML (rather than calling `lib/design_loop.py::run_design_loop`). Refactoring it to call `run_design_loop` would simplify the workflow and remove the inline `maybe_distill` call this PR adds. Worth a separate small issue.

## Verification

- Manually verified all signatures: `run_design_loop`, `run_workshop`, `run_delegate` accept `distill_enabled` with default `True`.
- All Python files parse; `remote-dev-bot.yml` parses as YAML.
- `pytest tests/ -q` not run locally (no pytest on dev VPS); CI will run on this PR.
- Behavioral verification will come from the next `/dogfood design` and `/dogfood workshop` runs after merge — distillation should show up as a cost line and as `## Distilled Context` in the agent's view.

## Why

Beyond the obvious "less wasted exploration":

- For the over-exploration pattern observed in #585 / #554 (resolve case), better starting context is one of the few mechanisms that actually reduces the model's "let me read one more file" tendency. Distillation gives the design loop the same advantage resolve already has.
- The structural extract (function/class index with line numbers) lets the agent jump directly to relevant definitions instead of grepping — particularly useful for design questions where the answer is distributed across the codebase.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 33 +++++++++++++++++++++++++++
 lib/design_loop.py                   | 44 ++++++++++++++++++++++++++++++++++++
 lib/workshop.py                      |  5 ++++
 tests/test_design_loop.py            | 39 ++++++++++++++++++++++++++++++++
 4 files changed, 121 insertions(+)
```
