### PR TITLE
Inline-revert the setup-rdb composite action (#599 finally fixed)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -89,22 +89,36 @@ jobs:
       distill_enabled: ${{ steps.parse.outputs.distill_enabled }}
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+
+      - name: Checkout remote-dev-bot config and lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
+          python-version: "3.12"
 
       - name: Install PyYAML
         run: pip install PyYAML
@@ -129,7 +143,7 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST --field content=rocket
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Assign commenter to issue
         if: steps.parse.outputs.assign_issue == 'true'
@@ -139,7 +153,7 @@ jobs:
           gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
             --add-assignee "${{ github.event.comment.user.login }}"
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
   # --- Mode: resolve — run LiteLLM agent loop, open a PR ---
   resolve:
@@ -148,28 +162,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+
+      - name: Checkout remote-dev-bot lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          include_rdb_config: 'false'
+          python-version: "3.12"
 
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Select the correct API key based on the model's provider prefix.
           # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
@@ -246,8 +272,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
@@ -306,7 +332,7 @@ jobs:
       - name: Safety-net push
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # If the agent made commits but forgot to push, or exhausted iterations without
           # calling finish(), save the work now. Skipped for no_op runs (nothing to push).
@@ -347,7 +373,7 @@ jobs:
       - name: Post result comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
@@ -546,7 +572,7 @@ jobs:
         if: needs.parse.outputs.assign_pr == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Extract PR number from send_pull_request output
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log | head -1)
@@ -563,7 +589,7 @@ jobs:
           always() &&
           !(github.event.issue.pull_request || github.event.pull_request)
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # For issue triggers: append the cost table to the newly created PR body.
           # Write /tmp/cost_embedded as sentinel so the fallback step skips.
@@ -669,7 +695,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"
@@ -688,28 +714,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+
+      - name: Checkout remote-dev-bot lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          include_rdb_config: 'false'
+          python-version: "3.12"
 
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Select the correct API key based on the model's provider prefix.
           # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
@@ -786,8 +824,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
@@ -846,7 +884,7 @@ jobs:
       - name: Safety-net push
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # If the agent made commits but forgot to push, or exhausted iterations without
           # calling finish(), save the work now. Skipped for no_op runs (nothing to push).
@@ -887,7 +925,7 @@ jobs:
       - name: Post result comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ON_FAILURE="${{ needs.parse.outputs.on_failure }}"
@@ -1055,7 +1093,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
           GITHUB_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -1208,7 +1246,7 @@ jobs:
         if: needs.parse.outputs.assign_pr == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Extract PR number from send_pull_request output
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log | head -1)
@@ -1225,7 +1263,7 @@ jobs:
           always() &&
           !(github.event.issue.pull_request || github.event.pull_request)
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # For issue triggers: append the cost table to the newly created PR body.
           # Write /tmp/cost_embedded as sentinel so the fallback step skips.
@@ -1331,7 +1369,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"
@@ -1351,23 +1389,37 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          fetch-depth: '0'
+
+      - name: Checkout remote-dev-bot config and lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          fetch_depth: '0'
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install PyYAML litellm
@@ -1382,7 +1434,7 @@ jobs:
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Select the correct API key based on the model's provider prefix.
           # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
@@ -1514,7 +1566,7 @@ jobs:
             fi
           fi
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run review loop
         id: review
@@ -1901,7 +1953,7 @@ jobs:
 
       - name: Post review comment
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ALIAS="${{ needs.parse.outputs.alias }}"
@@ -1995,7 +2047,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"
@@ -2015,29 +2067,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          fetch-depth: '0'
+
+      - name: Checkout remote-dev-bot lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          fetch_depth: '0'
-          include_rdb_config: 'false'
+          python-version: "3.12"
 
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           MODEL="${{ needs.parse.outputs.model }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
@@ -2096,7 +2160,7 @@ jobs:
 
       - name: Verify this is a PR
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           IS_PR=${{ (github.event.issue.pull_request || github.event.pull_request) && 'true' || 'false' }}
@@ -2118,8 +2182,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -2157,7 +2221,7 @@ jobs:
       - name: Post result comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -2236,7 +2300,7 @@ jobs:
       - name: Post cost comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           MODEL="${{ needs.parse.outputs.model }}"
@@ -2349,23 +2413,37 @@ jobs:
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "Resolved checkout ref: $REF (issue_type=$ISSUE_TYPE)"
 
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ steps.resolve_ref.outputs.ref }}
+
+      - name: Checkout remote-dev-bot config and lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          target_ref: ${{ steps.resolve_ref.outputs.ref }}
+          python-version: "3.12"
 
       - name: Capture checkout info
         id: checkout_info
@@ -2389,7 +2467,7 @@ jobs:
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Select the correct API key based on the model's provider prefix.
           # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
@@ -2477,7 +2555,7 @@ jobs:
           echo "$ISSUE_BODY" > /tmp/issue_body.txt
           echo "$COMMENTS" > /tmp/issue_comments.txt
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run design loop
         id: design
@@ -2861,7 +2939,7 @@ jobs:
 
       - name: Post analysis comment
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           ALIAS="${{ needs.parse.outputs.alias }}"
@@ -2962,7 +3040,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"
@@ -3002,23 +3080,37 @@ jobs:
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "Resolved checkout ref: $REF (issue_type=$ISSUE_TYPE)"
 
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ steps.resolve_ref.outputs.ref }}
+
+      - name: Checkout remote-dev-bot config and lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          target_ref: ${{ steps.resolve_ref.outputs.ref }}
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install PyYAML litellm
@@ -3033,7 +3125,7 @@ jobs:
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           # Select the correct API key based on the design model's provider prefix.
           # Writing to GITHUB_OUTPUT passes values between steps as step outputs.
@@ -3121,7 +3213,7 @@ jobs:
           echo "$ISSUE_BODY" > /tmp/issue_body.txt
           echo "$COMMENTS" > /tmp/issue_comments.txt
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       - name: Run workshop
         id: workshop
@@ -3134,7 +3226,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ISSUE_TYPE: ${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           MAX_ITERATIONS: ${{ needs.parse.outputs.workshop_max_iterations }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
           EXTRA_FILES: ${{ env.RDB_EXTRA_FILES }}
@@ -3245,7 +3337,7 @@ jobs:
       - name: Post result comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -3272,7 +3364,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"
@@ -3292,23 +3384,37 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Checkout rdb action source
+      - name: Generate app token
+        if: vars.RDB_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RDB_APP_ID }}
+          private-key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.app_token_owner }}
+
+      - name: Checkout target repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          ref: ${{ needs.parse.outputs.target_branch }}
+
+      - name: Checkout remote-dev-bot config and lib
         uses: actions/checkout@v5
         with:
           repository: gnovak/remote-dev-bot
+          token: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           ref: ${{ inputs.rdb_ref }}
-          path: .rdb-action
+          path: .remote-dev-bot
+          sparse-checkout: |
+            /remote-dev-bot.yaml
+            /lib/
+          sparse-checkout-cone-mode: false
 
-      - name: Setup RDB
-        id: setup
-        uses: ./.rdb-action/.github/actions/setup-rdb
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          app_id: ${{ vars.RDB_APP_ID }}
-          app_private_key: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-          pat_token: ${{ secrets.RDB_PAT_TOKEN }}
-          rdb_ref: ${{ inputs.rdb_ref }}
-          app_token_owner: ${{ inputs.app_token_owner }}
-          target_ref: ${{ needs.parse.outputs.target_branch }}
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install PyYAML litellm
@@ -3323,7 +3429,7 @@ jobs:
       - name: Determine API key
         id: apikey
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           MODEL="${{ needs.parse.outputs.model }}"
           ALIAS="${{ needs.parse.outputs.alias }}"
@@ -3402,7 +3508,7 @@ jobs:
           echo "$ISSUE_BODY" > /tmp/issue_body.txt
           echo "$COMMENTS" > /tmp/issue_comments.txt
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
 
       # ===================================================================
       # Stages 1-3: Design + Council Design Review + Design Revision
@@ -3418,7 +3524,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ISSUE_TYPE: ${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           MAX_ITERATIONS: ${{ needs.parse.outputs.delegate_max_iterations }}
           MAX_DESIGN_ITERATIONS: ${{ needs.parse.outputs.delegate_max_design_iterations }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
@@ -3574,8 +3680,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
@@ -3683,7 +3789,7 @@ jobs:
       - name: Safety-net push
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           NO_OP=$(python3 -c "import json,os; d=json.load(open('/tmp/resolve_status.json')) if os.path.exists('/tmp/resolve_status.json') else {}; print('true' if d.get('no_op') else 'false')" 2>/dev/null || echo "false")
           if [[ "$NO_OP" == "true" ]]; then
@@ -3706,7 +3812,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
           GITHUB_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -3853,8 +3959,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ github.repository_owner }}
           GIT_USERNAME: ${{ github.repository_owner }}
           E2E_TEST_TOKEN: ${{ secrets.E2E_TEST_TOKEN }}
@@ -4011,7 +4117,7 @@ jobs:
       - name: Post result comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
           DELEGATE_MAX_ITER: ${{ needs.parse.outputs.delegate_max_iterations }}
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
@@ -4136,7 +4242,7 @@ jobs:
         if: needs.parse.outputs.assign_pr == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' /tmp/spr_output.log | head -1)
           if [ -z "$PR_URL" ]; then
@@ -4155,7 +4261,7 @@ jobs:
       - name: Post cost comment (fallback)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
           if [ -f /tmp/cost_embedded ]; then
             echo "Cost already reported — skipping fallback"


### PR DESCRIPTION
**Plan F.** After three failed attempts to make the composite-action approach work for external workflow_call invocations, giving up on the composite action and inlining the steps back into all 8 jobs.

## Why the composite-action approach failed

| PR | Approach | What broke |
|---|---|---|
| #605 | `uses: ...@${{ inputs.rdb_ref }}` | Workflow won't parse — GHA doesn't evaluate `inputs.X` in `uses:` ref |
| #609 | Pre-checkout to `.rdb-action/`, ref via local path | Workflow loaded; main steps ran; post-step cleanup failed because target-repo checkout wiped `.rdb-action/` |
| #610 | Add `clean: false` to internal target checkout | Didn't help — `actions/checkout` does *"Deleting the contents of $GITHUB_WORKSPACE"* before fresh `git init`, regardless of `clean:` flag, when the workspace doesn't already contain a git repo at the root |

Verdict: GHA's local composite actions in reusable workflow_call don't compose with target-repo checkouts. The action's source needs to survive on disk through to post-step cleanup, but the target checkout always wipes the workspace root.

## What this PR does

Inline the 4 setup steps back into all 8 jobs. The composite action's behavioral knobs are folded inline per call site:

- **parse, review, design, workshop, delegate**: full sparse checkout (`/remote-dev-bot.yaml` + `/lib/`)
- **resolve, build, reconcile**: `/lib/` only
- **review, reconcile**: `fetch-depth: '0'` (need full git history for diff/rebase)
- **design, workshop, delegate**: target ref from `steps.resolve_ref.outputs.ref` or `needs.parse.outputs.target_branch`

`steps.setup.outputs.token` references throughout the workflow are rewritten to `steps.app-token.outputs.token` to match the inline step's id.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Programmatic check: every job has `Generate app token`, `Checkout target repository`, `Checkout remote-dev-bot ...`, and `Set up Python` steps.
- Behavioral verification: re-run both smoke tests after merge.

## Maintenance debt this brings back

PR #596 (the composite action) removed ~120 LOC of YAML duplication. This restores it (~250 lines net added — slightly more than before because of `app_token_owner` and other additions since). That duplication is the cost of GHA's composite-action limitations in cross-repo workflow_call. We can revisit if a different reusable mechanism becomes viable (e.g., a reusable workflow snippet, but those have their own constraints).

The composite action file `.github/actions/setup-rdb/action.yml` is now unreferenced but left in place. A follow-up can delete it.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 392 ++++++++++++++++++++++-------------
 1 file changed, 249 insertions(+), 143 deletions(-)
```
