### PR TITLE
Fix gpt-small model ID — gpt-5.5-mini doesn't exist

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -134,8 +134,8 @@ models:
     description: "Most capable — for complex multi-file features"
 
   gpt-small:
-    id: openai/gpt-5.5-mini
-    description: "OpenAI GPT-5.5 Mini — fast, cost-effective coding"
+    id: openai/gpt-5.1-codex-mini
+    description: "OpenAI GPT-5.1 Codex Mini — fast, cost-effective coding"
 
   gpt-large:
     id: openai/gpt-5.5


### PR DESCRIPTION
## Summary
- `gpt-small` was set to `openai/gpt-5.5-mini` in PR #576, but **that model does not exist** — OpenAI shipped `gpt-5.5` and `gpt-5.5-pro` without a mini variant
- Every gpt-small run since #576 has failed with `litellm.NotFoundError: The model gpt-5.5-mini does not exist`; uncaught because the default model is claude-small (dogfood never exercises gpt-small) and Full Test Suite hadn't been re-run since March
- Switch to `openai/gpt-5.1-codex-mini` — closest mini-tier cousin to gpt-5.5 that actually exists, codex-tuned for code work, already referenced elsewhere in the repo

## Test plan
- [ ] After merge, re-run Full Test Suite on dev and confirm gpt-small e2e passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)