### PR TITLE
Use checkout-first pattern for composite action (#605 follow-up)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -89,9 +89,16 @@ jobs:
       distill_enabled: ${{ steps.parse.outputs.distill_enabled }}
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -141,9 +148,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -674,9 +688,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1330,9 +1351,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -1987,9 +2015,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2314,9 +2349,16 @@ jobs:
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "Resolved checkout ref: $REF (issue_type=$ISSUE_TYPE)"
 
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -2960,9 +3002,16 @@ jobs:
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "Resolved checkout ref: $REF (issue_type=$ISSUE_TYPE)"
 
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
@@ -3243,9 +3292,16 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - name: Checkout rdb action source
+        uses: actions/checkout@v5
+        with:
+          repository: gnovak/remote-dev-bot
+          ref: ${{ inputs.rdb_ref }}
+          path: .rdb-action
+
       - name: Setup RDB
         id: setup
-        uses: gnovak/remote-dev-bot/.github/actions/setup-rdb@${{ inputs.rdb_ref }}
+        uses: ./.rdb-action/.github/actions/setup-rdb
         with:
           app_id: ${{ vars.RDB_APP_ID }}
           app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Follow-up to #605 (which broke things) — going directly to the robust fix instead of the hardcode-flip-flip dance.

Supersedes the closed #608.

## Why not `@${{ inputs.rdb_ref }}`

PR #605 tried it. It doesn't work — GHA doesn't evaluate `inputs.X` expressions in the `@ref` portion of `uses:` (uses is parsed before workflow_call inputs are bound). Both post-#605 smoke tests failed at workflow-load time with **0 jobs created** and "log not found" — the textbook signature of a workflow YAML that won't parse.

## Why not hardcode `@dev`

Works for now, but every release would require a manual flip: bump `@dev` → `@main` on dev → merge → tag → flip back to `@dev` for ongoing development. Easy to forget. Easier to just not do it.

## What this does

Add an `actions/checkout` step before each `Setup RDB` call to fetch rdb at `inputs.rdb_ref` into `./.rdb-action/`, then reference the composite action via local path:

```yaml
- name: Checkout rdb action source
  uses: actions/checkout@v5
  with:
    repository: gnovak/remote-dev-bot
    ref: ${{ inputs.rdb_ref }}
    path: .rdb-action

- name: Setup RDB
  id: setup
  uses: ./.rdb-action/.github/actions/setup-rdb
  with: ...
```

Replicated across all 8 setup-rdb call sites.

## Why this works (where the expression form failed)

The composite action's `action.yml` is loaded into runner memory when the `Setup RDB` step starts (action resolution is at step entry, not workflow load). The composite action's first internal step is a checkout of the **target** repo into `$GITHUB_WORKSPACE`, which `git clean`s and would wipe our pre-checked-out `.rdb-action/`. That's fine — the action's code is already loaded into memory, the on-disk source isn't needed by subsequent steps within the action.

## Behavior matrix

| Caller | shim `@ref` | `rdb_ref` input | Composite action loaded from |
|---|---|---|---|
| Default external (agent.yml @main) | main | main | **@main** |
| You / bridge-analysis (@dev) | dev | dev | **@dev** |
| dogfood.yml | dev | dev | **@dev** |
| Hypothetical user pinned to @v0.9.0 | v0.9.0 | v0.9.0 | **@v0.9.0** |

The action ref always tracks `inputs.rdb_ref`. No release-time maintenance.

## Cost

- ~48 lines of YAML added (~6 per site × 8 sites)
- One extra `actions/checkout` per job (small public repo, ~1-2s)
- No release-time dance

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly.
- Counted: 8 occurrences of new pattern, 0 of old broken `@${{ inputs.rdb_ref }}`.
- Behavioral verification once merged: I'll re-run the two smoke tests (`/dogfood design` on rdb #599 + `/agent-design-claude-small` on bridge-analysis #355) and confirm both produce real comments.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 72 ++++++++++++++++++++++++++++++++----------
 1 file changed, 64 insertions(+), 8 deletions(-)
```
