### PR TITLE
Make timeout e2e test reliably exercise the watchdog

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -311,7 +311,7 @@ jobs:
           fi
 
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
-          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          TIMEOUT_SECONDS=$(awk -v m="$TIMEOUT_MINUTES" 'BEGIN{print int(m*60)}')
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
           echo $(date +%s) > /tmp/start_time
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
@@ -863,7 +863,7 @@ jobs:
           fi
 
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
-          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          TIMEOUT_SECONDS=$(awk -v m="$TIMEOUT_MINUTES" 'BEGIN{print int(m*60)}')
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
           echo $(date +%s) > /tmp/start_time
           # Run agent loop under timeout. On expiry: SIGTERM first, then SIGKILL after 60s.
@@ -2204,7 +2204,7 @@ jobs:
           echo "Reconciling PR #${PR_NUMBER} onto base branch: ${BASE_BRANCH}"
 
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
-          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          TIMEOUT_SECONDS=$(awk -v m="$TIMEOUT_MINUTES" 'BEGIN{print int(m*60)}')
           echo "Reconcile timeout: ${TIMEOUT_MINUTES} minutes"
           echo $(date +%s) > /tmp/start_time
 
@@ -3742,7 +3742,7 @@ jobs:
           Running resolve agent with \`${{ needs.parse.outputs.alias }}\` (\`${{ needs.parse.outputs.model }}\`) to implement the revised design..."
 
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
-          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          TIMEOUT_SECONDS=$(awk -v m="$TIMEOUT_MINUTES" 'BEGIN{print int(m*60)}')
           echo "Resolver timeout: ${TIMEOUT_MINUTES} minutes"
 
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \
@@ -4064,7 +4064,7 @@ jobs:
           Running resolve agent with \`${{ needs.parse.outputs.alias }}\` (\`${{ needs.parse.outputs.model }}\`) to apply council code review feedback to this PR..."
 
           TIMEOUT_MINUTES="${{ needs.parse.outputs.timeout_minutes }}"
-          TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+          TIMEOUT_SECONDS=$(awk -v m="$TIMEOUT_MINUTES" 'BEGIN{print int(m*60)}')
           echo "Stage 6 resolver timeout: ${TIMEOUT_MINUTES} minutes"
 
           timeout --kill-after=60 "$TIMEOUT_SECONDS" \

--- a/lib/config.py
+++ b/lib/config.py
@@ -89,7 +89,7 @@ DEFAULT_TIMEOUT_MINUTES = 120
 ALLOWED_ARGS = {
     "max_iterations": int,       # agent.max_iterations (code-writing stages)
     "max_design_iterations": int,  # delegate: budget for design/exploration stages
-    "timeout_minutes": int,      # agent.timeout_minutes
+    "timeout_minutes": float,    # agent.timeout_minutes (float so e2e tests can use sub-minute values)
     "extra_files": list,         # mode's extra_files
     "branch": str,               # agent.branch (target branch for PRs)
     "status_log_interval": int,       # rolling status log interval (0 = disabled)

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -375,17 +375,30 @@ log "  Issue #$RF_ISSUE_NUM created. Triggering /agent-resolve..."
 post_issue_comment "$RF_ISSUE_NUM" "$TEST_REPO" "/agent-resolve"
 
 # --- Trigger timeout test ---
+# Purpose: verify the watchdog kills the agent process when it exceeds
+# timeout_minutes. The task must be concrete enough that the agent cannot
+# scope-reduce its way to an early finish() — and the timeout short enough
+# that even fast scope-reduced work doesn't fit. (The previous vague
+# "refactor everything" prompt with timeout_minutes=1 let the agent finish
+# in 50s by creating one file with type hints; watchdog never fired.)
 log "Creating timeout test issue..."
 timeout_ts=$(date +%s)
 timeout_title="Test: timeout enforcement (e2e-timeout-$timeout_ts)"
 timeout_issue_url=$(gh issue create --repo "$TEST_REPO" \
     --title "$timeout_title" \
-    --body "Analyze and refactor every file in this repository to follow best practices, add comprehensive type hints, docstrings, and unit tests. This task is intentionally scope-heavy.")
+    --body "Create exactly 50 Python files named day_01.py through day_50.py in a new \`days/\` directory at the repo root. Each file must contain exactly one function with this exact signature and body (substitute NN with the day number, NOT zero-padded in the body):
+
+\`\`\`python
+def visits_on_day_NN() -> int:
+    return NN
+\`\`\`
+
+All 50 files must be created and committed in a single PR. This is a concrete, fully-specified task that cannot be scope-reduced — produce all 50 files or report failure.")
 timeout_issue_num="${timeout_issue_url##*/}"
 cleanup_issues+=("$timeout_issue_num")
 
-log "  Issue #$timeout_issue_num. Posting /agent-resolve with timeout_minutes = 1..."
-post_issue_comment "$timeout_issue_num" "$TEST_REPO" $'/agent-resolve\ntimeout_minutes = 1'
+log "  Issue #$timeout_issue_num. Posting /agent-resolve with timeout_minutes = 0.5..."
+post_issue_comment "$timeout_issue_num" "$TEST_REPO" $'/agent-resolve\ntimeout_minutes = 0.5'
 
 TIMEOUT_RUN_ID=""
 TIMEOUT_RESULT=""


### PR DESCRIPTION
## Why

The most recent full-suite run failed the (now-tightened) timeout assertion because the agent scope-reduced the vague refactor task and finished in 50s instead of being killed by the 1-minute watchdog:

\`\`\`
Tool: finish({'success': True, 'explanation': 'Created utils.py with type hints
       and docstrings, and test_utils.py with 14 passing unit tests.'})
\`\`\`

The test had been silently coasting on PR #624's lax "no comment found = PASS" predecessor for months. The tightened assertion correctly fails, but the underlying issue is that the test doesn't actually exercise the watchdog anymore — the agent's improved wrapup/scoping just routes around it.

## Fix

Two changes, both needed (defense in depth):

- **Concrete uncompressible task**: replace "refactor every file to follow best practices..." with "create exactly 50 Python files named \`day_01.py\`..\`day_50.py\` with this exact body". The agent can no longer satisfy the requirement by writing one demonstrative file — it's all 50 or explicit failure.
- **Shorter watchdog**: cut \`timeout_minutes\` from 1 to 0.5. Even scope-reduced work doesn't fit in 30s. Required adding fractional support: \`timeout_minutes\` is now \`float\` in \`lib/config.py\`'s \`ALLOWED_ARGS\`, and the 5 workflow watchdog steps change from \`\$((TIMEOUT_MINUTES*60))\` (bash integer math, drops fractional values to 0) to \`awk -v m=… 'BEGIN{print int(m*60)}'\`.

The float type also leaves the door open for users who want \`timeout_minutes=1.5\` in production configs.

## Test plan

- [x] Pytest: 655 passed
- [x] \`bash -n tests/e2e.sh\`
- [x] Awk math spot-checked for inputs 0.5, 1, 60 → 30, 60, 3600
- [ ] Next full-test-suite run should show \`timeout: PASS (watchdog fired + comment posted)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)