### PR TITLE
Resolve: teach the prompt to treat design/spec comments as binding scope

### DIFF
--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -481,6 +481,32 @@ You operate in a fully automated pipeline — there is no human available to ans
 - Make forward progress on every turn, or call finish() to stop.
 """
 
+SCOPE = """
+## Scope: what counts as "done"
+
+Read the issue body AND the issue/PR comments before forming your plan. The
+comments are not optional context — they often contain decisive scope
+information that supersedes the body.
+
+**If the comments contain a substantial design analysis, implementation
+spec, or output from a prior `/agent-design`, `/agent-workshop`, or
+`/agent-delegate` run, treat the most recent revised version as the
+binding contract for your work — NOT the issue body alone.** The issue
+body may be a sketch; the spec is the contract. Implement every component
+the spec lists (every file, route, table, function, test). Do NOT call
+`finish(success=True)` while spec items remain unaddressed unless you have
+a concrete reason a specific item should be omitted, which you post as a
+comment on the issue first.
+
+If no design or spec comments exist, the issue body is the contract.
+
+When a detailed spec is present, expect a multi-file, multi-component
+implementation that takes far more iterations than a typical bug fix.
+Scope-reducing to "the foundational piece" and shipping a tiny PR is the
+wrong outcome — it leaves the issue effectively unresolved and the user
+has to re-invoke the agent on the same scope.
+"""
+
 WORKFLOW = """
 ## Problem-Solving Workflow
 
@@ -488,7 +514,7 @@ Follow this process:
 
 1. **Read only what you need**: Read only the files you are about to change — no speculative exploration. If the issue already identifies the relevant files, go straight to them. You should be writing or modifying a file by iteration 5 for a simple fix, or iteration 10 for a complex multi-file change. If you are still only reading files past iteration 10, stop and start implementing.
 2. **Plan**: Identify the minimal set of changes needed.
-3. **Implement**: Make focused, minimal changes. Modify existing files rather than creating new ones. Never create multiple versions of the same file (e.g., fix.py alongside fix_v2.py).
+3. **Implement**: Make focused changes scoped to the task. For a bug fix, prefer modifying existing files over creating new ones — and never create multiple versions of the same file (e.g., fix.py alongside fix_v2.py). For a spec-driven implementation, create exactly the new files the spec lists (no more, no fewer).
 4. **Verify**: Run tests if they exist. Check that the code is syntactically valid. If tests require dependencies that aren't installed, install them first (`pip install pytest`, `npm install`, etc.) — you are allowed to install packages freely.
 5. **Commit and push**: Stage all changes, commit with a clear message, and push.
 6. **Finish**: Call finish() with a meaningful pr_title and pr_body.
@@ -518,10 +544,16 @@ def _budget_paragraph(max_iterations):
     return (
         f"\n## Iteration Budget\n\n"
         f"You have a budget of **{max_iterations} iterations** for this task. "
-        f"Aim to finish in significantly fewer if the task allows — the budget is a "
-        f"ceiling, not a target. Don't pad with extra exploration just because the "
-        f"budget is there. A simple fix should take 5-10 iterations; a complex "
-        f"multi-file change rarely needs more than 20-30.\n"
+        f"Aim to finish in significantly fewer if the task allows — the budget "
+        f"is a ceiling, not a target. Don't pad with extra exploration just "
+        f"because the budget is there.\n\n"
+        f"Typical iteration counts:\n"
+        f"- Simple fix (one file, focused change): 5-10 iterations.\n"
+        f"- Complex multi-file change: 20-30 iterations.\n"
+        f"- Implementing a detailed multi-component spec (see ## Scope above): "
+        f"50-100+ iterations — every file, route, table, and test the spec "
+        f"lists has to be created. Stopping at 20-30 to ship a 'foundational' "
+        f"subset is the wrong call when a spec is the contract.\n"
     )
 
 STUCK_RECOVERY = """
@@ -644,6 +676,7 @@ is complete before committing — call `finish()` now.
 
     prompt = (
         AGENT_ROLE
+        + SCOPE
         + _budget_paragraph(MAX_ITERATIONS)
         + f"\n# Repository Context\n\n{repo_context}\n\n"
         + WORKFLOW

--- a/tests/test_resolve_scope_prompt.py
+++ b/tests/test_resolve_scope_prompt.py
@@ -1,0 +1,96 @@
+"""Tests for the SCOPE section of resolve.py's system prompt.
+
+The SCOPE section tells the agent to treat substantial design / spec
+comments as the binding contract for the work, rather than scope-reducing
+based on the issue body alone. This guards against the failure mode where
+an agent with a vague issue body + detailed spec in comments scope-reduces
+to a "foundational subset" and ships a tiny PR — see bridge-analysis #436
+(PR #437: 3 files / 40 LOC out of a ~10-file web app spec).
+
+The fix lives in resolve's general prompt so it works for both manual
+flows (user runs /agent-design, then /agent-resolve on the same issue)
+and delegate (which is conceptually the macro expansion of the manual
+flow). No delegate-specific Stage 4 prompt — single source of truth.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+_ENV_PATCH = patch.dict(
+    os.environ,
+    {
+        "ISSUE_NUMBER": "456",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "LLM_MODEL": "anthropic/claude-3-5-sonnet-20241022",
+        "BASH_OUTPUT_LIMIT": "0",
+        "CONTEXT_KEEP_TOOL_RESULTS": "0",
+        "MAX_CONTEXT_TOKENS": "0",
+        "COMPACTION_COVERAGE": "0.5",
+        "COMPACTION_FACTOR": "0.5",
+    },
+)
+_ENV_PATCH.start()
+import lib.resolve as resolve_mod  # noqa: E402  (after env patch)
+_ENV_PATCH.stop()
+
+
+class TestScopeSection:
+    """The SCOPE section must be present and assert the spec-as-contract rule."""
+
+    def test_scope_section_exists(self):
+        assert "## Scope: what counts as \"done\"" in resolve_mod.SCOPE
+
+    def test_scope_mentions_design_and_spec_comments(self):
+        import re
+        # Whitespace-tolerant match (the SCOPE prompt is hard-wrapped).
+        normalized = re.sub(r"\s+", " ", resolve_mod.SCOPE.lower())
+        assert "design analysis" in normalized
+        assert "implementation spec" in normalized
+
+    def test_scope_names_the_macro_commands(self):
+        for cmd in ("/agent-design", "/agent-workshop", "/agent-delegate"):
+            assert cmd in resolve_mod.SCOPE, f"SCOPE should mention {cmd!r}"
+
+    def test_scope_warns_against_scope_reduction(self):
+        # The phrase doesn't have to be verbatim, but the anti-shortcut
+        # framing must be present in some form so the model can pattern-match.
+        text = resolve_mod.SCOPE.lower()
+        assert "scope-reduc" in text or "shortcut" in text or "foundational" in text
+
+    def test_scope_says_dont_finish_with_unaddressed_items(self):
+        text = resolve_mod.SCOPE.lower()
+        assert "finish" in text and "unaddressed" in text
+
+    def test_scope_is_in_assembled_system_prompt(self):
+        """SCOPE must actually be wired into build_system_prompt's output."""
+        prompt = resolve_mod.build_system_prompt(
+            repo_context="some repo context",
+            issue_context_str="some issue body",
+        )
+        assert "## Scope: what counts as \"done\"" in prompt
+
+
+class TestBudgetParagraphAcknowledgesLargerScopes:
+    """The iteration-budget paragraph must acknowledge spec-driven runs need
+    way more iterations than typical bug fixes — otherwise the old "20-30
+    iterations is unusual" guidance keeps biasing the agent toward early
+    finish() even with SCOPE present."""
+
+    def test_budget_mentions_spec_driven_iteration_range(self):
+        text = resolve_mod._budget_paragraph(150)
+        assert "spec" in text.lower()
+        # 50+ iterations should be acknowledged as normal for spec runs.
+        assert "50" in text or "100" in text
+
+    def test_budget_still_warns_against_padding(self):
+        # SCOPE-aware doesn't mean we lift the "don't pad" guard for small fixes.
+        text = resolve_mod._budget_paragraph(50)
+        assert "ceiling, not a target" in text
+        assert "pad" in text.lower()


### PR DESCRIPTION
Bridge-analysis #436 surfaced the failure mode: vague issue body + detailed spec in \`/agent-delegate\` comments → agent scope-reduces to a tractable subset (schema + CLI), opens PR #437 (3 files, 40 LOC), declares victory. ~85% of the spec dropped on the floor.

## Not a delegate-specific problem

Manual \`/agent-design\` → \`/agent-resolve\` would hit the same shortcut. The resolve system prompt biases toward small fixes:
- "A simple fix should take 5-10 iterations; a complex multi-file change rarely needs more than 20-30"
- "Modify existing files rather than creating new ones"
- "Call finish() as soon as the task is done"

For a spec-driven implementation those are wrong.

## Fix — in resolve's general prompt (one source of truth)

Per the chat discussion: delegate is a macro that expands to the same agentic calls a user could invoke manually. The fix lives in resolve's prompt so it triggers identically for both flows; no delegate-specific Stage 4 prompt to drift.

**Three changes:**

1. **New SCOPE section** wired into build_system_prompt (between AGENT_ROLE and the budget paragraph). Says: if comments contain a substantial design analysis, implementation spec, or output from a prior \`/agent-design\` / \`/agent-workshop\` / \`/agent-delegate\` run, treat the most recent revised version as the binding contract — not the issue body alone. Plus explicit anti-shortcut framing.

2. **Iteration-budget paragraph** acknowledges spec-driven scope: "implementing a detailed multi-component spec: 50-100+ iterations — every file, route, table, and test the spec lists has to be created."

3. **WORKFLOW step 3** softens "modify existing files rather than creating new ones" to apply only to bug fixes — for spec-driven work, the spec defines the file set.

## Test plan

- [x] 8 new tests pin SCOPE wording + budget paragraph + the fact that SCOPE is wired into build_system_prompt's output
- [x] 670 unit tests pass (was 662)
- [ ] Empirical validation: re-run delegate (or manual resolve after delegate's design comments) on bridge-analysis #436 and see if the resulting PR meaningfully implements the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)