### PR TITLE
Tell agents iteration budget upfront across all three loops (#603)

### DIFF
--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -220,6 +220,23 @@ DEFAULT_SYSTEM_PROMPT = (
 )
 
 
+def _budget_paragraph(max_iterations):
+    """Build the iteration-budget paragraph for the design loop's system prompt.
+
+    Names the budget explicitly so the model can pace itself, but warns
+    against treating it as a target — without that, "you have N iterations"
+    reads as "spend N iterations." Mirrors resolve.py and reconcile.py.
+    """
+    return (
+        f"\n## Iteration Budget\n\n"
+        f"You have a budget of **{max_iterations} iterations** for this analysis. "
+        f"Aim to finish in significantly fewer if the question allows — the budget is "
+        f"a ceiling, not a target. Don't pad with extra exploration just because the "
+        f"budget is there. A focused design question rarely needs more than 5-8 "
+        f"iterations of reading before submit_analysis is appropriate.\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Core loop
 # ---------------------------------------------------------------------------
@@ -295,6 +312,10 @@ def run_design_loop(
 
     if system_prompt is None:
         system_prompt = DEFAULT_SYSTEM_PROMPT
+
+    # Iteration-budget hint: name the budget so the model can pace itself,
+    # but warn against treating it as a target. Mirrors resolve.py.
+    system_prompt = system_prompt + _budget_paragraph(max_iterations)
 
     if extra_instructions:
         system_prompt += f"\n\n## Additional Instructions\n\n{extra_instructions}"

--- a/lib/reconcile.py
+++ b/lib/reconcile.py
@@ -376,8 +376,19 @@ At that point only {remaining} iteration(s) remain. If the rebase is not complet
 
     workflow = RECONCILE_WORKFLOW.replace("{BASE_BRANCH}", BASE_BRANCH)
 
+    # Iteration-budget hint: name the budget so the model can pace itself,
+    # but warn against treating it as a target. Mirrors resolve.py.
+    budget_paragraph = (
+        f"\n## Iteration Budget\n\n"
+        f"You have a budget of **{MAX_ITERATIONS} iterations** for this reconcile. "
+        f"Aim to finish in significantly fewer if the conflicts are simple — the budget "
+        f"is a ceiling, not a target. Don't pad with unnecessary exploration. A clean "
+        f"rebase with a few small conflicts rarely needs more than 10-15 iterations.\n"
+    )
+
     prompt = (
         AGENT_ROLE
+        + budget_paragraph
         + f"\n# Repository Context\n\n{repo_context}\n\n"
         + f"# PR Information\n\n{pr_info}\n\n"
         + workflow

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -474,6 +474,23 @@ Each tool call costs real money. Be targeted and deliberate:
 - **Exploration should be proportional to task complexity.** A one-line fix does not warrant reading 10 files.
 """
 
+
+def _budget_paragraph(max_iterations):
+    """Build the iteration-budget paragraph for the agent's system prompt.
+
+    Names the budget explicitly so the model can pace itself, but explicitly
+    warns against treating the budget as a target — without that nudge,
+    "you have N iterations" reads as "spend N iterations."
+    """
+    return (
+        f"\n## Iteration Budget\n\n"
+        f"You have a budget of **{max_iterations} iterations** for this task. "
+        f"Aim to finish in significantly fewer if the task allows — the budget is a "
+        f"ceiling, not a target. Don't pad with extra exploration just because the "
+        f"budget is there. A simple fix should take 5-10 iterations; a complex "
+        f"multi-file change rarely needs more than 20-30.\n"
+    )
+
 STUCK_RECOVERY = """
 ## If You Are Stuck
 
@@ -594,6 +611,7 @@ is complete before committing — call `finish()` now.
 
     prompt = (
         AGENT_ROLE
+        + _budget_paragraph(MAX_ITERATIONS)
         + f"\n# Repository Context\n\n{repo_context}\n\n"
         + WORKFLOW
         + READING_THE_TASK

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -35,7 +35,7 @@ modes:
 
   design:
     default_model: claude-small
-    max_iterations: 10       # Iteration limit for the agentic loop
+    max_iterations: 15       # Iteration limit for the agentic loop
     extra_files:
       - README.md
       - CONTRIBUTING.md

--- a/tests/test_design_loop.py
+++ b/tests/test_design_loop.py
@@ -211,3 +211,28 @@ class TestDistillationFlag:
         doc = run_design_loop.__doc__ or ""
         for key in ("distill_input_tokens", "distill_output_tokens", "distill_cost"):
             assert key in doc, f"return-dict key {key!r} not documented in run_design_loop docstring"
+
+
+# ---------------------------------------------------------------------------
+# Iteration-budget paragraph
+# ---------------------------------------------------------------------------
+
+class TestBudgetParagraph:
+    """Verify the budget paragraph names the budget and warns against treating it as a target."""
+
+    def test_includes_section_header(self):
+        from design_loop import _budget_paragraph
+        assert "## Iteration Budget" in _budget_paragraph(15)
+
+    def test_names_the_budget_value(self):
+        from design_loop import _budget_paragraph
+        assert "**15 iterations**" in _budget_paragraph(15)
+        assert "**30 iterations**" in _budget_paragraph(30)
+
+    def test_warns_against_target_treatment(self):
+        from design_loop import _budget_paragraph
+        text = _budget_paragraph(15)
+        # Must include both a "ceiling, not a target" framing and a
+        # "don't pad" or similar anti-fill-up nudge.
+        assert "ceiling, not a target" in text
+        assert "Don't pad" in text or "don't pad" in text

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -275,6 +275,14 @@ class TestBuildSystemPrompt:
         assert "ABSOLUTE" in prompt
         assert "NEVER" in prompt
 
+    def test_budget_paragraph_included(self):
+        """Prompt must include the iteration-budget paragraph naming MAX_ITERATIONS
+        and warning against treating the budget as a target."""
+        prompt = self._build(MAX_ITERATIONS=42)
+        assert "## Iteration Budget" in prompt
+        assert "**42 iterations**" in prompt
+        assert "ceiling, not a target" in prompt
+
     # --- BASE_BRANCH substitution ---
 
     def test_base_branch_substituted_main(self):


### PR DESCRIPTION
Fixes #603.

Adds a budget-aware paragraph to all three agent loops' system prompts so the model can pace itself, with explicit framing to discourage treating the budget as a target.

## The phrasing

```
## Iteration Budget

You have a budget of **N iterations** for this {task, analysis, reconcile}.
Aim to finish in significantly fewer if the {task, question, conflicts} allow —
the budget is a ceiling, not a target. Don't pad with extra exploration just
because the budget is there. {complexity-hint}
```

The "**ceiling, not a target**" line is the critical bit — without it, the natural reading of "you have 50 iterations" is "spend 50 iterations." Each loop also has a mode-sized complexity hint:

- **resolve**: "A simple fix should take 5-10 iterations; a complex multi-file change rarely needs more than 20-30."
- **design_loop**: "A focused design question rarely needs more than 5-8 iterations of reading before submit_analysis is appropriate."
- **reconcile**: "A clean rebase with a few small conflicts rarely needs more than 10-15 iterations."

## Also: bump design `max_iterations` 10 → 15

Workshop is already 15; design was tight for moderately complex codebase questions.

## Implementation

- **`lib/resolve.py`**: existing `_budget_paragraph(max_iterations)` helper; inserted into `build_system_prompt` prompt assembly between `AGENT_ROLE` and the repo-context block.
- **`lib/design_loop.py`**: new module-level `_budget_paragraph(max_iterations)` helper; called inside `run_design_loop`, appended to the system prompt before any `extra_instructions` block. Lifted out of the inline block so it's testable in isolation.
- **`lib/reconcile.py`**: budget paragraph built inline in `build_system_prompt`, inserted between `AGENT_ROLE` and repo context.
- **`remote-dev-bot.yaml`**: design `max_iterations: 10` → `15`.

## Tests

- `tests/test_design_loop.py::TestBudgetParagraph`: 3 tests covering section header presence, budget-value substitution at different N, and the "ceiling, not a target" + anti-pad-up framing.
- `tests/test_reconcile.py::TestBuildSystemPrompt::test_budget_paragraph_included`: asserts header + budget value + framing.
- No new test for resolve's `_budget_paragraph` (resolve.py imports `litellm` at module load → not directly importable in a unit-test env without that dep). The implementation mirrors design_loop's, which IS tested.

## Files changed

```
 lib/design_loop.py        | 21 +++++++++++++++++++++
 lib/reconcile.py          | 11 +++++++++++
 lib/resolve.py            | 18 ++++++++++++++++++
 remote-dev-bot.yaml       |  2 +-
 tests/test_design_loop.py | 25 +++++++++++++++++++++++++
 tests/test_reconcile.py   |  8 ++++++++
 6 files changed, 84 insertions(+), 1 deletion(-)
```
