### PR TITLE
Move delegate's full pipeline cost summary from issue to PR (#527)

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -4233,9 +4233,32 @@ jobs:
             cat /tmp/cost_table.txt >> /tmp/delegate_result_comment.md
           fi
 
-          gh issue comment "$ISSUE_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --body-file /tmp/delegate_result_comment.md
+          # Post the full result+cost comment on the PR when one exists (the PR
+          # is the deliverable — that's where reviewers look). The issue gets a
+          # slim "pipeline complete — see PR" link with no cost block, so the
+          # cumulative scanner doesn't see the same cost in two places when it
+          # walks PR → linked issue. (Fixes #527.)
+          if [[ -n "$PR_URL" ]]; then
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+            gh pr comment "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/delegate_result_comment.md
+            {
+              echo "🤖 **Model:** \`${ALIAS}\` (\`${MODEL}\`)"
+              echo ""
+              echo "### ✅ Delegate pipeline complete"
+              echo ""
+              echo "See the PR for details and cost summary: ${PR_URL}"
+            } | gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file -
+          else
+            # No PR (aborted or no-PR failure) — post the cost comment on the
+            # issue, since that's the only place to post it.
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/delegate_result_comment.md
+          fi
           echo "cost embedded" > /tmp/cost_embedded
 
       - name: Assign triggerer to PR
@@ -4253,10 +4276,11 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --add-assignee "${{ github.event.comment.user.login }}"
 
-      # NOTE: Delegate's "Append cost to PR" step was removed to prevent
-      # double-counting — delegate already posts cost as an issue comment
-      # (in "Post result comment" above), and the cumulative scanner would
-      # count both if the same cost table appeared on both the issue and PR.
+      # NOTE: Delegate has no "Append cost to PR" step (unlike resolve/build).
+      # Delegate's full pipeline cost is posted as a PR *comment* by the
+      # "Post result comment" step above. Appending the same cost to the PR
+      # body too would double-count when the cumulative scanner walks the
+      # PR's comments + body.
 
       - name: Post cost comment (fallback)
         if: always()


### PR DESCRIPTION
Fixes #527.

## What changes

Delegate's "pipeline complete" comment with the full cumulative cost previously posted on the **issue**. Moving it to the **PR** instead — that's where reviewers look when deciding to merge. The issue gets a slim "pipeline complete — see PR for details" link with no cost block.

## Implementation

In the delegate `Post result comment` step, branch on whether a PR was produced:

| Case | Issue gets | PR gets |
|---|---|---|
| PR created (normal success) | Slim link-only comment, no cost block | Full result + cost table + cumulative section |
| No PR (abort / no-PR failure) | Full cost comment | (no PR exists) |

The slim issue comment intentionally has no `### 💰 Cost` block so the cumulative scanner walking PR → linked issue doesn't see the same cost in two places.

The existing comment block explaining why delegate has no "Append cost to PR" step is updated to reflect the new behavior (cost is now a PR *comment*, not an issue comment; the same anti-double-count rationale still applies — don't also append to PR body).

## Out of scope (not in this PR)

#527's body also mentions cost-reporting unification — sharing implementation between delegate's internal aggregation and resolve/reconcile's retrospective comment-scanning. That's broader future work; not done here.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Behavioral: the next `/dogfood-delegate` run after merge should post the cost summary on the resulting PR (not the issue), with a link-only stub on the issue.

## Files changed

```
 .github/workflows/remote-dev-bot.yml | 38 +++++++++++++++++++++++++++++-------
 1 file changed, 31 insertions(+), 7 deletions(-)
```
