### PR TITLE
Fix composite action lookup for external workflow callers (#599)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -676,7 +676,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1332,7 +1332,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1989,7 +1989,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2316,7 +2316,7 @@ jobs:
 
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2962,7 +2962,7 @@ jobs:
 
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -3245,7 +3245,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: ./.github/actions/setup-rdb
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Fixes #599.

## What was broken

PR #596 added a composite action at `.github/actions/setup-rdb/` and referenced it from all 8 jobs via `uses: ./.github/actions/setup-rdb`. That relative path is **resolved against the caller repo's checkout**, not the workflow's source repo. Result: invocations from inside `gnovak/remote-dev-bot` itself worked (action present on disk); invocations from `gnovak/bridge-analysis` and any other external repo failed at the parse job with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.github/actions/setup-rdb'. Did you forget to run actions/checkout
before running your local action?
```

Concrete observation: bridge-analysis #355 had two `/agent resolve` invocations on 2026-04-29 that failed instantly in the `resolve / parse / Setup RDB` step before any agent comment could be posted.

## Fix

Reference the composite action by its full repository path with the same ref the workflow uses for `lib/` and config:

```yaml
uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
```

Single sed across all 8 call sites; 8 lines changed.

## Behavior matrix

| Caller | shim `@ref` | `rdb_ref` input | Composite action loaded from |
|---|---|---|---|
| Default user (`agent.yml@main`) | main | main | **@main** |
| bridge-analysis-style (tracking dev) | dev | dev | **@dev** |
| `dogfood.yml` | dev | dev | **@dev** |
| Hypothetical user pinned to a tag | v1.0 | v1.0 | **@v1.0** |

The composite action is always loaded from the same ref as `lib/` and `remote-dev-bot.yaml` — which is correct, since they have to be compatible with each other anyway. Users retain control via the `rdb_ref` input in their shim.

## Why this works

GHA supports expressions in the *ref* portion of `uses:` (the part after `@`), specifically for actions in repositories. The constraint is on the *path* portion (which is hardcoded `gnovak/remote-dev-bot/.github/actions/setup-rdb`).

If for any reason this turns out not to work in this exact context (composite action invoked from a reusable workflow), the fallback is to inline-revert PR #596's refactor — but the expression form is documented as supported and is the cleanest solution.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/remote-dev-bot.yml'))"` parses cleanly.
- Counted: 8 occurrences of new path, 0 of old `./` path.
- Behavioral verification: the next `/dogfood` after merge will validate that the action loads correctly. If it doesn't, the parse job will fail loudly and we revert.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 16 ++++++++--------
 1 file changed, 8 insertions(+), 8 deletions(-)
```
