### PR TITLE
Set clean: false on target checkout (#609 follow-up)

### DIFF
--- a/.github/actions/setup-rdb/action.yml
+++ b/.github/actions/setup-rdb/action.yml
@@ -64,6 +64,12 @@ runs:
         token: ${{ steps.app-token.outputs.token || inputs.pat_token || github.token }}
         ref: ${{ inputs.target_ref }}
         fetch-depth: ${{ inputs.fetch_depth }}
+        # Don't `git clean -ffdx` the workspace before checking out — the
+        # caller pre-fetched this composite action's source into
+        # .rdb-action/ and that subdir must survive so GHA can re-read
+        # action.yml at post-step time. The runner workspace is fresh
+        # per job so leftover-file risk is nil.
+        clean: false
 
     - name: Checkout remote-dev-bot config and lib
       if: ${{ inputs.include_rdb_config == 'true' }}


### PR DESCRIPTION
Follow-up to #609. The checkout-first pattern got further than #605's expression form (workflow loaded; jobs ran), but every job failed at the "Post Setup RDB" step with:

```
Can't find 'action.yml' under .rdb-action/.github/actions/setup-rdb.
Did you forget to run actions/checkout before running your local action?
```

## Why

After #609, the sequence is:
1. Pre-checkout step fetches rdb to `.rdb-action/` ✓
2. Setup RDB step starts; GHA loads `.rdb-action/.github/actions/setup-rdb/action.yml` ✓
3. Composite action's "Checkout target repository" step runs `actions/checkout@v5` with `clean=true` (default) → executes `git clean -ffdx` on `$GITHUB_WORKSPACE` → **wipes `.rdb-action/`** ✗
4. Composite action's remaining steps run fine (action.yml is loaded into memory)
5. **Post-step cleanup**: GHA tries to re-read `action.yml` to discover post-hooks for the sub-actions (create-github-app-token / checkout / setup-python). Source is gone. ✗

## Fix

Set `clean: false` on the composite action's target-repo checkout step:

```yaml
- name: Checkout target repository
  uses: actions/checkout@v5
  with:
    token: ${{ steps.app-token.outputs.token || inputs.pat_token || github.token }}
    ref: ${{ inputs.target_ref }}
    fetch-depth: ${{ inputs.fetch_depth }}
    clean: false   # ← preserve .rdb-action/ for post-step cleanup
```

`git checkout` itself doesn't remove untracked dirs — only `git clean` does. Skipping the clean preserves `.rdb-action/`, so post-step cleanup finds `action.yml` and proceeds normally.

The runner workspace is fresh per job, so the usual reason to clean (stale files from prior runs) doesn't apply.

## Verification

After this merges, I'll re-run both smoke tests (`/dogfood design` on rdb #599 + `/agent-design-claude-small` on bridge-analysis #355). Expect: workflow loads, jobs run, agent posts a comment. If we see actual agent comments this round, we're done.

## Files changed

```
 .github/actions/setup-rdb/action.yml | 6 ++++++
 1 file changed, 6 insertions(+)
```
