### PR TITLE
Distillation: tighten prompt, fix metric, model-dependent Tier-1 limit

### DIFF
--- a/lib/design_loop.py
+++ b/lib/design_loop.py
@@ -338,7 +338,10 @@ def run_design_loop(
                 + (f"\n\n## Discussion so far:\n{issue_comments}" if issue_comments else "")
             )
             print("Running context distillation pre-step (design loop)...")
-            distilled, distill_input_tokens, distill_output_tokens, distill_cost, structural_extract = maybe_distill(
+            # Note: design loop currently doesn't surface a per-iter savings
+            # metric, so we discard codebase_total_tokens here.
+            (distilled, distill_input_tokens, distill_output_tokens,
+             distill_cost, structural_extract, _codebase_total) = maybe_distill(
                 extra_context, issue_context_text, model
             )
             if distilled != extra_context:

--- a/lib/distill.py
+++ b/lib/distill.py
@@ -28,9 +28,18 @@ from litellm import completion
 
 # --- Constants (all hardcoded — no user-facing config) ---
 
-# Token budget below which we skip the structural-extract step and just send
-# the whole codebase to the distill LLM in one shot.
-DISTILL_SMALL_REPO_LIMIT = 100_000    # tokens — try to send whole codebase
+# Default token budget below which we skip the structural-extract step and
+# send the whole codebase to the distill LLM in one shot. Used as a fallback
+# when the model's context window can't be looked up. For models with a known
+# context window, the effective limit is computed by _small_repo_limit() as
+# DISTILL_SMALL_REPO_BUDGET_FRACTION × context_window — clamped between
+# DISTILL_SMALL_REPO_LIMIT_MIN and DISTILL_SMALL_REPO_LIMIT_MAX. This way a
+# 1M-token model gets the headroom to ingest a much bigger codebase in one
+# call, while a smaller model stays conservative.
+DISTILL_SMALL_REPO_LIMIT = 100_000      # fallback for unknown models
+DISTILL_SMALL_REPO_LIMIT_MIN = 50_000   # floor (don't go below this)
+DISTILL_SMALL_REPO_LIMIT_MAX = 500_000  # ceiling (don't get carried away)
+DISTILL_SMALL_REPO_BUDGET_FRACTION = 0.25  # share of input window we'll spend on codebase
 
 # Per-file size caps before truncation (in characters)
 SOURCE_FILE_CAP = 50_000    # for source/config files
@@ -83,6 +92,31 @@ STRUCT_OUTPUT_TOKENS = 16_384
 
 # First N lines to include for non-Python files in structural extract
 STRUCT_EXTRACT_HEAD_LINES = 30
+
+
+# --- Model-dependent thresholds ---
+
+def _small_repo_limit(model):
+    """Return the Tier-1-vs-Tier-2 cutoff for this model.
+
+    Larger context windows (1M tokens for current Claude/GPT/Gemini frontier
+    models) can comfortably ingest more of the codebase in one shot, so the
+    "small repo" threshold scales with the model's input window. Clamped to
+    [DISTILL_SMALL_REPO_LIMIT_MIN, DISTILL_SMALL_REPO_LIMIT_MAX].
+
+    Returns DISTILL_SMALL_REPO_LIMIT (the legacy 100K default) for any model
+    LiteLLM doesn't know about.
+    """
+    try:
+        import litellm
+        info = litellm.get_model_info(model)
+        window = int(info.get("max_input_tokens") or 0)
+    except Exception:
+        window = 0
+    if window <= 0:
+        return DISTILL_SMALL_REPO_LIMIT
+    raw = int(window * DISTILL_SMALL_REPO_BUDGET_FRACTION)
+    return max(DISTILL_SMALL_REPO_LIMIT_MIN, min(DISTILL_SMALL_REPO_LIMIT_MAX, raw))
 
 
 # --- File gathering ---
@@ -298,24 +332,41 @@ def format_structural_extract(files, include_line_numbers=False):
 
 DISTILL_SYSTEM_PROMPT = """\
 You are a code relevance filter. Given a codebase and a task description, \
-extract ONLY what is directly relevant to implementing the task:
-- Full content of files that will need to be modified
-- Signatures and docstrings (not full bodies) of functions that provide context \
-but won't be directly modified
-- Schema definitions, data structures, or config formats the task touches
-- Brief explanation of how each included item relates to the task
+produce a focused context block for a downstream coding agent.
 
-Your goal is to reduce the need for the downstream coding agent to explore and \
-understand the whole codebase. The agent should be able to read your output and \
-know exactly which files to modify, which functions to call, and what interfaces \
-to respect — without needing to read anything else.
+## Hard rule: files to be modified must be included in FULL
 
-Be explicit about boundaries: "you need to read this file", "you need this \
-function signature but don't need the full body", "don't bother reading X, \
-it's not relevant to this task".
+For any file the agent will need to modify, include the COMPLETE file content \
+verbatim — every line, top to bottom. Do NOT excerpt, summarize, or skip lines \
+even if the task references specific line numbers or function names. The agent \
+needs the surrounding code (imports, helpers, module-level state, neighbouring \
+functions) to understand how its changes interact with the rest of the file.
 
-Omit everything unrelated to the task. Be concise — the output feeds directly \
-into a coding agent's working context."""
+A request like "drop the threshold check in `_player_stats` at line 312" still \
+requires the FULL file — the agent has to see what `_player_stats` calls, what \
+calls `_player_stats`, what state it depends on, and so on. Returning only the \
+lines around 312 is worse than returning nothing: it gives the agent false \
+confidence that it has the relevant context when it doesn't.
+
+## What else to include
+
+- Signatures and docstrings (not full bodies) of functions in OTHER files \
+that the agent will need to call or whose interfaces it must respect.
+- Schema definitions, data structures, or config formats the task touches.
+- A one-line "why this file matters" note for each included file.
+
+## What to omit
+
+- Files unrelated to the task.
+- Full bodies of helper functions in non-modified files (signatures + \
+docstrings only).
+
+Be explicit about boundaries: \"you need to read this file\", \"you need \
+this function signature but don't need the full body\", \"don't bother \
+reading X, it's not relevant to this task\".
+
+Be concise on context, but never trim files that will be modified — \
+their full content is the foundation the agent's work rests on."""
 
 
 def distill(codebase_text, task_context, model):
@@ -332,10 +383,12 @@ def distill(codebase_text, task_context, model):
                 f"## Task\n\n{task_context}\n\n"
                 f"## Codebase\n\n{codebase_text}\n\n"
                 "## Instructions\n\n"
-                "Extract only what is relevant to the task above. Format as:\n\n"
+                "Produce a focused context block for the downstream coding "
+                "agent. Format as:\n\n"
                 "### Relevant Files\n\n"
                 "**`path/to/file.py`** — [one sentence: why this file matters]\n"
-                "```python\n[full content or relevant excerpt]\n```\n\n"
+                "```python\n[FULL file content, verbatim, no excerpting — see "
+                "the system prompt's hard rule]\n```\n\n"
                 "### Key Interfaces\n\n"
                 "[signatures and docstrings from other files that the task touches, "
                 "without full bodies]\n\n"
@@ -424,13 +477,16 @@ def _identify_relevant_files(extract_text, task_context, model):
 def maybe_distill(repo_context, issue_context, model, root="."):
     """Run context distillation pre-step.
 
-    Returns (context_text, input_tokens, output_tokens, cost, structural_extract).
-    On failure or skip, returns (repo_context, 0, 0, 0.0, "").
-    The structural_extract is a compact index of all functions/classes with line
-    numbers, intended to be included in the agent's system prompt alongside the
-    distilled context.
+    Returns (context_text, input_tokens, output_tokens, cost,
+             structural_extract, codebase_total_tokens).
+    On failure or skip, returns (repo_context, 0, 0, 0.0, "", 0).
+    The structural_extract is a compact index of all functions/classes with
+    line numbers, intended to be included in the agent's system prompt
+    alongside the distilled context. codebase_total_tokens is the estimated
+    size of the codebase that distillation scanned, so callers can compute
+    meaningful "tokens-saved-per-iteration" metrics.
     """
-    fallback = (repo_context, 0, 0, 0.0, "")
+    fallback = (repo_context, 0, 0, 0.0, "", 0)
 
     try:
         files = gather_repo_files(root=root)
@@ -454,9 +510,11 @@ def maybe_distill(repo_context, issue_context, model, root="."):
         total_output = 0
         total_cost = 0.0
 
-        if total_tokens <= DISTILL_SMALL_REPO_LIMIT:
-            # Tier 1: Small repo — send full codebase
-            print("  [Distill] Tier 1 (small repo): sending full codebase")
+        small_repo_limit = _small_repo_limit(model)
+        if total_tokens <= small_repo_limit:
+            # Tier 1: Small repo (relative to model's context window) — send
+            # full codebase in one call.
+            print(f"  [Distill] Tier 1 (small repo, ≤{small_repo_limit:,} tokens for this model): sending full codebase")
             codebase_text = format_codebase(files)
             result, inp, out, cost = distill(codebase_text, issue_context, model)
             total_input += inp
@@ -507,7 +565,7 @@ def maybe_distill(repo_context, issue_context, model, root="."):
             return fallback
 
         print(f"  [Distill] Distillation complete: ~{len(result) // 4:,} tokens output")
-        return result, total_input, total_output, total_cost, agent_structural_extract
+        return result, total_input, total_output, total_cost, agent_structural_extract, total_tokens
 
     except Exception as e:
         print(f"  [Distill] Distillation failed: {e} — proceeding with full repo context")

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -1145,16 +1145,20 @@ def main():
     distill_input_tokens = 0
     distill_output_tokens = 0
     distill_cost = 0.0
-    pre_distill_tokens = 0  # token estimate before distillation
-    post_distill_tokens = 0  # token estimate after distillation (0 = distillation did not run)
+    # pre_distill_tokens reflects what distillation actually saw (the codebase
+    # total), so the savings metric in the status log compares against the
+    # hypothetical "drag full codebase along every iteration" baseline. It is
+    # NOT the size of EXTRA_FILES (which was a bug — those are added context
+    # docs, not the thing distillation is replacing).
+    pre_distill_tokens = 0
+    post_distill_tokens = 0  # 0 = distillation did not run
     if DISTILL_ENABLED:
         try:
             from lib.distill import maybe_distill
-            pre_distill_tokens = len(repo_context) // 4
             print("Running context distillation pre-step...")
-            # Estimate tokens before distillation so we can measure savings
-            undistilled_tokens = estimate_tokens([{"content": repo_context}])
-            distilled, distill_input_tokens, distill_output_tokens, distill_cost, structural_extract = maybe_distill(
+            (distilled, distill_input_tokens, distill_output_tokens,
+             distill_cost, structural_extract,
+             codebase_total_tokens) = maybe_distill(
                 repo_context, issue_context, LLM_MODEL
             )
             if distilled != repo_context:
@@ -1165,9 +1169,10 @@ def main():
                 if structural_extract:
                     agent_context += f"\n\n## Codebase Index\n\n{structural_extract}"
                 distillation_ran = True
+                pre_distill_tokens = codebase_total_tokens
                 post_distill_tokens = len(distilled) // 4
                 print(f"Distillation complete: {distill_input_tokens} input tokens, {distill_output_tokens} output tokens, ${distill_cost:.4f}")
-                print(f"  [Distillation] {pre_distill_tokens} tokens -> {post_distill_tokens} tokens")
+                print(f"  [Distillation] codebase {pre_distill_tokens:,} tokens -> distilled context {post_distill_tokens:,} tokens")
             else:
                 agent_context = repo_context
                 print("Distillation skipped or returned original context")

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -462,7 +462,9 @@ class TestMaybeDistill:
         assert result[2] == 150   # 50 + 100
 
     def test_returns_tuple(self, tmp_path):
-        """maybe_distill returns (context, input_tokens, output_tokens, cost, structural_extract)."""
+        """maybe_distill returns
+        (context, input_tokens, output_tokens, cost, structural_extract,
+         codebase_total_tokens)."""
         files = {"main.py": "x"}
         make_git_repo(tmp_path, files)
 
@@ -475,13 +477,16 @@ class TestMaybeDistill:
         mock_response._hidden_params = {"response_cost": 0.001}
 
         with patch("lib.distill.completion", return_value=mock_response):
-            ctx, inp, out, cost, struct_extract = maybe_distill("repo", "task", "anthropic/claude-sonnet-4-5", root=str(tmp_path))
+            ctx, inp, out, cost, struct_extract, codebase_tokens = maybe_distill(
+                "repo", "task", "anthropic/claude-sonnet-4-5", root=str(tmp_path),
+            )
 
         assert ctx == "distilled"
         assert inp == 10
         assert out == 5
         assert cost == 0.001
         assert "<structural_extract>" in struct_extract
+        assert codebase_tokens >= 0
 
 
 # ---------------------------------------------------------------------------
@@ -508,6 +513,73 @@ class TestConstants:
         assert OTHER_FILE_CAP > 0
         assert DISTILL_SMALL_REPO_LIMIT > 0
         assert DISTILL_OUTPUT_TOKENS > 0
+
+
+# ---------------------------------------------------------------------------
+# Distillation system prompt — content locks
+# ---------------------------------------------------------------------------
+
+class TestDistillSystemPrompt:
+    """The distill LLM was over-compressing files when issues mentioned
+    specific line numbers — see PR that introduced this test for the
+    bridge-analysis #392 incident. The prompt now has a hard rule that
+    files to be modified are returned in FULL. Lock that in."""
+
+    def test_includes_files_must_be_full_rule(self):
+        from lib.distill import DISTILL_SYSTEM_PROMPT
+        # The phrase doesn't have to be exact — just confirm the rule
+        # is still present in some form that mentions "FULL" or "complete"
+        # for files-to-be-modified.
+        prompt_lower = DISTILL_SYSTEM_PROMPT.lower()
+        assert "full" in prompt_lower or "complete file" in prompt_lower
+        assert "modified" in prompt_lower or "modify" in prompt_lower
+
+    def test_warns_against_line_number_excerpting(self):
+        from lib.distill import DISTILL_SYSTEM_PROMPT
+        # Verify the prompt addresses the specific failure mode where
+        # the LLM excerpts around line-number references in the task.
+        assert "line number" in DISTILL_SYSTEM_PROMPT.lower()
+
+
+# ---------------------------------------------------------------------------
+# _small_repo_limit (model-dependent threshold)
+# ---------------------------------------------------------------------------
+
+class TestSmallRepoLimit:
+    """The Tier-1-vs-Tier-2 cutoff scales with the model's input window so
+    1M-token models get the headroom to ingest a much bigger codebase in
+    one shot, while smaller-window models stay conservative."""
+
+    def test_returns_fallback_for_unknown_model(self):
+        from lib.distill import _small_repo_limit, DISTILL_SMALL_REPO_LIMIT
+        with patch("litellm.get_model_info", side_effect=Exception("unknown")):
+            assert _small_repo_limit("nonsense/x") == DISTILL_SMALL_REPO_LIMIT
+
+    def test_scales_with_model_window(self):
+        from lib.distill import _small_repo_limit
+        # 1M window × 0.25 = 250K, within the clamp range
+        with patch("litellm.get_model_info",
+                   return_value={"max_input_tokens": 1_000_000}):
+            assert _small_repo_limit("any/model") == 250_000
+
+    def test_clamps_to_min_for_small_windows(self):
+        from lib.distill import _small_repo_limit, DISTILL_SMALL_REPO_LIMIT_MIN
+        # 100K window × 0.25 = 25K, but we floor at MIN
+        with patch("litellm.get_model_info",
+                   return_value={"max_input_tokens": 100_000}):
+            assert _small_repo_limit("any/model") == DISTILL_SMALL_REPO_LIMIT_MIN
+
+    def test_clamps_to_max_for_huge_windows(self):
+        from lib.distill import _small_repo_limit, DISTILL_SMALL_REPO_LIMIT_MAX
+        # 10M window × 0.25 = 2.5M, but we ceiling at MAX
+        with patch("litellm.get_model_info",
+                   return_value={"max_input_tokens": 10_000_000}):
+            assert _small_repo_limit("any/model") == DISTILL_SMALL_REPO_LIMIT_MAX
+
+    def test_returns_fallback_when_window_is_zero(self):
+        from lib.distill import _small_repo_limit, DISTILL_SMALL_REPO_LIMIT
+        with patch("litellm.get_model_info", return_value={"max_input_tokens": 0}):
+            assert _small_repo_limit("any/model") == DISTILL_SMALL_REPO_LIMIT
 
 
 # ---------------------------------------------------------------------------
@@ -741,16 +813,16 @@ class TestMaybeDistillThresholds:
     """
 
     def test_above_threshold_distill_called_and_result_returned(self, tmp_path):
-        """Tier 1 (small repo, <= DISTILL_SMALL_REPO_LIMIT tokens): distill() is called.
+        """Tier 1 (small repo, <= effective small-repo limit): distill() is called.
 
         Input clearly within the small-repo limit so maybe_distill() must invoke
         distill() exactly once (full-codebase path) and return its output.
+
+        The limit is now model-dependent (see _small_repo_limit); we stub it
+        here to keep the test independent of LiteLLM's pricing table.
         """
         files = {"main.py": "def foo(): pass"}
         make_git_repo(tmp_path, files)
-
-        # Use a token estimate clearly below DISTILL_SMALL_REPO_LIMIT → Tier 1 path.
-        small_token_count = DISTILL_SMALL_REPO_LIMIT - 1
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -762,8 +834,11 @@ class TestMaybeDistillThresholds:
 
         original_context = "original repo context"
 
+        # Pin both the codebase size estimate AND the model-dependent
+        # small-repo limit so the test deterministically exercises Tier 1.
         with patch("lib.distill.gather_repo_files", return_value=[{"path": "main.py", "content": "def foo(): pass", "is_source": True, "truncated": False}]), \
-             patch("lib.distill.estimate_tokens_for_files", return_value=small_token_count), \
+             patch("lib.distill.estimate_tokens_for_files", return_value=50_000), \
+             patch("lib.distill._small_repo_limit", return_value=100_000), \
              patch("lib.distill.completion", return_value=mock_response) as mock_comp:
             result = maybe_distill(original_context, "Fix a bug", "anthropic/claude-sonnet-4-5", root=str(tmp_path))
 


### PR DESCRIPTION
Three independent fixes investigated for bridge-analysis #392, where distillation compressed \`leaderboard.py\` down to 972 tokens (entire file → snippets only) and the status log reported "5.6K → 972 tokens, ~\$0.05 saved" — both numbers misleading.

## 1. Tighten the distill prompt against over-excerpting

When an issue references specific line numbers ("lines 312-313, 459-460, 534-535"), the distill LLM was extracting tiny snippets and discarding the surrounding file. The agent then kept saying "I need to read the full leaderboard.py" across iterations.

The prompt now has a **hard rule**: files to be modified are returned in FULL, regardless of how specific the task is. The user-message instructions and system prompt are consistent on this (no more "[full content or relevant excerpt]" escape hatch).

## 2. Fix the metric

Status log read:
\`\`\`
Distillation: 5.6K → 972 tokens (4.6K saved/iter × 30 iters = ~\$0.05 saved)
\`\`\`

That 5.6K was the size of EXTRA_FILES (README, AGENTS.md, etc.) — NOT what distillation processed. The actual codebase distillation scanned was 368K tokens. \`maybe_distill()\` now returns the codebase total as a 6th tuple element so \`resolve.py\` can pass the correct value into \`build_distillation_summary()\`.

For bridge-analysis #392:
| | Pre-token | Reported savings |
|---|---|---|
| Before | 5.6K (wrong) | ~\$0.05 |
| After | 368K (correct) | ~\$4.30 |

## 3. Model-dependent Tier-1-vs-Tier-2 cutoff

\`DISTILL_SMALL_REPO_LIMIT\` was a hardcoded 100K, set when 200K-window models were typical. All our currently-configured models have 1M-token input windows. Added \`_small_repo_limit(model)\` which scales the cutoff to 25% of the model's input window, clamped to [50K, 500K]. Old 100K constant is the fallback for unknown models.

Effective Tier-1 ceiling per model:

| Model | Window | Tier-1 cutoff |
|---|---|---|
| claude-sonnet-4-6 / opus-4-7 | 1M | 250K |
| gpt-5.5 | 1.05M | 262K |
| gemini-2.5-flash | 1.05M | 262K |
| claude-sonnet-4-5 | 200K | 50K (floor) |
| unknown / not in LiteLLM | — | 100K (legacy default) |

## Test plan

- [x] 662 unit tests pass (was 655; +7 for \`_small_repo_limit\` + prompt content locks)
- [x] Verified by hand on bridge-analysis #392 numbers: "368K → 972 tokens, ~\$4.30 saved"
- [ ] Next \`/agent-resolve\` on a bigger repo should show realistic distillation metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)