### PR TITLE
Auto-commit dirty WIP on recovery so partial work isn't lost (#604)

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -140,6 +140,39 @@ def run(cmd, *, check=True, timeout=60):
     return output
 
 
+def _commit_dirty_wip(label="partial work"):
+    """Commit any dirty working-tree changes as WIP and push to origin.
+
+    Called from the three recovery paths (exhausted iterations,
+    finish(success=False), and the _cleanup atexit handler) before any
+    git ls-remote check, so partial in-progress work is preserved when
+    the agent fails to commit + push on its own.
+
+    Returns True if a commit was made and pushed; False if the tree
+    was already clean OR if any git operation failed (non-fatal — the
+    caller should still attempt PR creation with whatever's already on
+    the remote).
+
+    Uses --no-verify to skip pre-commit hooks, since hook failures here
+    would defeat the safety-net purpose.
+    """
+    try:
+        status = run("git status --porcelain", check=False, timeout=30)
+        if not status.strip():
+            return False
+        run("git add -A", check=False, timeout=30)
+        commit_msg = f"WIP: auto-saved by recovery handler ({label})"
+        # `label` is a hardcoded literal at each call site (no user input),
+        # so single-quote interpolation in the shell command is safe.
+        run(f"git commit --no-verify -m '{commit_msg}'", check=False, timeout=60)
+        run("git push origin HEAD", check=False, timeout=60)
+        print(f"  Auto-committed dirty WIP: {label}")
+        return True
+    except Exception as e:
+        print(f"  Auto-commit-WIP failed (non-fatal): {e}")
+        return False
+
+
 # --- Branch setup ---
 
 def _find_available_branch(issue_number):
@@ -1820,6 +1853,11 @@ def main():
         if loop_completed_naturally:
             write_status(False, "Agent exhausted all iterations without calling finish()")
         print("Agent did not call finish() — treating as failure")
+        # Auto-commit any dirty working-tree changes so partial work isn't
+        # lost. The agent may have made edits without committing — without
+        # this, the safety push below would find no local commits and the
+        # branch on the remote would have nothing of value.
+        _commit_dirty_wip("agent did not finish")
         # Safety net: push any local commits the agent made but forgot to push.
         # Unpushed commits are lost when the runner shuts down, so we attempt a
         # push here regardless of whether the agent followed the push instructions.
@@ -1930,6 +1968,8 @@ def main():
         print(f"Agent reported failure: {explanation}")
         if ON_FAILURE == "draft" and ISSUE_TYPE == "issue":
             print("Creating draft PR (on_failure=draft)...")
+            # Auto-commit dirty changes so create_pr has something on the remote.
+            _commit_dirty_wip("agent reported failure")
             try:
                 _body = pr_body or explanation
                 _fixes = f"Fixes #{ISSUE_NUMBER}"
@@ -1953,6 +1993,10 @@ def _cleanup():
 
     Only runs when on_failure: draft is set."""
     if not _pr_created and _branch_created and ISSUE_TYPE == "issue" and ON_FAILURE == "draft":
+        # Auto-commit dirty changes so the remote branch (if any) has the
+        # agent's partial work. This covers cases where the agent crashed
+        # mid-edit before committing.
+        _commit_dirty_wip("agent terminated unexpectedly")
         try:
             remote_exists = bool(run(
                 f"git ls-remote --heads origin {_branch_created}",

--- a/tests/test_resolve_recovery.py
+++ b/tests/test_resolve_recovery.py
@@ -1,0 +1,138 @@
+"""Tests for the recovery helpers in lib/resolve.py — currently
+_commit_dirty_wip().
+
+resolve.py reads ISSUE_NUMBER from os.environ at import time, so we patch
+the environment before importing — same pattern as test_no_op.py and
+test_reconcile.py.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the repo root is on sys.path
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Import resolve.py with required env vars so module-level code succeeds.
+_ENV_PATCH = patch.dict(
+    os.environ,
+    {
+        "ISSUE_NUMBER": "456",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "LLM_MODEL": "anthropic/claude-3-5-sonnet-20241022",
+        "BASH_OUTPUT_LIMIT": "0",
+        "CONTEXT_KEEP_TOOL_RESULTS": "0",
+        "MAX_CONTEXT_TOKENS": "0",
+        "COMPACTION_COVERAGE": "0.5",
+        "COMPACTION_FACTOR": "0.5",
+    },
+)
+_ENV_PATCH.start()
+import lib.resolve as resolve_mod  # noqa: E402  (after env patch)
+_ENV_PATCH.stop()
+
+
+class TestCommitDirtyWip:
+    """Tests for _commit_dirty_wip() — the auto-save-WIP recovery helper."""
+
+    def test_clean_tree_returns_false_no_commit(self, monkeypatch):
+        """If git status is clean, return False without git add/commit/push."""
+        calls = []
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            calls.append(cmd)
+            if "git status" in cmd:
+                return ""  # clean tree
+            return ""
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        result = resolve_mod._commit_dirty_wip("test")
+        assert result is False
+        # Only `git status --porcelain` should have been called
+        assert len(calls) == 1
+        assert "git status" in calls[0]
+
+    def test_dirty_tree_commits_and_pushes(self, monkeypatch):
+        """If git status shows changes, run add → commit → push and return True."""
+        calls = []
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            calls.append(cmd)
+            if "git status" in cmd:
+                return " M lib/resolve.py\n?? scratch.py\n"  # dirty
+            return ""
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        result = resolve_mod._commit_dirty_wip("agent did not finish")
+        assert result is True
+        # Should have run: status, add, commit, push (4 commands)
+        assert len(calls) == 4
+        assert "git status" in calls[0]
+        assert calls[1] == "git add -A"
+        assert "git commit" in calls[2]
+        assert "--no-verify" in calls[2]
+        assert "agent did not finish" in calls[2]
+        assert calls[3] == "git push origin HEAD"
+
+    def test_label_appears_in_commit_message(self, monkeypatch):
+        """The label argument is included in the commit message."""
+        commit_cmd = []
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            if "git status" in cmd:
+                return " M file.py\n"
+            if "git commit" in cmd:
+                commit_cmd.append(cmd)
+            return ""
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        resolve_mod._commit_dirty_wip("custom-label-xyz")
+        assert len(commit_cmd) == 1
+        assert "custom-label-xyz" in commit_cmd[0]
+
+    def test_default_label(self, monkeypatch):
+        """Calling without arguments uses default label 'partial work'."""
+        commit_cmd = []
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            if "git status" in cmd:
+                return " M file.py\n"
+            if "git commit" in cmd:
+                commit_cmd.append(cmd)
+            return ""
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        resolve_mod._commit_dirty_wip()
+        assert "partial work" in commit_cmd[0]
+
+    def test_exception_is_non_fatal(self, monkeypatch):
+        """If a git command raises, _commit_dirty_wip returns False without re-raising."""
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            raise RuntimeError("simulated git failure")
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        # Must not raise
+        result = resolve_mod._commit_dirty_wip("test")
+        assert result is False
+
+    def test_uses_no_verify_flag(self, monkeypatch):
+        """Commit must include --no-verify to skip pre-commit hooks."""
+        # Pre-commit hooks running tests/formatters could fail and lose the WIP
+        # work entirely. --no-verify ensures the safety-net commit always lands.
+        commit_cmd = []
+
+        def fake_run(cmd, *, check=True, timeout=60):
+            if "git status" in cmd:
+                return " M f.py\n"
+            if "git commit" in cmd:
+                commit_cmd.append(cmd)
+            return ""
+
+        monkeypatch.setattr(resolve_mod, "run", fake_run)
+        resolve_mod._commit_dirty_wip("test")
+        assert "--no-verify" in commit_cmd[0]


### PR DESCRIPTION
Fixes #604.

## What was lost

When the agent fails to call `finish()` or crashes mid-run, three recovery paths in `resolve.py` try to create a draft PR from whatever was committed + pushed during the run:

1. Exhausted-iterations path (`if finish_args is None:`)
2. `finish(success=False)` path
3. `_cleanup()` atexit handler

All three previously checked `git ls-remote` for the branch and skipped PR creation if it didn't exist. But the agent often left dirty working-tree changes **without committing**, so the branch on the remote was missing or stale, and partial work got discarded when the runner shut down.

Concrete from #570's first run: agent ran 41 iterations, working tree dirty (status logs reported `[+dirty]` throughout), no remote branch at end, no draft PR created, **all partial work lost**.

## Fix

New `_commit_dirty_wip(label)` helper:

```python
def _commit_dirty_wip(label="partial work"):
    # status — bail if clean
    status = run("git status --porcelain", check=False, timeout=30)
    if not status.strip():
        return False
    # add → commit (no-verify) → push
    run("git add -A", check=False, timeout=30)
    run(f"git commit --no-verify -m 'WIP: auto-saved by recovery handler ({label})'", ...)
    run("git push origin HEAD", check=False, timeout=60)
    return True
```

Returns `True` if a commit was made; `False` if the tree was already clean OR if any git step failed. Failures are **non-fatal** — the caller still attempts PR creation with whatever's already on the remote. Uses `--no-verify` because pre-commit hooks failing here would defeat the safety-net purpose.

## Call sites

Three recovery paths in `resolve.py`, each gets a single `_commit_dirty_wip("...")` call BEFORE the existing `git ls-remote` check:

| Site | Label |
|---|---|
| Exhausted-iterations | `"agent did not finish"` |
| finish(success=False) | `"agent reported failure"` |
| `_cleanup()` atexit handler | `"agent terminated unexpectedly"` |

The labels show up in the WIP commit message, so post-mortem on a draft PR tells you which recovery path ran.

## Tests

`tests/test_resolve_recovery.py::TestCommitDirtyWip` (new file, follows the env-patch import pattern of `test_no_op.py`):

- `test_clean_tree_returns_false_no_commit` — clean tree → only `git status` runs, returns False
- `test_dirty_tree_commits_and_pushes` — dirty tree → status + add + commit + push, in order
- `test_label_appears_in_commit_message`
- `test_default_label` — `partial work`
- `test_exception_is_non_fatal` — git failures don't propagate
- `test_uses_no_verify_flag` — pre-commit hooks must be skipped

Mocks `resolve_mod.run` so the tests don't actually invoke git.

## Files changed

```
 lib/resolve.py                 |  44 +++++++++++++
 tests/test_resolve_recovery.py | 138 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 182 insertions(+)
```
