### PR TITLE
Fix module imports that break under production sys.path

### DIFF
--- a/lib/cumulative_cost.py
+++ b/lib/cumulative_cost.py
@@ -16,7 +16,7 @@ Usage from workflow Python heredoc:
 import re
 import subprocess
 
-from lib.formatting import _fmt_tok, _fmt_loc
+from formatting import _fmt_tok, _fmt_loc
 
 
 def extract_costs_from_text(text: str) -> tuple:

--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 
-from lib.tools import (
+from tools import (
     validate_path as _tools_validate_path,
     execute_read_file as _tools_execute_read_file,
     execute_gh as _tools_execute_gh,

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 # Cost formatting helpers — imported from shared lib/formatting.py
 # ---------------------------------------------------------------------------
 
-from lib.formatting import _fmt_tok, _fmt_ela, _fmt_bpd, _fmt_loc, _fmt_info, TABLE_HEADER
+from formatting import _fmt_tok, _fmt_ela, _fmt_bpd, _fmt_loc, _fmt_info, TABLE_HEADER
 
 
 def _build_cost_table(input_tokens, output_tokens, cost, elapsed, output_text):

--- a/tests/test_production_imports.py
+++ b/tests/test_production_imports.py
@@ -1,0 +1,87 @@
+"""Regression tests for module-level imports under the production sys.path layout.
+
+The remote-dev-bot.yml workflow invokes the lib/ modules with
+`sys.path.insert(0, '.remote-dev-bot/lib')` — i.e., only the lib/
+directory is on sys.path, NOT the rdb repo root. Modules that import
+their siblings as `from lib.X import ...` will silently break in
+production while continuing to pass test suites that run with
+`PYTHONPATH=.` (which adds both to the path).
+
+This file spawns a subprocess with sys.path set up the same way as the
+workflow heredoc, then imports each module. The subprocess isolation
+matters: if the test process already has both paths on sys.path,
+`from lib.X` will resolve from the rdb root and mask the bug.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent
+LIB_DIR = REPO_ROOT / "lib"
+
+
+def _import_in_production_pathlayout(module_name: str) -> subprocess.CompletedProcess:
+    """Run `python -c 'import <module_name>'` with only lib/ on sys.path.
+
+    Mimics the production invocation: workflow heredocs do
+    `sys.path.insert(0, '.remote-dev-bot/lib')` and then `from <module> import ...`.
+    Returns the CompletedProcess so tests can assert on returncode and stderr.
+    """
+    # Match the workflow heredoc: prepend lib/ to sys.path, but leave stdlib
+    # paths in place. Critically, the REPO ROOT (which would let `from lib.X`
+    # resolve) must NOT be on sys.path — that's the production condition we're
+    # reproducing.
+    code = (
+        "import sys; "
+        f"sys.path = [p for p in sys.path if p not in ({str(REPO_ROOT)!r}, '')]; "
+        f"sys.path.insert(0, {str(LIB_DIR)!r}); "
+        f"import {module_name}"
+    )
+    # Use the same Python that's running pytest. PYTHONPATH must be cleared so
+    # the parent process's path doesn't leak in and mask the bug.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+class TestProductionSysPathImports:
+    """Each library module must import cleanly when only lib/ is on sys.path."""
+
+    @pytest.mark.parametrize("module_name", [
+        "workshop",
+        "cumulative_cost",
+        "formatting",
+        "context",
+        "tools",
+        "distill",
+        "design_loop",
+    ])
+    def test_module_imports_with_only_lib_on_path(self, module_name):
+        """The workflow heredoc puts only lib/ on sys.path. Modules must
+        respect that — they must not assume the rdb repo root is also there
+        (which would let `from lib.X import ...` work).
+
+        If this fails for a module, change its top-level imports from
+        `from lib.X import Y` to `from X import Y` to match the heredoc style.
+        Modules that are *script entry points* (resolve.py, reconcile.py,
+        post_fallback_cost.py) handle this themselves with a
+        `sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))` —
+        those are not tested here because they would have to be invoked as
+        scripts, not imported.
+        """
+        result = _import_in_production_pathlayout(module_name)
+        assert result.returncode == 0, (
+            f"Importing {module_name!r} with production sys.path failed:\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Workshop mode has been crashing on every invocation with:

\`\`\`
File ".remote-dev-bot/lib/workshop.py", line 31, in <module>
    from lib.formatting import _fmt_tok, ...
ModuleNotFoundError: No module named 'lib'
\`\`\`

Failing run: [gnovak/bridge-analysis run 26121417319](https://github.com/gnovak/bridge-analysis/actions/runs/26121417319) (issue #393 \`/agent workshop\`).

## Root cause

The workflow heredocs invoke library modules with:

\`\`\`python
sys.path.insert(0, ".remote-dev-bot/lib")
from workshop import run_workshop
\`\`\`

Only \`lib/\` is on \`sys.path\`, not the rdb repo root. Three modules used \`from lib.X import ...\` which requires the rdb root on \`sys.path\` so that \`lib\` resolves as a package:

- \`lib/workshop.py:31\` — broken since commit e4209e7 (formatting.py extract). Hard crash; what surfaced this bug.
- \`lib/cumulative_cost.py:19\` — silently broken. Wrapped in \`try/except\` in the heredocs, so cumulative-cost tables have just been silently missing.
- \`lib/design_loop.py:13\` — broken since lib/tools.py extract. Latent because callers crashed earlier on the workshop import.

Tests passed because pytest runs with \`PYTHONPATH=.\` which puts both the rdb root AND lib/ on path, masking the production gap.

## Fix

- Changed all three to sibling-style \`from X import ...\` to match the heredoc convention.
- Script entry points (resolve.py, reconcile.py, post_fallback_cost.py) are unaffected — each handles its own \`sys.path\` with \`sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))\` so they work under either layout.
- New \`tests/test_production_imports.py\` spawns a subprocess with **only lib/ on sys.path** (matching the workflow heredoc, with \`PYTHONPATH\` cleared) and asserts every library module imports cleanly. Locks in the fix and will catch this regression for any new \`from lib.X\` import in a non-entry-point module.

## Test plan

- [x] 7 new tests pass (workshop, cumulative_cost, formatting, context, tools, distill, design_loop)
- [x] Full suite: 639 passed
- [ ] Next \`/agent-workshop\` invocation should actually run, not crash on import

🤖 Generated with [Claude Code](https://claude.com/claude-code)