### PR TITLE
Install litellm in test workflows

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pytest PyYAML
+        run: pip install pytest PyYAML litellm
 
       - name: Run unit tests
         run: pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pytest PyYAML
+        run: pip install pytest PyYAML litellm
 
       - name: Run tests
         run: pytest tests/ -v


### PR DESCRIPTION
## Summary
- Add `litellm` to `pip install` in both `full-test-suite.yml` (unit-tests job) and `test.yml`
- Several test modules (`test_distill.py`, `test_no_op.py`, `test_reconcile.py`, `test_resolve_recovery.py`) import `lib.{distill,resolve,reconcile}` which have top-level `import litellm`, causing pytest's collection phase to abort with 4 errors
- The most recent Full Test Suite run on dev failed in unit-tests because of this; verified locally that all 631 tests pass with `litellm` installed

## Test plan
- [ ] CI green on this PR
- [ ] Re-run "Full Test Suite: dev" after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)