### PR TITLE
Tighten e2e assertions so missing-output cases fail

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -811,29 +811,38 @@ for pos in "${!issue_nums[@]}"; do
 
     if [[ "$conclusion" == "success" ]]; then
         if [[ "$test_type" == "design" ]]; then
-            # Design mode: check if a comment was posted (not a PR)
+            # Design mode produces nothing but a "Design analysis" comment;
+            # missing that comment = the agent did not deliver its only output.
             comment_count=$(gh api "repos/$TEST_REPO/issues/$issue_num/comments" \
                 --jq '[.[] | select(.body | contains("Design analysis"))] | length' \
                 2>/dev/null || echo "0")
             if [[ "$comment_count" -gt 0 ]]; then
                 status="PASS (comment posted)"
+                ((pass++)) || true
             else
-                status="PASS (no comment found)"
+                status="FAIL (no design comment posted — workflow ran but did not deliver)"
+                ((fail++)) || true
             fi
-            ((pass++)) || true
         elif [[ "$test_type" == "workshop" ]]; then
-            # Workshop mode: check if a Stage 2 summary comment was posted (no PR)
+            # Workshop produces nothing but Stage 1 / Stage 2 comments; missing
+            # them means the workshop pipeline did not deliver. (This is exactly
+            # the failure mode that PR #623 fixed — workshop crashed on import,
+            # produced only an "exited unexpectedly" fallback, and the prior
+            # lax assertion still counted it as a PASS.)
             comment_count=$(gh api "repos/$TEST_REPO/issues/$issue_num/comments" \
                 --jq '[.[] | select(.body | contains("Workshop Stage 2 complete") or contains("Workshop Stage 1"))] | length' \
                 2>/dev/null || echo "0")
             if [[ "$comment_count" -gt 0 ]]; then
                 status="PASS (workshop comments posted)"
+                ((pass++)) || true
             else
-                status="PASS (no workshop comment found)"
+                status="FAIL (no Workshop Stage 1/2 comment — workshop did not run to completion)"
+                ((fail++)) || true
             fi
-            ((pass++)) || true
         elif [[ "$test_type" == "build" ]]; then
-            # Build mode: Stage 1 creates a PR; Stage 2 posts council code reviews on the PR.
+            # Build mode: Stage 1 creates a PR; Stage 2 posts council code reviews.
+            # The council review IS the value-add of build mode over plain resolve,
+            # so missing it = the test didn't exercise what makes build distinct.
             pr_num=$(gh pr list --repo "$TEST_REPO" \
                 --search "head:rdb-fix-issue-$issue_num" \
                 --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
@@ -849,15 +858,18 @@ for pos in "${!issue_nums[@]}"; do
                     2>/dev/null || echo "0")
                 if [[ "$council_comment_count" -gt 0 ]]; then
                     status="PASS (PR #$pr_num + council review posted)"
+                    ((pass++)) || true
                 else
-                    status="PASS (PR #$pr_num created, no council comment found)"
+                    status="FAIL (PR #$pr_num created but no council review — Stage 2 did not run)"
+                    ((fail++)) || true
                 fi
-                ((pass++)) || true
             fi
         elif [[ "$test_type" == "delegate" ]]; then
             # Delegate mode: Stages 1-3 post design/council/revision comments on issue;
             # Stage 4 creates a PR; Stage 5 posts council code review on the PR;
-            # final summary comment is posted on the issue.
+            # final "Delegate pipeline complete" comment on the issue marks completion.
+            # The delegate test must exercise BOTH the council review AND the final
+            # marker — missing either means the pipeline didn't fully run.
             pr_num=$(gh pr list --repo "$TEST_REPO" \
                 --search "head:rdb-fix-issue-$issue_num" \
                 --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
@@ -885,12 +897,17 @@ for pos in "${!issue_nums[@]}"; do
                     2>/dev/null || echo "0")
                 if [[ "$pipeline_comment" -gt 0 ]] && [[ "$council_comment_count" -gt 0 ]]; then
                     status="PASS (PR #$pr_num + council review + pipeline complete)"
+                    ((pass++)) || true
                 elif [[ "$pipeline_comment" -gt 0 ]]; then
-                    status="PASS (PR #$pr_num created, pipeline complete, no council comment found)"
+                    status="FAIL (PR #$pr_num + pipeline complete but no council review — Stage 5 missing)"
+                    ((fail++)) || true
+                elif [[ "$council_comment_count" -gt 0 ]]; then
+                    status="FAIL (PR #$pr_num + council review but no pipeline-complete marker — pipeline did not finish)"
+                    ((fail++)) || true
                 else
-                    status="PASS (PR #$pr_num created, no pipeline complete comment found)"
+                    status="FAIL (PR #$pr_num created but neither council review nor pipeline-complete marker)"
+                    ((fail++)) || true
                 fi
-                ((pass++)) || true
             fi
         else
             # Resolve mode: check if a PR was created
@@ -970,10 +987,11 @@ else
         reconcile_comment=$(gh api "repos/$TEST_REPO/issues/$RECONCILE_PR_NUM/comments"             --jq '[.[] | select(.body | test("Reconcile complete|reconcile complete"; "i"))] | length'             2>/dev/null || echo "0")
         if [[ "$reconcile_comment" -gt 0 ]]; then
             log "  reconcile-test: PASS (force-pushed new SHA ${new_sha:0:7}, Reconcile complete comment found)  $reconcile_url"
+            ((RECONCILE_PASS++)) || true
         else
-            log "  reconcile-test: PASS (force-pushed new SHA ${new_sha:0:7}, no Reconcile complete comment found)  $reconcile_url"
+            log "  reconcile-test: FAIL (force-pushed but no 'Reconcile complete' comment — workflow may have crashed after the push)  $reconcile_url"
+            ((RECONCILE_FAIL++)) || true
         fi
-        ((RECONCILE_PASS++)) || true
     fi
 fi
 
@@ -1025,10 +1043,11 @@ elif [[ "$RF_REVIEW_RESULT" == "success" ]]; then
         2>/dev/null || echo "0")
     if [[ "$comment_count" -gt 0 ]]; then
         rf_review_status="PASS (review comment posted)"
+        ((RF_PASS++)) || true
     else
-        rf_review_status="PASS (no review comment found)"
+        rf_review_status="FAIL (review workflow succeeded but no 'Code review by' comment posted)"
+        ((RF_FAIL++)) || true
     fi
-    ((RF_PASS++)) || true
 else
     rf_review_status="FAIL ($RF_REVIEW_RESULT)"
     ((RF_FAIL++)) || true
@@ -1049,9 +1068,12 @@ if [[ -z "$TIMEOUT_RESULT" ]]; then
     timeout_status="TIMEOUT (e2e wait exceeded)"
     ((TIMEOUT_PHASE_FAIL++)) || true
 elif [[ "$TIMEOUT_RESULT" == "success" || "$TIMEOUT_RESULT" == "failure" ]]; then
-    # Both success and failure are valid: the watchdog kills OpenHands (making the
-    # resolver step exit non-zero → job conclusion = failure), but cleanup steps
-    # still run due to if:always(). Accept either conclusion as "run completed".
+    # Both success and failure are valid: the watchdog kills the agent (making
+    # the resolver step exit non-zero → job conclusion = failure), but cleanup
+    # steps still run due to if:always(). The PASS criterion is that the
+    # watchdog actually fired and posted a "could not fully resolve" /
+    # "exited unexpectedly" comment — without that, we have no evidence the
+    # timeout path was exercised at all.
     comment_count=$(gh api "repos/$TEST_REPO/issues/$timeout_issue_num/comments" \
         --jq '[.[] | select(.body | contains("could not fully resolve") or contains("exited unexpectedly"))] | length' \
         2>/dev/null || echo "0")
@@ -1059,8 +1081,8 @@ elif [[ "$TIMEOUT_RESULT" == "success" || "$TIMEOUT_RESULT" == "failure" ]]; the
         timeout_status="PASS (watchdog fired + comment posted) [${TIMEOUT_RESULT}]"
         ((TIMEOUT_PHASE_PASS++)) || true
     else
-        timeout_status="PASS (run completed, no comment found) [${TIMEOUT_RESULT}]"
-        ((TIMEOUT_PHASE_PASS++)) || true
+        timeout_status="FAIL (run completed but no watchdog comment — timeout path did not fire) [${TIMEOUT_RESULT}]"
+        ((TIMEOUT_PHASE_FAIL++)) || true
     fi
 else
     timeout_status="FAIL ($TIMEOUT_RESULT)"
@@ -1144,23 +1166,33 @@ if [[ -z "$WRAPUP_RESULT" ]]; then
     wrapup_status="TIMEOUT (e2e wait exceeded)"
     ((WRAPUP_PHASE_FAIL++)) || true
 elif [[ "$WRAPUP_RESULT" == "success" ]]; then
-    # Check for either a PR (agent finished) or a failure comment (wrapup triggered)
+    # The wrapup test runs with max_iterations=4 on a task the agent cannot
+    # plausibly finish, so we expect *either*:
+    #   - A PR (agent finished anyway), OR
+    #   - A "could not fully resolve" comment (wrapup nudge triggered the
+    #     graceful failure path).
+    # Neither = the run completed without exercising the wrapup path → FAIL.
+    #
+    # NB: branch name was historically `openhands-fix-issue-$N` (stale since
+    # v0.6.0 OpenHands removal); current branches are `rdb-fix-issue-$N-$alias`.
+    # That stale name meant the pr_count branch never fired and the test was
+    # silently coasting on the "no clear output" PASS for months.
     pr_count=$(gh pr list --repo "$TEST_REPO" \
-        --search "head:openhands-fix-issue-$wrapup_issue_num" \
+        --search "head:rdb-fix-issue-$wrapup_issue_num" \
         --json number --jq 'length' 2>/dev/null || echo "0")
     comment_count=$(gh api "repos/$TEST_REPO/issues/$wrapup_issue_num/comments" \
         --jq '[.[] | select(.body | contains("could not fully resolve"))] | length' \
         2>/dev/null || echo "0")
     if [[ "$pr_count" -gt 0 ]]; then
         wrapup_status="PASS (agent finished — PR created)"
-        cleanup_branches+=("openhands-fix-issue-$wrapup_issue_num")
+        cleanup_branches+=("rdb-fix-issue-$wrapup_issue_num")
         ((WRAPUP_PHASE_PASS++)) || true
     elif [[ "$comment_count" -gt 0 ]]; then
         wrapup_status="PASS (wrapup triggered — failure comment posted)"
         ((WRAPUP_PHASE_PASS++)) || true
     else
-        wrapup_status="PASS (run completed, no clear output found)"
-        ((WRAPUP_PHASE_PASS++)) || true
+        wrapup_status="FAIL (run completed but neither PR nor wrapup comment — wrapup path did not fire)"
+        ((WRAPUP_PHASE_FAIL++)) || true
     fi
 else
     wrapup_status="FAIL ($WRAPUP_RESULT)"


### PR DESCRIPTION
## Why

The workshop import crash fixed in PR #623 was already present when the v0.9.0 e2e ran on 2026-05-11. The e2e workshop test ran. It "passed". Because the assertion was:

\`\`\`bash
if [[ "\$comment_count" -gt 0 ]]; then
    status="PASS (workshop comments posted)"
else
    status="PASS (no workshop comment found)"   # ← here
fi
((pass++)) || true
\`\`\`

The crash produced an \`exited unexpectedly\` fallback comment which doesn't match the Stage 1/2 substring → 0 matches → catch-all PASS. We shipped a broken workshop mode and the test didn't catch it.

Audited all e2e assertions and tightened the false-pass paths.

## Spots fixed

| Test | Old (PASS) | New |
|---|---|---|
| design | no "Design analysis" comment | FAIL |
| workshop | no Stage 1/2 comment | FAIL |
| build | PR but no council review | FAIL |
| delegate | PR but no pipeline-complete marker | FAIL |
| delegate | PR but no council review | FAIL |
| rf-review | no "Code review by" comment | FAIL |
| timeout | run completed but no watchdog comment | FAIL |
| wrapup | run completed but no PR and no wrapup comment | FAIL |
| reconcile | force-pushed but no "Reconcile complete" | FAIL |

Plus a latent bug in the wrapup test: it searched for PRs on \`openhands-fix-issue-\$N\` (stale since the v0.6.0 OpenHands removal); the current branch convention is \`rdb-fix-issue-\$N-\$alias\`. The "agent finished — PR created" branch had not fired for months; the test was silently coasting on the now-FAIL "no clear output" catch-all. Fixed.

All substring patterns verified against the actual strings the code emits in \`lib/workshop.py\`, \`lib/reconcile.py\`, and \`.github/workflows/remote-dev-bot.yml\`.

## Test plan

- [x] \`bash -n tests/e2e.sh\` passes
- [x] Pytest: 655 passed (no regressions)
- [ ] Next full-test-suite run on dev should still PASS — these changes only convert false-positive PASS to FAIL, so anything that was *genuinely* passing keeps passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)