### PR TITLE
Wire /agent-review council=true into the review job

### DIFF
--- a/.github/workflows/remote-dev-bot.yml
+++ b/.github/workflows/remote-dev-bot.yml
@@ -1570,6 +1570,10 @@ jobs:
 
       - name: Run review loop
         id: review
+        # Single-reviewer agentic path. Skipped when `council = true` is set on
+        # the trigger comment — in that case the next step runs parallel
+        # non-agentic reviewers via run_build_council instead.
+        if: needs.parse.outputs.council_models == '' || needs.parse.outputs.council_models == '[]'
         env:
           LLM_API_KEY: ${{ steps.apikey.outputs.key }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1951,7 +1955,113 @@ jobs:
                   f.write(review)
           PYEOF
 
+      - name: Run council code review
+        # Parallel multi-reviewer path, activated when `council = true` was set
+        # on the trigger comment. Calls the same run_build_council that build
+        # Stage 2 and delegate Stage 5 use; only the user-visible labels differ
+        # (banner_label / attribution_label / completion_label).
+        if: needs.parse.outputs.council_models != '' && needs.parse.outputs.council_models != '[]'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          COUNCIL_MODELS: ${{ needs.parse.outputs.council_models }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          date +%s > /tmp/start_time
+          PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
+          python3 << PYEOF
+          import json
+          import os
+          import subprocess
+          import sys
+
+          sys.path.insert(0, ".remote-dev-bot/lib")
+          from workshop import run_build_council
+
+          github_repo = os.environ["GITHUB_REPO"]
+          github_token = os.environ["GH_TOKEN"]
+          pr_number = "${PR_NUMBER}"
+
+          # PR title / body / diff were already written to /tmp by the
+          # "Fetch PR context" step earlier in this job.
+          def _read(path, default=""):
+              try:
+                  with open(path) as f:
+                      return f.read().strip()
+              except FileNotFoundError:
+                  return default
+
+          pr_title = _read("/tmp/pr_title.txt")
+          pr_body = _read("/tmp/pr_body.txt")
+          pr_diff = _read("/tmp/pr_diff.txt")
+
+          # Cap diff like the single-reviewer path does, to avoid token blowups.
+          if len(pr_diff) > 100000:
+              pr_diff = pr_diff[:100000] + "\n\n... (diff truncated, showing first 100000 characters)"
+
+          # Pull the linked issue if the "Fetch PR context" step found one.
+          linked = _read("/tmp/linked_issue.txt")
+          issue_title = ""
+          issue_body_text = linked  # the file contains "Issue #N: title\n\nbody"
+          if linked:
+              first_line, _, rest = linked.partition("\n")
+              if first_line.startswith("Issue #"):
+                  # "Issue #N: <title>"
+                  parts = first_line.split(":", 1)
+                  if len(parts) == 2:
+                      issue_title = parts[1].strip()
+                      issue_body_text = rest.strip()
+
+          council_models = json.loads(os.environ.get("COUNCIL_MODELS", "[]") or "[]")
+          council_extra_instructions = "${{ needs.parse.outputs.extra_instructions }}"
+
+          env = {**os.environ, "GH_TOKEN": github_token}
+
+          def post_pr_comment(body):
+              proc = subprocess.run(
+                  ["gh", "pr", "comment", pr_number,
+                   "--repo", github_repo,
+                   "--body", body],
+                  env=env,
+                  capture_output=True, text=True,
+              )
+              if proc.returncode != 0:
+                  print(f"Warning: failed to post PR comment: {proc.stderr}", file=sys.stderr)
+
+          build_result = run_build_council(
+              council_models=council_models,
+              issue_title=issue_title,
+              issue_body=issue_body_text,
+              pr_title=pr_title,
+              pr_body=pr_body,
+              pr_diff=pr_diff,
+              extra_instructions=council_extra_instructions,
+              post_comment_fn=post_pr_comment,
+              banner_label="Council Code Review",
+              attribution_label="/agent-review council=true",
+              completion_label="Council code review complete — awaiting human review",
+          )
+
+          # Write usage data so the "Post cost comment (fallback)" step
+          # below picks it up (the council path does not embed cost in any
+          # single per-reviewer comment).
+          usage = {
+              "input_tokens": build_result["total_input_tokens"],
+              "output_tokens": build_result["total_output_tokens"],
+              "cost": build_result["total_cost"],
+              "iterations": 0,
+          }
+          with open("/tmp/llm_usage.json", "w") as f:
+              json.dump(usage, f)
+          PYEOF
+
       - name: Post review comment
+        # Single-reviewer agentic path only — paired with "Run review loop"
+        # above. Council mode posts each reviewer's comment directly from
+        # within run_build_council, so this step doesn't apply.
+        if: needs.parse.outputs.council_models == '' || needs.parse.outputs.council_models == '[]'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RDB_PAT_TOKEN || github.token }}
         run: |
@@ -3913,6 +4023,9 @@ jobs:
               pr_diff=pr_diff,
               extra_instructions=council_extra_instructions,
               post_comment_fn=post_pr_comment,
+              banner_label="Delegate Stage 5/6 — Council Code Review",
+              attribution_label="/agent-delegate Stage 5",
+              completion_label="Delegate Stage 5/6 complete — awaiting human review",
           )
 
           # Merge council usage into aggregate

--- a/lib/workshop.py
+++ b/lib/workshop.py
@@ -358,8 +358,17 @@ def run_build_council(
     pr_diff,
     extra_instructions="",
     post_comment_fn=None,
+    banner_label="Build Stage 2 — Council Code Review",
+    attribution_label="/agent-build Stage 2",
+    completion_label="Build Stage 2 complete — awaiting human review",
 ):
-    """Run Stage 2 council code reviews for build mode.
+    """Run parallel council code reviews on a PR.
+
+    Used by:
+      - /agent-build Stage 2 (defaults)
+      - /agent-delegate Stage 5 (overrides labels for "Delegate Stage 5/6")
+      - /agent-review with council=true (overrides labels for plain
+        "Council Code Review", no build/delegate prefix)
 
     Runs each council model's review in parallel (non-agentic). Posts each
     review via post_comment_fn (defaults to print if None).
@@ -367,6 +376,11 @@ def run_build_council(
     extra_instructions is the mode-level extra_instructions string; each council
     member's model-level extra_instructions (from council_model["extra_instructions"])
     is appended per-reviewer.
+
+    banner_label, attribution_label, completion_label parameterize the
+    user-visible mode-specific text so the same parallel-review code can
+    serve build mode, delegate Stage 5, and /agent-review council=true
+    without each emitting "Build Stage 2 — ..." headers.
 
     Returns dict with council_results, total_input_tokens,
     total_output_tokens, total_cost.
@@ -382,8 +396,8 @@ def run_build_council(
 
     if not council_models:
         post(
-            "## 🏛️ Build Stage 2 — Council Code Review\n\n"
-            "⚠️ No council models configured. Skipping council code review.\n"
+            f"## 🏛️ {banner_label}\n\n"
+            f"⚠️ No council models configured. Skipping council code review.\n"
         )
         return {
             "council_results": [],
@@ -393,7 +407,7 @@ def run_build_council(
         }
 
     post(
-        f"## 🏛️ Build Stage 2 — Council Code Review\n\n"
+        f"## 🏛️ {banner_label}\n\n"
         f"Requesting code reviews from {len(council_models)} council member(s): "
         f"{', '.join('`' + m['alias'] + '`' for m in council_models)}...\n"
     )
@@ -465,12 +479,12 @@ def run_build_council(
                 f"🤖 **Council reviewer:** `{cr['model_alias']}` (`{cr['model_id']}`)\n\n"
                 f"{cr['review']}\n\n"
                 f"---\n"
-                f"_Council code review by `/agent-build` Stage 2 (`{cr['model_alias']}`)_"
+                f"_Council code review by `{attribution_label}` (`{cr['model_alias']}`)_"
             )
 
     n = len(council_results)
     post(
-        f"## Build Stage 2 complete — awaiting human review\n\n"
+        f"## {completion_label}\n\n"
         f"{n} model(s) have posted code reviews above. Please review the feedback "
         f"and address any concerns before merging.\n"
     )

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 from workshop import (
     build_council_review_prompt,
     resolve_council_models,
+    run_build_council,
     COUNCIL_REVIEW_SYSTEM_PROMPT,
 )
 
@@ -18,6 +19,74 @@ from workshop import (
 # ---------------------------------------------------------------------------
 # resolve_council_models
 # ---------------------------------------------------------------------------
+
+class TestRunBuildCouncilLabels:
+    """run_build_council is shared by build Stage 2, delegate Stage 5, and
+    /agent-review council=true. Each uses different banner/attribution/
+    completion labels — verify the parameters are threaded through to the
+    posted comments so the labels can be customized per-caller."""
+
+    def _mock_review_result(self, alias="claude-small"):
+        return {
+            "review": f"## Code Review by {alias}\n\nLooks good.",
+            "model_alias": alias,
+            "model_id": "anthropic/test",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost": 0.01,
+            "elapsed": 1.0,
+        }
+
+    def test_default_labels_match_build_stage_2(self):
+        from unittest.mock import patch
+        posted = []
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}), \
+             patch("workshop.run_council_code_review",
+                   return_value=self._mock_review_result()):
+            run_build_council(
+                council_models=[{"alias": "claude-small", "id": "anthropic/test"}],
+                issue_title="t",
+                issue_body="b",
+                pr_title="pt",
+                pr_body="pb",
+                pr_diff="diff",
+                post_comment_fn=posted.append,
+            )
+        joined = "\n".join(posted)
+        assert "Build Stage 2 — Council Code Review" in joined
+        assert "/agent-build Stage 2" in joined
+        assert "Build Stage 2 complete" in joined
+
+    def test_custom_labels_for_review_council(self):
+        """When /agent-review with council=true calls this function, labels
+        should NOT say 'Build Stage 2' — that text would confuse the user
+        about which command they invoked."""
+        from unittest.mock import patch
+        posted = []
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}), \
+             patch("workshop.run_council_code_review",
+                   return_value=self._mock_review_result()):
+            run_build_council(
+                council_models=[{"alias": "claude-small", "id": "anthropic/test"}],
+                issue_title="t",
+                issue_body="b",
+                pr_title="pt",
+                pr_body="pb",
+                pr_diff="diff",
+                post_comment_fn=posted.append,
+                banner_label="Council Code Review",
+                attribution_label="/agent-review council=true",
+                completion_label="Council code review complete — awaiting human review",
+            )
+        joined = "\n".join(posted)
+        # Custom labels present
+        assert "## 🏛️ Council Code Review" in joined
+        assert "/agent-review council=true" in joined
+        assert "Council code review complete — awaiting human review" in joined
+        # Build-mode labels NOT leaking in
+        assert "Build Stage 2" not in joined
+        assert "/agent-build" not in joined
+
 
 class TestResolveCouncilModels:
     """Tests for council model filtering logic."""


### PR DESCRIPTION
The parser already enabled council mode for \`/agent-review\` (\`lib/config.py:593\` treats \`council=true\` as setting \`council_models\` output for review mode), but the \`review:\` workflow job had no council branch — it unconditionally ran the single-reviewer agentic loop. \`/agent-review\` with \`council=true\` parsed fine but produced exactly one review.

Found on bridge-analysis PR #438 (issue #436):

\`\`\`
/agent-review
council = true
\`\`\`

→ one review from claude-small only.

## Wiring

- New "Run council code review" step in the review job, guarded \`if: council_models != '[]' && council_models != ''\`. Calls \`run_build_council\` (already used by build Stage 2 and delegate Stage 5) with /agent-review-flavored labels.
- Existing "Run review loop" and "Post review comment" steps get the opposite guard so they only run in single-reviewer mode.
- "Post cost comment (fallback)" stays unguarded; the new council step writes \`/tmp/llm_usage.json\` the same way single-reviewer does, so the fallback picks up cost in both modes.

## Label parameterization on run_build_council

The function previously hard-coded "Build Stage 2 — Council Code Review" / "\`/agent-build\` Stage 2" in banner, per-reviewer attribution, and completion message. Now parameterized:

| Caller | banner_label | attribution_label |
|---|---|---|
| Build Stage 2 (defaults) | "Build Stage 2 — Council Code Review" | "/agent-build Stage 2" |
| Delegate Stage 5 | "Delegate Stage 5/6 — Council Code Review" | "/agent-delegate Stage 5" |
| /agent-review council=true | "Council Code Review" | "/agent-review council=true" |

## Test plan

- [x] 664 unit tests pass (+2 for label-parameterization assertions)
- [x] YAML syntactically valid
- [ ] Empirical: \`/agent-review\` + \`council = true\` on a PR posts 3 council reviewer comments (one per configured council model), not one single-reviewer comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)