### PR TITLE
Hardcode @dev for composite action ref (#605 follow-up)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -676,7 +676,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1332,7 +1332,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1989,7 +1989,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2316,7 +2316,7 @@ jobs:
 
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2962,7 +2962,7 @@ jobs:
 
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -3245,7 +3245,7 @@ jobs:
     steps:
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Follow-up to #605, which broke things.

## What happened

PR #605 changed the composite-action ref to `@${{ inputs.rdb_ref }}`. Confidence was 70-80% that GHA expressions are supported in the `@ref` portion of `uses:`. They are not — at least not for `inputs.X` references in this context. `uses:` is resolved at workflow-load time, before workflow_call inputs are bound.

Symptoms after #605 merged:
- `/dogfood design` on rdb #599 → run failed instantly, **0 jobs created, log not found**
- `/agent-design-claude-small` on bridge-analysis #355 → same instant failure pattern

This is the textbook signature of a workflow YAML that won't parse.

## This PR

Hardcode `@dev` instead:

```yaml
uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@dev
```

8 lines changed. Works for both current callers because both use `@dev`:

- **dogfood.yml** — shim points to `remote-dev-bot.yml@dev` with `rdb_ref: dev` → composite action from `@dev` ✓
- **bridge-analysis** — same configuration ✓
- **agent.yml @main (default external users)** — `main` does not yet have the composite action at all, so this code path is not reached on the main workflow ✓

## Maintenance debt

Pre-0.9 release: bump the 8 `@dev` references to `@main` in this file before the release tag, so post-release users on `@main` get the action from `@main`. This is a manual one-line-per-site sed at release time. Worth flagging on the 0.9 prep checklist.

## Future improvement (not this PR)

Switch to a checkout-first pattern so the ref always tracks `inputs.rdb_ref`:

```yaml
- name: Checkout rdb action source
  uses: actions/checkout@v5
  with:
    repository: gnovak/remote-dev-bot
    ref: ${{ inputs.rdb_ref }}
    path: .rdb-action

- name: Setup RDB
  uses: ./.rdb-action/.github/actions/setup-rdb
  with: ...
```

Adds one step per job (~40 extra YAML lines across 8 jobs) but eliminates the release-time hardcode-update. Defer to a follow-up; this PR is the urgent fix.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 16 ++++++++--------
 1 file changed, 8 insertions(+), 8 deletions(-)
```
